### PR TITLE
Add recpatcha to contact form for non-authenticated users

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -116,6 +116,10 @@ Rails/FilePath:
 Rails/OutputSafety:
   Exclude:
 
+RSpec/AnyInstance:
+  Exclude:
+    - 'spec/controllers/hyrax/contact_form_controller_spec.rb'
+
 RSpec/DescribeClass:
   Exclude:
     - 'spec/abilities/**/*'
@@ -185,3 +189,4 @@ RSpec/ExpectInHook:
 RSpec/VerifiedDoubles:
   Exclude:
     - 'spec/features/create_child_work_spec.rb'
+    - 'spec/controllers/hyrax/contact_form_controller_spec.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
   gem 'fcrepo_wrapper'
+  gem 'rspec-its'
   gem 'rspec-rails'
   gem 'solr_wrapper', '>= 0.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -673,6 +673,9 @@ GEM
     rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
@@ -854,6 +857,7 @@ DEPENDENCIES
   riiif (~> 1.1)
   rsolr (>= 1.0)
   rspec-activemodel-mocks
+  rspec-its
   rspec-rails
   rubocop (~> 0.51.0)
   rubocop-rspec (~> 1.20.1)

--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -14,3 +14,7 @@
 @import "blacklight_gallery/slideshow";
 @import "blacklight_gallery/osd_viewer";
 @import 'hyrax/hyrax';
+
+.g-recaptcha {
+  margin-bottom: 20px;
+}

