### PR TITLE
Pin to Hyrax master where collections-sprint is merged in

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'hyrax', git: 'https://github.com/samvera/hyrax.git', ref: '184d47cd3cb222973f065be927b1d455a81deaf6'
+gem 'hyrax', git: 'https://github.com/samvera/hyrax.git', ref: '51b45cc2dc35eb8101f3eec5bde28922b63a0872'
 group :development, :test do
   gem 'solr_wrapper', '>= 0.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 184d47cd3cb222973f065be927b1d455a81deaf6
-  ref: 184d47cd3cb222973f065be927b1d455a81deaf6
+  revision: 51b45cc2dc35eb8101f3eec5bde28922b63a0872
+  ref: 51b45cc2dc35eb8101f3eec5bde28922b63a0872
   specs:
     hyrax (2.1.0.alpha)
       active-fedora (~> 11.5, >= 11.5.2)
@@ -118,12 +118,12 @@ GEM
       io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (7.2.5)
+    autoprefixer-rails (8.0.0)
       execjs
-    awesome_nested_set (3.1.3)
-      activerecord (>= 4.0.0, < 5.2)
-    aws-partitions (1.57.0)
-    aws-sdk-core (3.14.0)
+    awesome_nested_set (3.1.4)
+      activerecord (>= 4.0.0, < 5.3)
+    aws-partitions (1.59.0)
+    aws-sdk-core (3.15.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
@@ -143,7 +143,7 @@ GEM
       i18n
     bcrypt (3.1.11)
     bindex (0.5.0)
-    blacklight (6.14.0)
+    blacklight (6.14.1)
       bootstrap-sass (~> 3.2)
       deprecation
       globalid
@@ -244,7 +244,7 @@ GEM
     dry-container (0.6.0)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.4.2)
+    dry-core (0.4.4)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.2.0)
     dry-logic (0.4.2)
@@ -298,7 +298,7 @@ GEM
       railties (>= 3.2, < 5.2)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    google-api-client (0.19.5)
+    google-api-client (0.19.7)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)
       httpclient (>= 2.8.1, < 3.0)
@@ -327,7 +327,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http_logger (0.5.1)
-    httparty (0.15.6)
+    httparty (0.15.7)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     hydra-access-controls (10.5.0)
@@ -773,7 +773,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.8)
     tins (1.16.3)
-    tinymce-rails (4.7.5)
+    tinymce-rails (4.7.6)
       railties (>= 3.1.1)
     turbolinks (5.1.0)
       turbolinks-source (~> 5.1)

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "display a work as its owner" do
 
       # Displays FileSets already attached to this work
       within '.related-files' do
-        expect(page).to have_selector '.filename', text: 'A Contained FileSet'
+        expect(page).to have_selector '.attribute-filename', text: 'A Contained FileSet'
       end
     end
   end


### PR DESCRIPTION
Fixes #69 

Pins the Hyrax gem to the commit that merges the `collections-sprint` branch into `master`

Also tweaks a test to match a similar change to the same spec in Hyrax.