### PR TITLE
Enable Shibboleth, order dependency

### DIFF
--- a/spec/features/uc_shibboleth_spec.rb
+++ b/spec/features/uc_shibboleth_spec.rb
@@ -60,6 +60,7 @@ describe 'UC account workflow', type: :feature do
 
   describe 'overridden devise sign-in page' do
     it 'shows a shibboleth login link if shibboleth is enabled' do
+      AUTH_CONFIG['shibboleth_enabled'] = true
       visit new_user_session_path
       if yaml['test']['shibboleth_enabled'] == true
         expect(page).to have_link('Central Login form', href: '/users/auth/shibboleth')


### PR DESCRIPTION
Fixes #148

Present short summary (50 characters or less)

This PR fixes a flaky test with order dependency. One of the examples disables Shibboleth and had to be reenabled for the tests to pass with seed 4197. Read issue comments for more info.