--- a/app/controllers/hyrax/contact_form_controller.rb
+++ b/app/controllers/hyrax/contact_form_controller.rb
@@ -1,0 +1,59 @@
+module Hyrax
+  class ContactFormController < ApplicationController
+    extend ActiveSupport::Concern
+    before_action :build_contact_form
+    FAIL_NOTICE = "You must complete the Captcha to confirm the form. ".freeze
+
+    def new; end
+
+    def create
+      # not spam and a valid form
+      if @contact_form.valid? && passes_captcha_or_is_logged_in?
+        Hyrax::ContactMailer.contact(@contact_form).deliver_now
+        flash.now[:notice] = 'Thank you for your message!'
+        after_deliver
+        @contact_form = ContactForm.new
+      else
+        flash.now[:error] = 'Sorry, this message was not sent successfully. '
+        flash.now[:error] << FAIL_NOTICE
+        flash.now[:error] << @contact_form.errors.full_messages.map(&:to_s).join(", ")
+      end
+      render :new
+    rescue RuntimeError => exception
+      handle_create_exception(exception)
+    end
+
+    def handle_create_exception(exception)
+      logger.error("Contact form failed to send: #{exception.inspect}")
+      flash.now[:error] = 'Sorry, this message was not delivered.'
+      render :new
+    end
+
+    # Override this method if you want to perform additional operations
+    # when a email is successfully sent, such as sending a confirmation
+    # response to the user.
+    def after_deliver; end
+
+    def verify_google_recaptcha(_key, response)
+      status = `curl "https://www.google.com/recaptcha/api/siteverify?secret=#{CAPTCHA_SERVER['_key']}&response=#{response}"`
+      hash = JSON.parse(status)
+      hash["success"] == true
+    end
+
+    protected
+
+      def build_contact_form
+        @contact_form = Hyrax::ContactForm.new(contact_form_params)
+      end
+
+      def contact_form_params
+        return {} unless params.key?(:contact_form)
+        params.require(:contact_form).permit(:contact_method, :category, :name, :email, :subject, :message)
+      end
+
+      def passes_captcha_or_is_logged_in?
+        return true if current_user.present?
+        verify_google_recaptcha(CAPTCHA_SERVER['secret_key'], params["g-recaptcha-response"])
+      end
+  end
+end

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -1,0 +1,55 @@
+<script src='https://www.google.com/recaptcha/api.js'></script>
+<div class="alert alert-info">
+  <%= render 'directions' %>
+</div>
+
+<h1>
+    <%= t('hyrax.contact_form.header') %>
+</h1>
+
+<% if user_signed_in? %>
+  <% nm = current_user.name %>
+  <% em = current_user.email %>
+<% else %>
+  <% nm = '' %>
+  <% em = '' %>
+<% end %>
+
+<%= form_for @contact_form, url: hyrax.contact_form_index_path,
+                            html: { class: 'form-horizontal' } do |f| %>
+  <%= f.text_field :contact_method, class: 'hide' %>
+  <div class="form-group">
+    <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 control-label" %>
+    <% issue_types = Hyrax::ContactForm.issue_types_for_locale.dup %>
+    <% issue_types.unshift([t('hyrax.contact_form.select_type'), nil]) %>
+    <div class="col-sm-10">
+      <%= f.select 'category', options_for_select(issue_types), {}, {class: 'form-control', required: true } %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :name, t('hyrax.contact_form.name_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :email, t('hyrax.contact_form.email_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :email, value: em, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :subject, t('hyrax.contact_form.subject_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :subject, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :message, t('hyrax.contact_form.message_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_area :message, rows: 4, class: 'form-control', required: true %></div>
+  </div>
+
+  <% if current_user.blank? %>
+    <div class="g-recaptcha" data-sitekey= "<%=CAPTCHA_SERVER['site_key']%>"></div>
+  <% end %>
+
+  <%= f.submit value: t('hyrax.contact_form.button_label'), class: "btn btn-primary" %>
+<% end %>

--- a/config/initializers/load_captcha_configs.rb
+++ b/config/initializers/load_captcha_configs.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+CAPTCHA_SERVER = YAML.load_file(Rails.root.join('config', 'recaptcha.yml'))[Rails.env]

--- a/config/recaptcha.yml
+++ b/config/recaptcha.yml
@@ -1,0 +1,11 @@
+# stores ReCaptcha image server url
+
+development:
+  site_key: ENV["UCRATE_RECAPTCHA_PUB_KEY"]
+  secret_key: ENV["UCRATE_RECAPTCHA_PRI_KEY"]
+test:
+  site_key: ENV["UCRATE_RECAPTCHA_PUB_KEY"]
+  secret_key: ENV["UCRATE_RECAPTCHA_PRI_KEY"]
+production:
+  site_key: ENV["UCRATE_RECAPTCHA_PUB_KEY"]
+  secret_key: ENV["UCRATE_RECAPTCHA_PRI_KEY"]

--- a/spec/controllers/hyrax/contact_form_controller_spec.rb
+++ b/spec/controllers/hyrax/contact_form_controller_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::ContactFormController do
+  routes { Hyrax::Engine.routes }
+  let(:user) { create(:user) }
+  let(:required_params) do
+    {
+      category: "Depositing content",
+      name: "Gandalf the Grey",
+      email: "gandalf@middle.earth",
+      subject: "When in doubt,",
+      message: "Follow your nose!"
+    }
+  end
+
+  describe 'while user is unauthenticated' do
+    it 'successfully allows reCaptcha' do
+      described_class.any_instance.stub(:verify_google_recaptcha).and_return(true)
+      Hyrax::ContactMailer.any_instance.stub(:mail).and_return(true)
+      post :create, params: { contact_form: required_params }
+      expect(flash[:notice]).to match(/Thank you for your message/)
+    end
+
+    it 'fails on reCaptcha failure' do
+      post :create, params: { contact_form: required_params }
+      expect(flash[:error]).to match(/You must complete the Captcha to confirm the form/)
+    end
+  end
+
+  describe "while user is authenticated" do
+    before { sign_in(user) }
+
+    describe "#new" do
+      subject { response }
+
+      before { get :new }
+      it { is_expected.to be_success }
+    end
+
+    describe "#create" do
+      subject { flash }
+
+      before { post :create, params: { contact_form: params } }
+      context "with the required parameters" do
+        let(:params) { required_params }
+
+        its(:notice) { is_expected.to eq("Thank you for your message!") }
+      end
+
+      context "without a category" do
+        let(:params)  { required_params.except(:category) }
+
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. You must complete the Captcha to confirm the form. Category can't be blank") }
+      end
+
+      context "without a name" do
+        let(:params)  { required_params.except(:name) }
+
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. You must complete the Captcha to confirm the form. Name can't be blank") }
+      end
+
+      context "without an email" do
+        let(:params)  { required_params.except(:email) }
+
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. You must complete the Captcha to confirm the form. Email can't be blank") }
+      end
+
+      context "without a subject" do
+        let(:params)  { required_params.except(:subject) }
+
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. You must complete the Captcha to confirm the form. Subject can't be blank") }
+      end
+
+      context "without a message" do
+        let(:params)  { required_params.except(:message) }
+
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. You must complete the Captcha to confirm the form. Message can't be blank") }
+      end
+
+      context "with an invalid email" do
+        let(:params)  { required_params.merge(email: "bad-wolf") }
+
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. You must complete the Captcha to confirm the form. Email is invalid") }
+      end
+    end
+
+    describe "#after_deliver" do
+      context "with a successful email" do
+        it "calls #after_deliver" do
+          expect(controller).to receive(:after_deliver)
+          post :create, params: { contact_form: required_params }
+        end
+      end
+      context "with an unsuccessful email" do
+        it "does not call #after_deliver" do
+          expect(controller).not_to receive(:after_deliver)
+          post :create, params: { contact_form: required_params.except(:email) }
+        end
+      end
+    end
+
+    context "when encoutering a RuntimeError" do
+      let(:logger) { double(info?: true) }
+
+      before do
+        allow(controller).to receive(:logger).and_return(logger)
+        allow(Hyrax::ContactMailer).to receive(:contact).and_raise(RuntimeError)
+      end
+      it "is logged via Rails" do
+        expect(logger).to receive(:error).with("Contact form failed to send: #<RuntimeError: RuntimeError>")
+        post :create, params: { contact_form: required_params }
+      end
+    end
+  end
+end

--- a/spec/features/contact_form_spec.rb
+++ b/spec/features/contact_form_spec.rb
@@ -1,20 +1,32 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe "Sending an email via the contact form", type: :feature do
   let(:user) { create(:user) }
 
-  before { sign_in(user) }
+  describe "with unauthenticated user" do
+    it "shows recaptcha dialog" do
+      visit '/'
+      click_link "Contact"
+      expect(page).to have_css('div.g-recaptcha')
+    end
+  end
 
-  it "sends mail" do
-    visit '/'
-    click_link "Contact"
-    expect(page).to have_content "Contact Form"
-    fill_in "Your Name", with: "Test McPherson"
-    fill_in "Your Email", with: "archivist1@example.com"
-    fill_in "Message", with: "I am contacting you regarding ScholarSphere."
-    fill_in "Subject", with: "My Subject is Cool"
-    select "Depositing content", from: "Issue Type"
-    click_button "Send"
-    expect(page).to have_content "Thank you for your message!"
+  describe "with authenticated user" do
+    before { sign_in(user) }
+
+    it "sends mail" do
+      visit '/'
+      click_link "Contact"
+      expect(page).to have_content "Contact Form"
+      fill_in "Your Name", with: "Test McPherson"
+      fill_in "Your Email", with: "archivist1@example.com"
+      fill_in "Message", with: "I am contacting you regarding ScholarSphere."
+      fill_in "Subject", with: "My Subject is Cool"
+      select "Depositing content", from: "Issue Type"
+      click_button "Send"
+      expect(page).to have_content "Thank you for your message!"
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,7 @@ require 'capybara/rspec'
 require 'capybara/rails'
 require 'selenium-webdriver'
 require 'database_cleaner'
+require 'rspec/its'
 
 unless ENV['SKIP_MALEFICENT']
   # See https://github.com/jeremyf/capybara-maleficent
@@ -96,6 +97,8 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
   config.include Devise::Test::IntegrationHelpers, type: :feature
+
+  config.include Devise::Test::ControllerHelpers, type: :controller
 
   config.before :suite do
     DatabaseCleaner.clean_with(:truncation)


### PR DESCRIPTION
Fixes #61;

May need to verify that [this](https://github.com/uclibs/ucrate/blob/f94f3b270b0a7ac0c6ec78ea45d8c93499db698b/app/controllers/hyrax/contact_form_controller.rb#L38) indeed receives the secret key and recaptcha authentication works. But, apart from that, this PR is in good shape.

Changes proposed in this pull request:
* Adds Google reCaptcha to the contact form. reCaptcha verification only for unauthenticated users.
