### PR TITLE
Update TargetRubyVersion for rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-rspec
 
 
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.4
   DisplayCopNames: true
   Include:
     - '**/Rakefile'


### PR DESCRIPTION
Updates the TargetRubyVersion in .rubocop.yml to ruby 2.4.  Other projects have started having problems with Travis when the version is not set properly.