### PR TITLE
add uclibs browse_everything gem and config for Kaltura and Box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ coverage/*
 
 ##Mac OS
 .DS_Store
+
+# Application files to ingore
+fits.log

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'browse-everything', github: 'uclibs/browse-everything', branch: 'master'
+gem 'kaltura', '0.1.1'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.4'
 # Use sqlite3 as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,26 @@ GIT
       signet
       tinymce-rails (~> 4.1)
 
+GIT
+  remote: https://github.com/uclibs/browse-everything.git
+  revision: 1e1e2db1522dcbab1233a30d959ce9564a294d23
+  branch: master
+  specs:
+    browse-everything (0.14.2)
+      addressable (~> 2.5)
+      aws-sdk-s3
+      bootstrap-sass (~> 3.2)
+      dropbox-sdk (>= 1.6.2)
+      font-awesome-rails
+      google-api-client (~> 0.9)
+      google_drive
+      httparty
+      kaltura
+      rails (>= 3.1)
+      ruby-box
+      sass-rails
+      signet
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -122,15 +142,15 @@ GEM
       execjs
     awesome_nested_set (3.1.4)
       activerecord (>= 4.0.0, < 5.3)
-    aws-partitions (1.59.0)
+    aws-partitions (1.63.0)
     aws-sdk-core (3.15.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.4.0)
+    aws-sdk-kms (1.5.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.8.0)
+    aws-sdk-s3 (1.8.1)
       aws-sdk-core (~> 3)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
@@ -167,19 +187,6 @@ GEM
       sass (>= 3.3.4)
     bootstrap_form (2.7.0)
     breadcrumbs_on_rails (3.0.1)
-    browse-everything (0.15.1)
-      addressable (~> 2.5)
-      aws-sdk-s3
-      bootstrap-sass (~> 3.2)
-      dropbox_api (>= 0.1.10)
-      font-awesome-rails
-      google-api-client (~> 0.9)
-      google_drive
-      httparty
-      rails (>= 3.1)
-      ruby-box
-      sass-rails
-      signet
     builder (3.2.3)
     byebug (9.1.0)
     cancancan (1.17.0)
@@ -237,9 +244,8 @@ GEM
     docile (1.1.5)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
-    dropbox_api (0.1.10)
-      faraday (~> 0.9, ~> 0.8)
-      oauth2 (~> 1.1)
+    dropbox-sdk (1.6.5)
+      json
     dry-configurable (0.7.0)
       concurrent-ruby (~> 1.0)
     dry-container (0.6.0)
@@ -299,7 +305,7 @@ GEM
       railties (>= 3.2, < 5.2)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    google-api-client (0.19.7)
+    google-api-client (0.19.8)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)
       httpclient (>= 2.8.1, < 3.0)
@@ -323,12 +329,13 @@ GEM
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
+    hashie (3.5.7)
     hiredis (0.6.1)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http_logger (0.5.1)
-    httparty (0.15.7)
+    httparty (0.16.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     hydra-access-controls (10.5.0)
@@ -412,6 +419,9 @@ GEM
     json-schema (2.8.0)
       addressable (>= 2.4)
     jwt (1.5.6)
+    kaltura (0.1.1)
+      hashie (>= 1.0.0)
+      httparty (>= 0.7.8)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -821,6 +831,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  browse-everything!
   byebug
   capybara
   capybara-maleficent (~> 0.2)
@@ -836,6 +847,7 @@ DEPENDENCIES
   hyrax!
   jbuilder (~> 2.5)
   jquery-rails
+  kaltura (= 0.1.1)
   listen (~> 3.0.5)
   puma (~> 3.0)
   rails (~> 5.1.4)

--- a/config/browse_everything_providers.yml
+++ b/config/browse_everything_providers.yml
@@ -1,0 +1,25 @@
+#
+# To make browse-everything aware of a provider, uncomment the info for that provider and add your API key information.
+# The file_system provider can be a path to any directory on the server where your application is running.
+#
+---
+# dropbox:
+#   :app_key: YOUR_DROPBOX_APP_KEY
+#   :app_secret: YOUR_DROPBOX_APP_SECRET
+box:
+  :client_id: bamboo_browse_everything_box_id
+  :client_secret: bamboo_browse_everything_box_secret
+# google_drive:
+#   :client_id: YOUR_GOOGLE_API_CLIENT_ID
+#   :client_secret: YOUR_GOOGLE_API_CLIENT_SECRET
+# s3:
+#   :bucket: YOUR_AWS_S3_BUCKET
+#   :response_type: :signed_url # set to :public_url for public urls or :s3_uri for an s3://BUCKET/KEY uri
+#   :app_key: YOUR_AWS_S3_KEY       # :app_key, :app_secret, and :region can be specified
+#   :app_secret: YOUR_AWS_S3_SECRET # explicitly here, or left out to use system-configured
+#   :region: YOUR_AWS_S3_REGION     # defaults.
+#   See https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/
+kaltura:
+  :partner_id: bamboo_browse_everything_kaltura_id
+  :administrator_secret: bamboo_browse_everything_kaltura_secret
+  :service_url: 'https://www.kaltura.com'

--- a/config/initializers/kaltura.rb
+++ b/config/initializers/kaltura.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Kaltura.configure do |config|
+  config.partner_id = 'bamboo_browse_everything_kaltura_id'
+  config.administrator_secret = 'bamboo_browse_everything_kaltura_secret'
+  config.service_url = 'https://www.kaltura.com'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 require 'sidekiq/web'
 Rails.application.routes.draw do
+  mount BrowseEverything::Engine => '/browse'
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
   mount Blacklight::Engine => '/'
   concern :searchable, Blacklight::Routes::Searchable.new

--- a/spec/features/cloud_upload_spec.rb
+++ b/spec/features/cloud_upload_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe "Selecting files to import from cloud providers", type: :feature do
+  let(:user) { create(:user) }
+
+  before do
+    # Grant the user access to deposit into an admin set.
+    create(:permission_template_access,
+           :deposit,
+           permission_template: create(:permission_template, with_admin_set: true, with_active_workflow: true),
+           agent_type: 'user',
+           agent_id: user.user_key)
+
+    sign_in user
+    visit '/dashboard'
+    click_link 'Works'
+    click_link "Add new work"
+  end
+
+  it "has a Cloud file picker using browse-everything" do
+    click_link "Files"
+    expect(page).to have_content "Add cloud files"
+  end
+end


### PR DESCRIPTION
Closes #86 

1. Added uclibs/browse-everything gem from our github fork
1. Ran generator: `rails g browse_everything:install --skip-assets`
1. Added `config/initializers/kaltura.rb`
1. Tested with localhost credentials for Kaltura and Box.com

Does this need any spec coverage? Do we have a test script I should add to?