### PR TITLE
Add collection title in the collection export page

### DIFF
--- a/app/helpers/collection_export_helper.rb
+++ b/app/helpers/collection_export_helper.rb
@@ -1,0 +1,7 @@
+module CollectionExportHelper
+  def collection_title(id)
+    Collection.find(id).title.first
+  rescue ActiveFedora::ObjectNotFoundError
+    "the collection doesn't exist"
+  end
+end

--- a/app/views/collection_exports/index.html.erb
+++ b/app/views/collection_exports/index.html.erb
@@ -1,9 +1,11 @@
+<% 'app/helpers/collection_export_helper.rb' %>
 <h1><%= t("collection_export.title") %></h1>
 
 <table class="table">
   <thead>
     <tr>
       <th scope="col"><%= t("collection_export.header.collection_id") %></th>
+      <th scope="col"><%= t("collection_export.header.title") %></th>
       <th scope="col"><%= t("collection_export.header.timestamp") %></th>
       <th scope="col"><%= t("collection_export.header.destroy") %></th>
       <th scope="col"><%= t("collection_export.header.download") %></th>
@@ -12,8 +14,10 @@
 
   <tbody>
     <% @collection_exports.each do |collection_export| %>
+
       <tr scope="row">
         <td><%= collection_export.collection_id %></td>
+        <td><%= collection_title(collection_export.collection_id) %></td>
         <td><%= collection_export.created_at %></td>
         <td><%= link_to t("collection_export.action.download"), collection_export_download_path(collection_export) %></td>
         <% if can? :destroy, collection_export %>

--- a/spec/features/collection_export_spec.rb
+++ b/spec/features/collection_export_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "collection export", type: :feature do
     let(:user) { create(:user) }
     let(:other_user) { create(:user) }
 
-    let(:user_collection) do
+    let!(:user_collection) do
       create(:public_collection,
              user: user,
              description: ['collection description'],
@@ -34,6 +34,7 @@ RSpec.describe "collection export", type: :feature do
         click_link "Export collection"
         expect(page).to have_content("Collection export was successfully created")
         expect(page).to have_content(user_collection.id)
+        expect(page).to have_content(user_collection.title.first)
 
         # can export a collection from the dashboard collection index
         # visit "dashboard/my/collections"


### PR DESCRIPTION
Fixes #161 
Add collection title on the collection export page.
Add test for the collection title column. 
Add collection_title helper to return the collection title. 