### PR TITLE
Update to Hyrax 2.1.0_beta1b_qa

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -183,6 +183,7 @@ RSpec/ExampleLength:
     - 'spec/features/contact_form_spec.rb'
     - 'spec/features/create_child_work_spec.rb'
     - 'spec/features/create_work_spec.rb'
+    - 'spec/features/create_work_admin_spec.rb'
     - 'spec/features/dashboard/collection_spec.rb'
     - 'spec/features/dashboard/display_dashboard_spec.rb'
     - 'spec/features/edit_work_spec.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem 'devise-guests', '~> 0.6'
 gem 'hydra-role-management'
-gem 'hyrax', git: 'https://github.com/samvera/hyrax.git', tag: 'v2.1.0.beta1'
+gem 'hyrax', git: 'https://github.com/samvera/hyrax.git', ref: '01d8ad5ecdf5b5658e6800d23d570c5d7b2c9cdc' # v2.1.0_beta1b_qa
 gem 'omniauth-openid'
 gem 'omniauth-shibboleth'
 gem 'riiif', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: e88981a04ef63fa38bf9fabc3ed9e269e562471b
-  tag: v2.1.0.beta1
+  revision: 01d8ad5ecdf5b5658e6800d23d570c5d7b2c9cdc
+  ref: 01d8ad5ecdf5b5658e6800d23d570c5d7b2c9cdc
   specs:
     hyrax (2.1.0.beta1)
       active-fedora (~> 11.5, >= 11.5.2)
@@ -23,7 +23,7 @@ GIT
       hydra-editor (~> 3.3)
       hydra-head (>= 10.5.0)
       hydra-works (~> 0.16)
-      iiif_manifest (~> 0.3.0)
+      iiif_manifest (>= 0.3, < 0.5)
       jquery-datatables-rails (~> 3.4)
       jquery-ui-rails (~> 6.0)
       json-schema
@@ -48,7 +48,7 @@ GIT
       samvera-nesting_indexer (~> 1.0, >= 1.0.1)
       select2-rails (~> 3.5)
       signet
-      simple_form (= 3.5.0)
+      simple_form (~> 3.2, <= 3.5.0)
       tinymce-rails (~> 4.1)
 
 GIT
@@ -250,7 +250,7 @@ GEM
     dry-container (0.6.0)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.4.4)
+    dry-core (0.4.5)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.2.0)
     dry-logic (0.4.2)
@@ -381,13 +381,8 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    iiif-presentation (0.2.0)
-      activesupport (>= 3.2.18)
-      faraday (>= 0.9)
-      json
-    iiif_manifest (0.3.0)
+    iiif_manifest (0.4.0)
       activesupport (>= 4)
-      iiif-presentation (~> 0.2.0)
     inflecto (0.0.2)
     io-like (0.3.0)
     jbuilder (2.7.0)
@@ -439,7 +434,7 @@ GEM
       rdf-xsd (>= 2.2, < 4.0)
       sparql (>= 2.2, < 4.0)
       sxp (~> 1.0)
-    ldp (0.7.0)
+    ldp (0.7.2)
       deprecation
       faraday
       http_logger
@@ -760,7 +755,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    slop (4.6.1)
+    slop (4.6.2)
     solr_wrapper (1.2.0)
       faraday
       retriable

--- a/db/migrate/20180312130601_add_branding_to_collection_type.hyrax.rb
+++ b/db/migrate/20180312130601_add_branding_to_collection_type.hyrax.rb
@@ -1,0 +1,5 @@
+class AddBrandingToCollectionType < ActiveRecord::Migration[5.1]
+  def change
+    add_column :hyrax_collection_types, :brandable, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180220183258) do
+ActiveRecord::Schema.define(version: 20180312130601) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -131,6 +131,7 @@ ActiveRecord::Schema.define(version: 20180220183258) do
     t.boolean "assigns_workflow", default: false, null: false
     t.boolean "assigns_visibility", default: false, null: false
     t.boolean "share_applies_to_new_works", default: true, null: false
+    t.boolean "brandable", default: true, null: false
     t.index ["machine_id"], name: "index_hyrax_collection_types_on_machine_id", unique: true
   end
 

--- a/spec/factories/collection_types.rb
+++ b/spec/factories/collection_types.rb
@@ -1,12 +1,13 @@
 FactoryBot.define do
   factory :collection_type, class: Hyrax::CollectionType do
