### PR TITLE
Generate seed data for testing

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,73 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+class AddSeedObjects < ActiveRecord::Migration[5.1]
+
+  password = Devise.friendly_token.first(8)
+  puts "Password for all accounts: #{password}\n\n"
+
+  User.find_by_email('manydeposits@example.com').try(:destroy)
+  many_deposits = User.create(
+    email: 'manydeposits@example.com',
+    first_name: 'Many',
+    last_name: 'Deposits',
+    password: password,
+    password_confirmation: password)
+  puts "Account created: #{many_deposits.email}"
+
+  User.find_by_email('nodeposits@example.com').try(:destroy)
+  no_deposits = User.create(
+    email: 'nodeposits@example.com',
+    first_name: 'No',
+    last_name: 'Deposits',
+    password: password,
+    password_confirmation: password)
+  puts "Account created: #{no_deposits.email}"
+
+  User.find_by_email('delegate@example.com').try(:destroy)
+  student_delegate = User.create(
+    email: 'delegate@example.com',
+    first_name: 'Student',
+    last_name: 'Delegate',
+    password: password,
+    password_confirmation: password)
+  puts "Account created: #{student_delegate.email}"
+
+  User.find_by_email('admin@example.com').try(:destroy)
+  admin_user = User.create(
+    email: 'admin@example.com',
+    first_name: 'Admin',
+    last_name: 'User',
+    password: password,
+    password_confirmation: password)
+  admin = Role.create(name: 'admin')
+  admin.users << admin_user
+  admin.save
+  puts "Account created: #{admin_user.email}\n\n"
+
+  users_with_works = [many_deposits, student_delegate, admin_user]
+  works_per_user = 10
+
+  users_with_works.each do |user|
+    works_per_user.times do
+      work = GenericWork.create(
+        title: ['This is the title'],
+        description: ['This is the description'],
+        depositor: user.email,
+        owner: user.email,
+        creator: ["#{user.last_name}, #{user.first_name}"],
+        subject: ['geography', 'history', 'chemistry'],
+        rights_statement: ["http://rightsstatements.org/vocab/InC/1.0/"],
+        publisher: ['Penguin Publishing'],
+        language: ['English'],
+        based_near: ['The world'],
+        date_created: [Time.zone.at(rand * Time.now.to_i).to_s.sub(/\s(.*)/, '')]
+      )
+      work.read_groups = [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC]
+      work.edit_users = [user.email]
+      work.save
+      work.to_solr
+    end
+    puts "#{works_per_user} Generic Works created for #{user.email}"
+  end
+
+end


### PR DESCRIPTION
Partial work for #104 

I decided to open a PR just for creating seed data.  This is gets used by the manual test script I'm still working on.

To test this, run `bundle exec rake db:migrate` then make sure
1. you can log in as all the generated users
1. the admin user does have admin rights
1. each user owns 10 works (except nodeposits@example.com)
1. you can run the rake task over and over without errors