### PR TITLE
Update to latest Hyrax gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem 'devise-guests', '~> 0.6'
 gem 'hydra-role-management'
-gem 'hyrax', git: 'https://github.com/samvera/hyrax.git', ref: '51b45cc2dc35eb8101f3eec5bde28922b63a0872'
+gem 'hyrax', git: 'https://github.com/samvera/hyrax.git', ref: '5edc4f1d676cb73a347127623a242e621493b192'
 gem 'riiif', '~> 1.1'
 gem 'rsolr', '>= 1.0'
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 51b45cc2dc35eb8101f3eec5bde28922b63a0872
-  ref: 51b45cc2dc35eb8101f3eec5bde28922b63a0872
+  revision: 5edc4f1d676cb73a347127623a242e621493b192
+  ref: 5edc4f1d676cb73a347127623a242e621493b192
   specs:
     hyrax (2.1.0.alpha)
       active-fedora (~> 11.5, >= 11.5.2)
@@ -48,6 +48,7 @@ GIT
       samvera-nesting_indexer (~> 1.0, >= 1.0.1)
       select2-rails (~> 3.5)
       signet
+      simple_form (= 3.5.0)
       tinymce-rails (~> 4.1)
 
 GIT
@@ -376,7 +377,7 @@ GEM
       blacklight
       bootstrap_form
       cancancan
-    hydra-works (0.16.0)
+    hydra-works (0.17.0)
       hydra-derivatives (~> 3.0)
       hydra-file_characterization (~> 0.3, >= 0.3.3)
       hydra-pcdm (>= 0.9)
@@ -795,7 +796,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.8)
     tins (1.16.3)
-    tinymce-rails (4.7.6)
+    tinymce-rails (4.7.7)
       railties (>= 3.1.1)
     turbolinks (5.1.0)
       turbolinks-source (~> 5.1)

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'collection', type: :feature, with_nested_reindexing: true do
       expect(page).to have_content(work2.title.first)
       expect(page).to have_content(col1.title.first)
       expect(page).to have_content(col2.title.first)
-      expect(page).not_to have_css(".pager")
+      expect(page).not_to have_css(".pagination")
 
       click_link "Gallery"
       expect(page).to have_content(work1.title.first)
@@ -58,7 +58,7 @@ RSpec.describe 'collection', type: :feature, with_nested_reindexing: true do
   end
 
   # TODO: this is just like the block above. Merge them.
-  describe 'show pages of a collection' do
+  describe 'show work pages of a collection' do
     before do
       docs = (0..12).map do |n|
         { "has_model_ssim" => ["GenericWork"], :id => "zs25x871q#{n}",
@@ -76,7 +76,29 @@ RSpec.describe 'collection', type: :feature, with_nested_reindexing: true do
 
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
       visit "/collections/#{collection.id}"
-      expect(page).to have_css(".pager")
+      expect(page).to have_css(".pagination")
+    end
+  end
+
+  describe 'show subcollection pages of a collection' do
+    before do
+      docs = (0..12).map do |n|
+        { "has_model_ssim" => ["Collection"], :id => "zs25x871q#{n}",
+          "depositor_ssim" => [user.user_key],
+          "suppressed_bsi" => false,
+          "member_of_collection_ids_ssim" => [collection.id],
+          "nesting_collection__parent_ids_ssim" => [collection.id],
+          "edit_access_person_ssim" => [user.user_key] }
+      end
+      ActiveFedora::SolrService.add(docs, commit: true)
+
+      sign_in user
+    end
+    let(:collection) { create(:named_collection, user: user) }
+
+    it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
+      visit "/collections/#{collection.id}"
+      expect(page).to have_css(".pagination")
     end
   end
 end


### PR DESCRIPTION
Updates UCrate to use the version of the Hyrax gem from 2/20/2018.

The update broke one feature test because of changes to Hyrax code.  I pulled in an update version of spec/features/collection_spec.rb to fix it.