-    sequence(:title) { |n| "Title #{n}" }
+    sequence(:title) { |n| "Collection Type #{n}" }
     sequence(:machine_id) { |n| "title_#{n}" }
 
     description 'Collection type with all options'
     nestable true
     discoverable true
     sharable true
+    brandable true
     share_applies_to_new_works true
     allow_multiple_membership true
     require_membership false
@@ -68,6 +69,14 @@ FactoryBot.define do
 
     trait :not_discoverable do
       discoverable false
+    end
+
+    trait :brandable do
+      brandable true
+    end
+
+    trait :not_brandable do
+      brandable false
     end
 
     trait :sharable do

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -52,6 +52,7 @@ FactoryBot.define do
   #   let(:settings) { [
   #                      :nestable,                  # OR :not_nestable,
   #                      :discoverable,              # OR :not_discoverable
+  #                      :brandable,                 # OR :not_brandable
   #                      :sharable,                  # OR :not_sharable OR :sharable_no_work_permissions
   #                      :allow_multiple_membership, # OR :not_allow_multiple_membership
   #                    ] }
@@ -63,6 +64,7 @@ FactoryBot.define do
   #   let(:settings) { [
   #                      :nestable,                  # OR :not_nestable,
   #                      :discoverable,              # OR :not_discoverable
+  #                      :brandable,                 # OR :not_brandable
   #                      :sharable,                  # OR :not_sharable OR :sharable_no_work_permissions
   #                      :allow_multiple_membership, # OR :not_allow_multiple_membership
   #                    ] }
@@ -105,7 +107,7 @@ FactoryBot.define do
       with_nesting_attributes nil
       with_solr_document false
     end
-    sequence(:title) { |n| ["Title #{n}"] }
+    sequence(:title) { |n| ["Collection Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)
@@ -162,7 +164,7 @@ FactoryBot.define do
       user { create(:user) }
     end
 
-    sequence(:title) { |n| ["Title #{n}"] }
+    sequence(:title) { |n| ["User Collection Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)
@@ -181,7 +183,7 @@ FactoryBot.define do
       do_save false
     end
 
-    sequence(:title) { |n| ["Title #{n}"] }
+    sequence(:title) { |n| ["Typeless Collection Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
       create_access false
       with_nesting_attributes nil
     end
-    sequence(:title) { |n| ["Title #{n}"] }
+    sequence(:title) { |n| ["Collection Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)
@@ -88,7 +88,7 @@ FactoryBot.define do
       user { create(:user) }
     end
 
-    sequence(:title) { |n| ["Title #{n}"] }
+    sequence(:title) { |n| ["User Collection Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)
@@ -108,7 +108,7 @@ FactoryBot.define do
       do_save false
     end
 
-    sequence(:title) { |n| ["Title #{n}"] }
+    sequence(:title) { |n| ["Typeless Collection Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)

--- a/spec/features/collection_multi_membership_spec.rb
+++ b/spec/features/collection_multi_membership_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_repo: true, js: true, with_nested_reindexing: true do
+RSpec.describe 'Adding a work to multiple collections', type: :feature, clean_repo: true, js: true do
   let(:admin_user) { create(:admin, email: 'admin@example.com') }
   let(:single_membership_type_1) { create(:collection_type, :not_allow_multiple_membership, title: 'Single-membership 1') }
   let(:single_membership_type_2) { create(:collection_type, :not_allow_multiple_membership, title: 'Single-membership 2') }

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'collection', type: :feature, with_nested_reindexing: true do
+RSpec.describe 'collection', type: :feature, clean_repo: true do
   let(:user) { create(:user) }
 
   let(:collection1) { create(:public_collection, user: user) }

--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -77,6 +77,50 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
       expect(page).to have_link('Settings', href: '#settings')
       expect(page).to have_link('Participants', href: '#participants')
     end
+
+    it 'tries to make a collection type with existing title, and receives error message', :js do
+      click_link 'Create new collection type'
+
+      expect(page).to have_content 'Create New Collection Type'
+
+      # confirm only Description tab is visible
+      expect(page).to have_link('Description', href: '#metadata')
+      expect(page).not_to have_link('Settings', href: '#settings')
+      expect(page).not_to have_link('Participants', href: '#participants')
+
+      # confirm metadata fields exist
+      expect(page).to have_selector 'input#collection_type_title'
+      expect(page).to have_selector 'textarea#collection_type_description'
+
+      # set values and save
+      fill_in('Type name', with: title)
+      fill_in('Type description', with: description)
+
+      click_button('Save')
+
+      visit '/admin/collection_types'
+      click_link 'Create new collection type'
+
+      expect(page).to have_content 'Create New Collection Type'
+
+      # confirm only Description tab is visible
+      expect(page).to have_link('Description', href: '#metadata')
+      expect(page).not_to have_link('Settings', href: '#settings')
+      expect(page).not_to have_link('Participants', href: '#participants')
+
+      # confirm metadata fields exist
+      expect(page).to have_selector 'input#collection_type_title'
+      expect(page).to have_selector 'textarea#collection_type_description'
+
+      # set values and save
+      fill_in('Type name', with: title)
+      fill_in('Type description', with: description)
+
+      click_button('Save')
+
+      # Confirm error message is displayed.
+      expect(page).to have_content 'Save was not successful because title has already been taken, and machine_id has already been taken.'
+    end
   end
 
   describe 'edit collection type' do
@@ -120,6 +164,7 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
 
         # confirm all non-admin_set checkboxes are on
         expect(page).to have_checked_field('collection_type_nestable')
+        expect(page).to have_checked_field('collection_type_brandable')
         expect(page).to have_checked_field('collection_type_discoverable')
         expect(page).to have_checked_field('collection_type_sharable')
         expect(page).to have_checked_field('collection_type_share_applies_to_new_works')
@@ -131,13 +176,14 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
         expect(page).to have_unchecked_field('collection_type_assigns_visibility', disabled: true)
 
         # change settings
-        page.uncheck('NESTABLE')
+        page.uncheck('NESTING')
         page.uncheck('DISCOVERY')
         page.check('APPLY TO NEW WORKS')
         page.uncheck('MULTIPLE MEMBERSHIP')
 
         # confirm all non-admin_set checkboxes are now off
         expect(page).to have_unchecked_field('collection_type_nestable')
+        expect(page).to have_checked_field('collection_type_brandable')
         expect(page).to have_unchecked_field('collection_type_discoverable')
         expect(page).to have_checked_field('collection_type_sharable')
         expect(page).to have_checked_field('collection_type_share_applies_to_new_works')
@@ -195,6 +241,7 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
 
           # confirm default user collection checkboxes are set to appropriate values
           expect(page).to have_checked_field('collection_type_nestable', disabled: true)
+          expect(page).to have_checked_field('collection_type_brandable', disabled: true)
           expect(page).to have_checked_field('collection_type_discoverable', disabled: true)
           expect(page).to have_checked_field('collection_type_sharable', disabled: true)
           expect(page).to have_unchecked_field('collection_type_share_applies_to_new_works', disabled: true)
@@ -268,6 +315,7 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
 
         # confirm all checkboxes are disabled
         expect(page).to have_field('collection_type_nestable', disabled: true)
+        expect(page).to have_field('collection_type_brandable', disabled: true)
         expect(page).to have_field('collection_type_discoverable', disabled: true)
         expect(page).to have_field('collection_type_sharable', disabled: true)
         expect(page).to have_field('collection_type_share_applies_to_new_works', disabled: true)

--- a/spec/features/create_work_admin_spec.rb
+++ b/spec/features/create_work_admin_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe 'Creating a new Work as admin', :js, :workflow do
+  let(:user) { create(:admin) }
+  let(:admin_set_1) do
+    create(:admin_set, id: AdminSet::DEFAULT_ID,
+                       title: ["Default Admin Set"],
+                       description: ["A description"],
+                       edit_users: [user.user_key])
+  end
+  let(:admin_set_2) do
+    create(:admin_set, title: ["Another Admin Set"],
+                       description: ["A description"],
+                       edit_users: [user.user_key])
+  end
+
+  before do
+    admin = Role.find_or_create_by(name: "admin")
+    admin.users << user
+    admin.save
+  end
+
+  context 'when there are multiple admin sets' do
+    before do
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, source_id: admin_set_1.id, with_admin_set: true, with_active_workflow: true),
+             agent_type: 'user',
+             agent_id: user.user_key)
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, source_id: admin_set_2.id, with_admin_set: true, with_active_workflow: true),
+             agent_type: 'user',
+             agent_id: user.user_key)
+      sign_in user
+    end
+
+    it "allows default admin set to be the first item in the select menu" do
+      visit '/dashboard'
+      click_link 'Works'
+      click_link "Add new work"
+      click_link "Relationship" # switch tab
+      expect(page).to have_content('Administrative Set')
+      expect(page).to have_content('Another Admin Set')
+      expect(page).to have_content('Default Admin Set')
+      expect(page).to have_selector('select#generic_work_admin_set_id')
+      expect(page).to have_select('generic_work_admin_set_id', selected: 'Default Admin Set')
+    end
+  end
+end

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Creating a new Work', :js, :workflow do
   let(:user) { create(:user) }
+  let!(:ability) { ::Ability.new(user) }
   let(:file1) { File.open(fixture_path + '/world.png') }
   let(:file2) { File.open(fixture_path + '/image.jp2') }
   let!(:uploaded_file1) { Hyrax::UploadedFile.create(file: file1, user: user) }

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       visit '/dashboard/my/collections'
     end
 
-    it 'lists all collections for all users', with_nested_reindexing: true do
+    it 'lists all collections for all users' do
       expect(page).to have_link 'All Collection'
       click_link 'All Collections'
       expect(page).to have_link(collection1.title.first)
@@ -539,7 +539,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
     end
   end
 
-  describe 'collection show page', with_nested_reindexing: true do
+  describe 'collection show page' do
     let(:collection) do
       create(:public_collection, user: user, description: ['collection description'], create_access: true)
     end
@@ -668,7 +668,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   end
 
   # TODO: this is just like the block above. Merge them.
-  describe 'show pages of a collection', with_nested_reindexing: true do
+  describe 'show pages of a collection' do
     before do
       docs = (0..12).map do |n|
         { "has_model_ssim" => ["GenericWork"], :id => "zs25x871q#{n}",
@@ -696,7 +696,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   end
 
   describe 'remove works from collection' do
-    context 'user that can edit', :with_nested_reindexing do
+    context 'user that can edit' do
       let!(:work2) { create(:work, title: ["King Louie"], member_of_collections: [collection1], user: user) }
       let!(:work1) { create(:work, title: ["King Kong"], member_of_collections: [collection1], user: user) }
 
@@ -785,14 +785,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
           expect(page).to have_field('collection_title', with: collection.title.first)
           expect(page).to have_field('collection_description', with: collection.description.first)
 
-          # TODO: These two expectations require the spec to include with_nested_reindexing: true.
-          # However, adding nested indexing causes this spec to fail to go through the update method
-          # in the controller unless js: true is also included. Including javascript greatly increases
-          # the time required for the spec to complete, so for now, I am simply commenting out these
-          # two expectations, as these are not integral to the function being tested.
-          # expect(page).to have_content(work1.title.first)
-          # expect(page).to have_content(work2.title.first)
-
           new_title = "Altered Title"
           new_description = "Completely new Description text."
           creators = ["Dorje Trollo", "Vajrayogini"]
@@ -838,9 +830,19 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         sign_in user
       end
 
-      it 'always includes branding' do
-        visit "/dashboard/collections/#{collection.id}/edit"
-        expect(page).to have_link('Branding', href: '#branding')
+      context 'with brandable set' do
+        let(:brandable_collection_id) { create(:collection, user: user, collection_type_settings: [:brandable], create_access: true).id }
+        let(:not_brandable_collection_id) { create(:collection, user: user, collection_type_settings: [:not_brandable], create_access: true).id }
+
+        it 'to true, it shows Branding tab' do
+          visit "/dashboard/collections/#{brandable_collection_id}/edit"
+          expect(page).to have_link('Branding', href: '#branding')
+        end
+
+        it 'to false, it hides Branding tab' do
+          visit "/dashboard/collections/#{not_brandable_collection_id}/edit"
+          expect(page).not_to have_link('Branding', href: '#branding')
+        end
       end
 
       context 'with discoverable set' do

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -2,7 +2,18 @@ require 'rails_helper'
 
 RSpec.describe 'Editing a work', type: :feature do
   let(:user) { create(:user) }
-  let(:work) { build(:work, user: user) }
+  let(:work) { build(:work, user: user, admin_set: another_admin_set) }
+  let(:default_admin_set) do
+    create(:admin_set, id: AdminSet::DEFAULT_ID,
+                       title: ["Default Admin Set"],
+                       description: ["A description"],
+                       edit_users: [user.user_key])
+  end
+  let(:another_admin_set) do
+    create(:admin_set, title: ["Another Admin Set"],
+                       description: ["A description"],
+                       edit_users: [user.user_key])
+  end
 
   before do
     sign_in user
@@ -12,7 +23,9 @@ RSpec.describe 'Editing a work', type: :feature do
   end
 
   context 'when the user changes permissions' do
-    it 'confirms copying permissions to files using Hyrax layout' do
+    let(:work) { create(:private_work, user: user, admin_set: default_admin_set) }
+
+    it 'confirms copying permissions to files using Hyrax layout and shows updated value', with_nested_reindexing: true do
       # e.g. /concern/generic_works/jq085k20z/edit
       visit edit_hyrax_generic_work_path(work)
       choose('generic_work_visibility_open')
@@ -20,6 +33,31 @@ RSpec.describe 'Editing a work', type: :feature do
       click_on('Save')
       expect(page).to have_content 'Apply changes to contents?'
       expect(page).not_to have_content "Powered by Hyrax"
+      click_on("No. I'll update it manually.")
+      within(".panel-heading") do
+        expect(page).to have_content('Public')
+      end
+    end
+  end
+
+  context 'when form loads' do
+    before do
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, source_id: default_admin_set.id, with_admin_set: true, with_active_workflow: true),
+             agent_type: 'user',
+             agent_id: user.user_key)
+      create(:permission_template_access,
+             :deposit,
+             permission_template: create(:permission_template, source_id: another_admin_set.id, with_admin_set: true, with_active_workflow: true),
+             agent_type: 'user',
+             agent_id: user.user_key)
+    end
+
+    it 'selects admin set already assigned' do
+      visit edit_hyrax_generic_work_path(work)
+      click_link "Relationships" # switch tab
+      expect(page).to have_select('generic_work_admin_set_id', selected: another_admin_set.title)
     end
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -37,21 +37,19 @@ RSpec.describe 'searching' do
       # it "does not display search options for dashboard files" do
       # This section was tested on its own, and required a full setup.
       within(".input-group-btn") do
+        expect(page).not_to have_content("All")
         expect(page).not_to have_content("My Works")
         expect(page).not_to have_content("My Collections")
         expect(page).not_to have_content("My Shares")
       end
       # end
 
-      expect(page).to have_content("All")
-      expect(page).to have_css("a[data-search-label*=All]", visible: false)
+      expect(page).not_to have_css("a[data-search-label*=All]", visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Works']", visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Collections']", visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Highlights']", visible: false)
       expect(page).not_to have_css("a[data-search-label*='My Shares']", visible: false)
 
-      click_button("All")
-      expect(page).to have_content("All of UCrate")
       fill_in "search-field-header", with: subject_value
       click_button("Go")
 

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -9,14 +9,18 @@ RSpec.describe "display a work as its owner" do
 
   context "as the work owner" do
     let(:work) do
-      create(:work_with_one_file,
+      create(:work,
              with_admin_set: true,
              title: ["Magnificent splendor"],
              source: ["The Internet"],
              based_near: ["USA"],
-             user: user)
+             user: user,
+             ordered_members: [file_set],
+             representative_id: file_set.id)
     end
     let(:user) { create(:user) }
+    let(:file_set) { create(:file_set, user: user, title: ['A Contained FileSet'], content: file) }
+    let(:file) { File.open(fixture_path + '/world.png') }
 
     before do
       sign_in user
@@ -33,11 +37,15 @@ RSpec.describe "display a work as its owner" do
       within '.related-files' do
         expect(page).to have_selector '.attribute-filename', text: 'A Contained FileSet'
       end
+
+      # IIIF manifest does not include locale query param
+      expect(find('div.viewer:first')['data-uri']).to eq "/concern/generic_works/#{work.id}/manifest"
     end
   end
 
   context "as a user who is not logged in" do
     let(:work) { create(:public_generic_work, title: ["Magnificent splendor"], source: ["The Internet"], based_near: ["USA"]) }
+    let(:page_title) { { text: "Generic Work | Magnificent splendor | ID: #{work.id} | UCrate" }.to_param }
 
     before do
       visit work_path
@@ -53,7 +61,7 @@ RSpec.describe "display a work as its owner" do
       expect(page).not_to have_selector "form#fileupload"
 
       # has some social media buttons
-      expect(page).to have_link '', href: "https://twitter.com/intent/tweet/?text=Magnificent+splendor&url=http%3A%2F%2Fwww.example.com%2Fconcern%2Fgeneric_works%2F#{work.id}"
+      expect(page).to have_link '', href: "https://twitter.com/intent/tweet/?#{page_title}&url=http%3A%2F%2Fwww.example.com%2Fconcern%2Fgeneric_works%2F#{work.id}"
 
       # exports EndNote
       expect(page).to have_link 'EndNote'


### PR DESCRIPTION
Fixes #135 

This updates ucrate to use Hyrax v2.1.0_beta1b_qa.  This is the same Hyrax version nurax is using and incorporates fixes based on the recent QA testing.

Most of this commit just tweaks our feature specs to match the changes made to the same specs in Hyrax.