### PR TITLE
Port over scholar welcome page and email

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -109,6 +109,11 @@ Style/ZeroLengthPredicate:
 Rails:
   Enabled: true
 
+Rails/SkipsModelValidations:
+  Exclude:
+    - 'app/models/user.rb'
+    - 'app/jobs/user_edit_profile_event_job.rb'
+
 Rails/ApplicationJob:
   Enabled: false
 
@@ -142,7 +147,7 @@ RSpec/DescribeClass:
     - 'spec/views/**/*'
 
 Rails/TimeZone:
-  Exclude: 
+  Exclude:
     - 'spec/services/collection_metadata_csv_factory_spec.rb'
 
 RSpec/ContextWording:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,10 +13,13 @@ class ApplicationController < ActionController::Base
   private
 
     # override devise helper and route to CC.new when parameter is set
-    def after_sign_in_path_for(_resource)
+    def after_sign_in_path_for(resource)
       cookies[:login_type] = "local"
-      return root_path unless parameter_set?
-      Hyrax::Engine.routes.url_helpers.dashboard_works_path
+      if !resource.waived_welcome_page
+        Rails.application.routes.url_helpers.welcome_page_index_path
+      else
+        Hyrax::Engine.routes.url_helpers.root_path
+      end
     end
 
     def after_sign_out_path_for(_resource_or_scope)
@@ -25,9 +28,5 @@ class ApplicationController < ActionController::Base
       else
         root_path
       end
-    end
-
-    def parameter_set?
-      session['user_return_to'] == '/'
     end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RegistrationsController < Devise::RegistrationsController
+  def after_sign_up_path_for(resource)
+    WelcomeMailer.welcome_email(resource).deliver
+    after_sign_in_path_for(resource)
+  end
+end

--- a/app/controllers/welcome_page_controller.rb
+++ b/app/controllers/welcome_page_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class WelcomePageController < ApplicationController
+  def index; end
+
+  def create
+    if user_just_waived_welcome_page?
+      current_user.waive_welcome_page!
+      redirect_to landing_page
+      flash[:notice] = "Thanks! You can always find the welcome page in our help menus."
+    else
+      redirect_to landing_page
+    end
+  end
+
+  def user_just_waived_welcome_page?
+    params[:commit] == t('hyrax.welcome.waive_page')
+  end
+
+  def user_waived_welcome_page?
+    current_user.waived_welcome_page
+  end
+  helper_method :user_waived_welcome_page?
+
+  def skip_new_user_help?
+    current_user.profile_update_not_required
+  end
+  helper_method :skip_new_user_help?
+
+  def landing_page
+    Hyrax::Engine.routes.url_helpers.root_path
+  end
+end

--- a/app/helpers/show_welcome_helper.rb
+++ b/app/helpers/show_welcome_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ShowWelcomeHelper
+  def show_welcome_page
+    if current_user.present? && current_user.student?
+      render "welcome_page/student_welcome_text"
+    else
+      render "welcome_page/welcome_text"
+    end
+  end
+end

--- a/app/jobs/user_edit_profile_event_job.rb
+++ b/app/jobs/user_edit_profile_event_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Log user profile edits to activity streams
+class UserEditProfileEventJob < EventJob
+  def perform(editor)
+    @editor = editor
+    super
+  end
+
+  def action
+    @editor.update_column(:profile_update_not_required, true)
+    "User #{link_to_profile @editor} has edited his or her profile"
+  end
+end

--- a/app/mailers/welcome_mailer.rb
+++ b/app/mailers/welcome_mailer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class WelcomeMailer < ActionMailer::Base
+  default from: 'ucrate@uc.edu'
+  def welcome_email(user)
+    @user = user
+    if @user.student?
+      @subject = 'Welcome to Ucrate@UC, UC students!'
+      @template = 'welcome_email_student.html.erb'
+    else
+      @subject = 'Welcome to Ucrate@UC!'
+      @template = 'welcome_email.html.erb'
+    end
+    send_mail
+  end
+
+  def send_mail
+    mail(
+      to: @user.email,
+      subject: @subject,
+      template_name: @template
+    )
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,8 +16,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable,
-         :omniauthable, omniauth_providers: [:shibboleth]
+         :recoverable, :rememberable, :trackable, :validatable, :omniauthable, omniauth_providers: [:orcid, :shibboleth]
 
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for
@@ -29,5 +28,13 @@ class User < ApplicationRecord
   def name
     return "#{first_name} #{last_name}" unless first_name.blank? || last_name.blank?
     user_key
+  end
+
+  def waive_welcome_page!
+    update_column(:waived_welcome_page, true)
+  end
+
+  def student?
+    uc_affiliation == 'student'
   end
 end

--- a/app/views/welcome_mailer/welcome_email.html.erb
+++ b/app/views/welcome_mailer/welcome_email.html.erb
@@ -1,0 +1,24 @@
+<h2 id="welcome-to-ucrateuc">Welcome to <%= t('hyrax.product_name') %></h2>
+<p>Welcome to <%= t('hyrax.product_name') %>! This email summarizes helpful information for using <%= t('hyrax.product_name') %>.</p>
+
+<h3 id="what-is-ucrateuc">What is <%= t('hyrax.product_name') %>?</h3>
+<p><%= t('hyrax.product_name') %> is a digital repository that enables the University of Cincinnati community to share research and scholarly work with a worldwide audience and preserve it for the future. Read more about the mission of <%= t('hyrax.product_name') %> on the <a href="https://scholar.uc.edu/about">About page</a>. Get the latest updates on development of <%= t('hyrax.product_name') %> on our <a href="http://libapps.libraries.uc.edu/scholarblog/">Scholarblog</a>. All users, including non-registered users, of <%= t('hyrax.product_name') %> are bound by the <a href="https://scholar.uc.edu/terms">Terms of Use</a>.</p>
+
+<h3 id="what-types-of-content-should-i-submit-to-ucrateuc">What types of content should I submit to <%= t('hyrax.product_name') %>?</h3>
+<p><%= t('hyrax.product_name') %> stores and preserves the scholarly output and creative works of UC faculty, staff, and students. Examples of appropriate content include, but are not limited to: <a href="https://en.wikipedia.org/wiki/Grey_literature">grey literature</a>, <a href="https://en.wikipedia.org/wiki/Preprint">pre-</a>, <a href="https://en.wikipedia.org/wiki/Postprint">post-</a>, and published versions of academic papers, manuscripts, senior design projects, posters, datasets, presentations, and other creative works. Content may be text, image, video, audio, or mixed-media in nature. Learn more about types of content you can share on the <a href="https://scholar.uc.edu/coll_policy">Collection Policy</a>.</p>
+<p>Students should work with a faculty member to share scholarly output and creative works, such a capstone projects.</p>
+
+<h3 id="how-do-i-get-started">How do I get started?</h3>
+<p>After you have edited your profile page for the first time, you may share content by clicking on [Add New] from the menu.</p>
+
+<h3 id="where-do-i-go-for-more-information">Where do I go for more information?</h3>
+<p>Under the Help button on the main <%= t('hyrax.product_name') %> menu, you will find the following help topics:</p>
+
+<ul>
+  <li><a href="https://scholar.uc.edu/faq">FAQs</a> – Answers to a variety of commonly asked questions</li>
+  <li><a href="https://scholar.uc.edu/format_advice">File Format Advice</a> – Help with finding the right file format for the content you submit to <%= t('hyrax.product_name') %></li>
+  <li><a href="https://scholar.uc.edu/creators_rights">Creator’s Rights</a> – Information on Copyright and Intellectual Property</li>
+</ul>
+
+<h4 id="need-further-assistance">Need Further Assistance?</h4>
+<p><a href="https://scholar.uc.edu/contact">Contact the <%= t('hyrax.product_name') %> Team</a>.</p>

--- a/app/views/welcome_mailer/welcome_email.text.erb
+++ b/app/views/welcome_mailer/welcome_email.text.erb
@@ -1,0 +1,31 @@
+Welcome to Ucrate@UC
+=================================
+
+Welcome to Ucrate@UC! This email summarizes helpful information for using Ucrate@UC.
+
+What is Ucrate@UC?
+-------------------
+
+Ucrate@UC is a digital repository that enables the University of Cincinnati community to share research and scholarly work with a worldwide audience and preserve it for the future. Read more about the mission of Ucrate@UC on the About page. Get the latest updates on development of Scholar@UC on our Scholarblog. All users, including non-registered users, of Scholar@UC are bound by the Terms of Use.
+
+What types of content should I submit to Ucrate@UC?
+----------------------------------------------------
+
+Ucrate@UC stores and preserves the scholarly output and creative works of UC faculty, staff, and students. Examples of appropriate content include, but are not limited to: grey literature, pre-, post-, and published versions of academic papers, manuscripts, senior design projects, posters, datasets, presentations, and other creative works. Content may be text, image, video, audio, or mixed-media in nature. Learn more about types of content you can share on the Collection Policy. Students should work with a faculty member to share scholarly output and creative works, such a capstone projects.
+
+How do I get started?
+---------------------
+
+After you have edited your profile page for the first time, you may share content by clicking on [Add New] from the menu.
+
+Where do I go for more information?
+-----------------------------------
+
+Under the Help button on the main Ucrate@UC menu, you will find the following help topics:
+
+  FAQs – Answers to a variety of commonly asked questions
+  File Format Advice – Help with finding the right file format for the content you submit to Ucrate@UC
+  Creator’s Rights – Information on Copyright and Intellectual Property
+
+Need Further Assistance?
+Contact the Ucrate@UC Team (https://scholar.uc.edu/contact_requests/new)

--- a/app/views/welcome_mailer/welcome_email_student.html.erb
+++ b/app/views/welcome_mailer/welcome_email_student.html.erb
@@ -1,0 +1,22 @@
+<h2 id="welcome-to-ucrateuc">Welcome to <%= t('hyrax.product_name') %>, UC Students</h2>
+<p>Welcome to <%= t('hyrax.product_name') %>! In this email, you will learn how students can use <%= t('hyrax.product_name') %>.</p>
+
+<h3 id="what-is-ucrateuc">What is <%= t('hyrax.product_name') %>?</h3>
+<p><%= t('hyrax.product_name') %> is a digital repository that enables the University of Cincinnati community to share research and scholarly work with a worldwide audience and preserve it for the future. It provides free access to material written, produced, and researched by the UC community. Read more about the mission of <%= t('hyrax.product_name') %> on the <a href="https://scholar.uc.edu/about">About page</a>. Get the latest updates on development of <%= t('hyrax.product_name') %> on our <a href="http://libapps.libraries.uc.edu/scholarblog/">Scholarblog</a>.</p>
+
+<h3 id="how-can-students-use-ucrateuc">How can students use <%= t('hyrax.product_name') %>?</h3>
+<p>Although only faculty and staff can submit content to <%= t('hyrax.product_name') %> at this time, students can log in and view material in the repository for research or classroom work. <%= t('hyrax.product_name') %> is constantly growing and includes information like published articles, photographs, manuscripts, datasets, posters and much more.</p>
+
+<p>In order to share scholarly output and creative works like capstone projects, students should work with a faculty member or advisor. Graduate students should continue to work with the <a href="http://grad.uc.edu/student-life/etd.html">Graduate School</a> for submission of electronic theses and dissertations.</p>
+
+<h3 id="how-can-students-use-materials">How can I use material I find in <%= t('hyrax.product_name') %>?</h3>
+<ul>
+  <li><p><b>Is material in <%= t('hyrax.product_name') %> copyrighted?</b> The material in Ucrate is subject to a variety of copyright protections; just as when using material from other database and online sources, you will want to check on the copyright. When uploading material to <%= t('hyrax.product_name') %>, submitters choose a content license or “access rights” for their content. An explanation of these licenses can be found on the <a href= "http://creativecommons.org/licenses/">Creative Commons website</a>. Still confused about copyright? See the UC Libraries’ <a href="http://guides.libraries.uc.edu/copyrightfair">campus guide on copyright.</a></p></li>
+
+  <li><p><b>Citing materials in <%= t('hyrax.product_name') %>: </b>Citing material in <%= t('hyrax.product_name') %> is similar to citing resources found in other database and online. See the <a href= "http://guides.libraries.uc.edu/citing">campus guide on citing your sources.</a></p></li>
+
+  <li><p><b>Terms of Use: </b>For more information, see the <%= t('hyrax.product_name') %> <a href="https://scholar.uc.edu/terms">Terms of Use.</a></p></li>
+</ul>
+
+<h4 id="need-further-assistance">Need Further Assistance?</h4>
+<p><a href="https://scholar.uc.edu/contact">Contact the <%= t('hyrax.product_name') %> Team</a>.</p>

--- a/app/views/welcome_mailer/welcome_email_student.text.erb
+++ b/app/views/welcome_mailer/welcome_email_student.text.erb
@@ -1,0 +1,30 @@
+Welcome to Ucrate@UC, UC Students
+====================================
+
+Welcome to Ucrate@UC! In this email, you will learn how students can use Ucrate@UC.
+
+What is Ucrate@UC?
+-------------------
+
+Ucrate@UC is a digital repository that enables the University of Cincinnati community to share research and scholarly work with a worldwide audience and preserve it for the future. It provides free access to material written, produced, and researched by the UC community. Read more about the mission of Ucrate@UC on the About page. Get the latest updates on development of Ucrate@UC on our Scholarblog.
+
+How can students use Ucrate@UC?
+--------------------------------
+
+Although only faculty and staff can submit content to Ucrate@UC at this time, students can log in and view material in the repository for research or classroom work. Ucrate@UC is constantly growing and includes information like published articles, photographs, manuscripts, datasets, posters and much more.
+
+In order to share scholarly output and creative works like capstone projects, students should work with a faculty member or advisor. Graduate students should continue to work with the Graduate School for submission of electronic theses and dissertations.
+
+How can I use material I find in Ucrate@UC?
+--------------------------------------------
+
+  Is material in Ucrate@UC copyrighted?:
+
+  	The material in Ucrate is subject to a variety of copyright protections; just as when using material from other database and online sources, you will want to check on the copyright. When uploading material to Ucrate@UC, submitters choose a content license or “access rights” for their content. An explanation of these licenses can be found on the Creative Commons website. Still confused about copyright? See the UC Libraries’ campus guide on copyright.
+
+  Citing materials in Ucrate@UC: Citing material in Ucrate@UC is similar to citing resources found in other database and online. See the campus guide on citing your sources.
+
+Terms of Use: For more information, see the Ucrate@UC Terms of Use.
+
+Need Further Assistance?
+Contact the Ucrate@UC Team (https://scholar.uc.edu/contact_requests/new)

--- a/app/views/welcome_page/_student_welcome_text.erb
+++ b/app/views/welcome_page/_student_welcome_text.erb
@@ -1,0 +1,22 @@
+<h2 id="welcome-to-scholaruc">Welcome to <%= t('hyrax.product_name') %>, UC Students</h2>
+<p>Welcome to <%= t('hyrax.product_name') %>! On this page, you will learn how students can use <%= t('hyrax.product_name') %>.</p>
+
+<h3 id="what-is-scholaruc">What is <%= t('hyrax.product_name') %>?</h3>
+<p><%= t('hyrax.product_name') %> is a digital repository that enables the University of Cincinnati community to share research and scholarly work with a worldwide audience and preserve it for the future. It provides free access to material written, produced, and researched by the UC community. Read more about the mission of <%= t('hyrax.product_name') %> on the <a href="/about">About page</a>. Get the latest updates on development of <%= t('hyrax.product_name') %> on our <a href="http://libapps.libraries.uc.edu/scholarblog/">Scholarblog</a>.</p>
+
+<h3 id="how-can-students-use-scholaruc">How can students use <%= t('hyrax.product_name') %>?</h3>
+<p>Although only faculty and staff can submit content to <%= t('hyrax.product_name') %> at this time, students can log in and view material in the repository for research or classroom work. <%= t('hyrax.product_name') %> is constantly growing and includes information like published articles, photographs, manuscripts, datasets, posters and much more.</p>
+
+<p>In order to share scholarly output and creative works like capstone projects, students should work with a faculty member or advisor. Graduate students should continue to work with the <a href="http://grad.uc.edu/student-life/etd.html">Graduate School</a> for submission of electronic theses and dissertations.</p>
+
+<h3 id="how-can-students-use-materials">How can I use material I find in <%= t('hyrax.product_name') %>?</h3>
+<ul>
+  <li><p><b>Is material in <%= t('hyrax.product_name') %> copyrighted?</b> The material in Scholar is subject to a variety of copyright protections; just as when using material from other database and online sources, you will want to check on the copyright. When uploading material to <%= t('hyrax.product_name') %>, submitters choose a content license or “access rights” for their content. An explanation of these licenses can be found on the <a href= "http://creativecommons.org/licenses/">Creative Commons website</a>. Still confused about copyright? See the UC Libraries’ <a href="http://guides.libraries.uc.edu/copyrightfair">campus guide on copyright.</a></p></li>
+
+  <li><p><b>Citing materials in <%= t('hyrax.product_name') %>: </b>Citing material in <%= t('hyrax.product_name') %> is similar to citing resources found in other database and online. See the <a href= "http://guides.libraries.uc.edu/citing">campus guide on citing your sources.</a></p></li>
+
+  <li><p><b>Terms of Use: </b>For more information, see the <%= t('hyrax.product_name') %> <a href="/terms">Terms of Use.</a></p></li>
+</ul>
+
+<h4 id="need-further-assistance">Need Further Assistance?</h4>
+<p><a href="/contact">Contact the <%= t('hyrax.product_name') %> Team</a>.</p>

--- a/app/views/welcome_page/_welcome_text.html.erb
+++ b/app/views/welcome_page/_welcome_text.html.erb
@@ -1,0 +1,24 @@
+<h2 id="welcome-to-scholaruc">Welcome to <%= t('hyrax.product_name') %></h2>
+<p>Welcome to <%= t('hyrax.product_name') %>! On this page, you will learn how to use <%= t('hyrax.product_name') %>.</p>
+
+<h3 id="what-is-scholaruc">What is <%= t('hyrax.product_name') %>?</h3>
+<p><%= t('hyrax.product_name') %> is a digital repository that enables the University of Cincinnati community to share research and scholarly work with a worldwide audience and preserve it for the future. Read more about the mission of <%= t('hyrax.product_name') %> on the <a href="/about">About page</a>. Get the latest updates on development of <%= t('hyrax.product_name') %> on our <a href="http://libapps.libraries.uc.edu/scholarblog/">Scholarblog</a>. All users, including non-registered users, of <%= t('hyrax.product_name') %> are bound by the <a href="/terms">Terms of Use</a>.</p>
+
+<h3 id="what-types-of-content-should-i-submit-to-scholaruc">What types of content should I submit to <%= t('hyrax.product_name') %>?</h3>
+<p><%= t('hyrax.product_name') %> stores and preserves the scholarly output and creative works of UC faculty, staff, and students. Examples of appropriate content include, but are not limited to: <a href="https://en.wikipedia.org/wiki/Grey_literature">grey literature</a>, <a href="https://en.wikipedia.org/wiki/Preprint">pre-</a>, <a href="https://en.wikipedia.org/wiki/Postprint">post-</a>, and published versions of academic papers, manuscripts, senior design projects, posters, datasets, presentations, and other creative works. Content may be text, image, video, audio, or mixed-media in nature. Learn more about types of content you can share on the <a href="/coll_policy">Collection Policy</a>.</p>
+<p>Students should work with a faculty member to share scholarly output and creative works, such a capstone projects.</p>
+
+<h3 id="how-do-i-get-started">How do I get started?</h3>
+<p>After you have edited your profile page for the first time, you may share content by clicking on [Add New] from the menu.</p>
+
+<h3 id="where-do-i-go-for-more-information">Where do I go for more information?</h3>
+<p>Under the Help button on the main <%= t('hyrax.product_name') %> menu, you will find the following help topics:</p>
+
+<ul>
+  <li><a href="/faq">FAQs</a> – Answers to a variety of commonly asked questions</li>
+  <li><a href="/format_advice">File Format Advice</a> – Help with finding the right file format for the content you submit to <%= t('hyrax.product_name') %></li>
+  <li><a href="/creators_rights">Creator’s Rights</a> – Information on Copyright and Intellectual Property</li>
+</ul>
+
+<h4 id="need-further-assistance">Need Further Assistance?</h4>
+<p><a href="/contact">Contact the <%= t('hyrax.product_name') %> Team</a>.</p>

--- a/app/views/welcome_page/index.html.erb
+++ b/app/views/welcome_page/index.html.erb
@@ -1,0 +1,16 @@
+<% if skip_new_user_help? && user_waived_welcome_page? %>
+  <%= raw show_welcome_page %>
+<% elsif skip_new_user_help? %>
+  <%= form_tag welcome_page_index_path, method: :post, id: "waive_welcome_page" do %>
+    <div class="form-actions centered">
+      <%= submit_tag t('hyrax.welcome.waive_page'), :class=> 'btn btn-primary' %>
+    </div>
+  <% end %>
+  <%= raw show_welcome_page %>
+<% else %>
+  <p>Next you’re going to edit your profile to make sure all your personal details are correct, but first please take a moment to review the help information below.</p>
+  <%= raw show_welcome_page %>
+  <div class="btn-group">
+    <%= link_to "Edit my Profile", Hyrax::Engine.routes.url_helpers.edit_dashboard_profile_path(current_user), class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -75,3 +75,5 @@ en:
       my:
         action:
           export_collection: "Export collection"
+    welcome:
+      waive_page: "Click here to hide this welcome page from displaying when you log in"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => '/sidekiq'
   end
 
-  devise_for :users, controllers: { omniauth_callbacks: 'callbacks' }
+  devise_for :users, controllers: { omniauth_callbacks: 'callbacks', registrations: "registrations" }
   mount Hydra::RoleManagement::Engine => '/'
 
   get 'login' => 'static#login'
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   mount Qa::Engine => '/authorities'
   mount Hyrax::Engine, at: '/'
   resources :welcome, only: 'index'
+  resources :welcome_page, only: [:index, :create]
   root 'hyrax/homepage#index'
   curation_concerns_basic_routes
   concern :exportable, Blacklight::Routes::Exportable.new

--- a/db/migrate/20180426120926_add_waived_welcome_to_user.rb
+++ b/db/migrate/20180426120926_add_waived_welcome_to_user.rb
@@ -1,0 +1,5 @@
+class AddWaivedWelcomeToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :waived_welcome_page, :boolean
+  end
+end

--- a/db/migrate/20180426130926_add_profile_update_not_required_to_user.rb
+++ b/db/migrate/20180426130926_add_profile_update_not_required_to_user.rb
@@ -1,0 +1,5 @@
+class AddProfileUpdateNotRequiredToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :profile_update_not_required, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180425183258) do
+ActiveRecord::Schema.define(version: 20180426130926) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -560,6 +560,8 @@ ActiveRecord::Schema.define(version: 20180425183258) do
     t.string "alternate_email"
     t.string "alternate_phone_number"
     t.string "blog"
+    t.boolean "waived_welcome_page"
+    t.boolean "profile_update_not_required"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/controllers/callbacks_controller_spec.rb
+++ b/spec/controllers/callbacks_controller_spec.rb
@@ -57,8 +57,8 @@ describe CallbacksController do
         get provider
       end
 
-      it 'redirects to the dashboard work page' do
-        response.should redirect_to(Hyrax::Engine.routes.url_helpers.dashboard_works_path)
+      it 'redirects to the welcome page' do
+        response.should redirect_to(Rails.application.routes.url_helpers.welcome_page_index_path)
       end
     end
 

--- a/spec/controllers/welcome_page_controller_spec.rb
+++ b/spec/controllers/welcome_page_controller_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe WelcomePageController, type: :controller do
+  context 'without signed in user' do
+    describe 'index' do
+      it 'renders the page' do
+        get :index
+        expect(response.status).to eq(200)
+        expect(response).to render_template('index')
+      end
+    end
+  end
+
+  context 'with signed in user' do
+    before do
+      sign_in(user)
+    end
+
+    describe 'without already waiving the page' do
+      let(:user) { FactoryBot.create(:user, waived_welcome_page: false) }
+
+      describe '.user_waived_welcome_page?' do
+        it 'returns the status of waived_welcome_page' do
+          expect(controller.user_waived_welcome_page?).to eq user.waived_welcome_page
+        end
+      end
+
+      describe '#index' do
+        it 'renders the page' do
+          get :index
+          expect(response.status).to eq(200)
+          expect(response).to render_template('index')
+        end
+      end
+
+      describe '#create' do
+        describe 'if welcome page waived' do
+          let(:params) { { waive_welcome_page: '1', commit: I18n.t('hyrax.welcome.waive_page') } }
+
+          before do
+            post :create, params: params
+          end
+          it 'redirects to landing page' do
+            expect(response).to redirect_to(Hyrax::Engine.routes.url_helpers.root_path)
+          end
+
+          it 'sets user waived_welcome_page to true' do
+            user.reload
+            expect(user.waived_welcome_page).to be true
+          end
+        end
+
+        describe 'if welcome page not waived' do
+          let(:params) { { waive_welcome_page: false } }
+
+          before do
+            post :create, params: params
+          end
+          it 'redirects to landing page' do
+            expect(response).to redirect_to(Hyrax::Engine.routes.url_helpers.root_path)
+          end
+
+          it 'keeps user.waived_welcome_page as false' do
+            expect(user.waived_welcome_page).to be false
+          end
+        end
+      end
+    end
+
+    describe 'after waiving the page' do
+      let(:user) { FactoryBot.create(:user, waived_welcome_page: true) }
+
+      describe '#index' do
+        it 'renders the page' do
+          get :index
+          expect(response.status).to eq(200)
+          expect(response).to render_template('index')
+        end
+      end
+    end
+  end
+end

--- a/spec/features/welcome_mailer_spec.rb
+++ b/spec/features/welcome_mailer_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe WelcomeMailer do
+  let(:user_email) { 'example@test.com' }
+  let(:user_password) { 'really_good_password' }
+  let(:email) { ActionMailer::Base.deliveries.last }
+
+  before do
+    AUTH_CONFIG['signups_enabled'] = true
+    visit new_user_registration_path
+    fill_in 'user_email', with: user_email
+    fill_in 'user_password', with: user_password
+    fill_in 'user_password_confirmation', with: user_password
+
+    click_button 'Sign up'
+  end
+  after do
+    ActionMailer::Base.deliveries = []
+    User.find_by_email(user_email).delete
+  end
+  it 'sends welcome email to user upon registration' do
+    email.to.should eq([user_email])
+    email.from.should == ["ucrate@uc.edu"]
+  end
+  context 'when user is a student' do
+    let(:student_user) { FactoryBot.create(:user, uc_affiliation: 'student') }
+    let(:student_email) { described_class.welcome_email(student_user) }
+
+    it 'sends a student specific welcome email' do
+      student_email.subject.should == "Welcome to Ucrate@UC, UC students!"
+    end
+  end
+  context 'when user is NOT a student' do
+    let(:faculty_user) { FactoryBot.create(:user, uc_affiliation: 'AnythingElse') }
+    let(:faculty_email) { described_class.welcome_email(faculty_user) }
+
+    it 'sends the default welcome email to non-student users' do
+      faculty_email.subject.should == "Welcome to Ucrate@UC!"
+    end
+  end
+end

--- a/spec/features/welcome_page_spec.rb
+++ b/spec/features/welcome_page_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe 'sign in when user has waived welcome page, type', :feature do
+  let(:user) { FactoryBot.create(:user, waived_welcome_page: true) }
+  let(:password) { FactoryBot.attributes_for(:user).fetch(:password) }
+
+  it 'when user has waived welcome page' do
+    visit user_session_path
+    fill_in('user[email]', with: user.email)
+    fill_in('user[password]', with: user.password)
+    click_on('Log in')
+    expect(page).to have_current_path(Hyrax::Engine.routes.url_helpers.root_path)
+  end
+end

--- a/spec/helpers/show_welcome_helper_spec.rb
+++ b/spec/helpers/show_welcome_helper_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+# include Devise::TestHelpers
+
+describe ShowWelcomeHelper, type: :helper do
+  let(:current_user) { FactoryBot.create(:user) }
+
+  before { sign_in current_user }
+  context 'when the user is not a student' do
+    it 'renders the welcome page' do
+      expect(helper.show_welcome_page).to include('what-types-of-content-should-i-submit-to-scholaruc')
+    end
+  end
+
+  context 'when the user is a student' do
+    before do
+      current_user.uc_affiliation = 'student'
+      current_user.save
+    end
+    it 'renders the student welcome page' do
+      expect(helper.show_welcome_page).to include('how-can-students-use-scholaruc')
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,4 +27,29 @@ RSpec.describe User, type: :model do
       end
     end
   end
+  subject(:user) { described_class.new(email: 'test@example.com', password: 'test1234') }
+
+  context 'when a user is not a student' do
+    before do
+      user.uc_affiliation = ''
+    end
+    it "returns false for .student?" do
+      expect(user.student?).to be false
+    end
+  end
+
+  context 'when a user is a student' do
+    before do
+      user.uc_affiliation = 'student'
+    end
+    it "returns true for .student?" do
+      expect(user.student?).to be true
+    end
+  end
+
+  it "sets waived_welcome_page to true" do
+    user.save!
+    user.waive_welcome_page!
+    expect(user.waived_welcome_page).to be true
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -98,8 +98,7 @@ RSpec.configure do |config|
 
   config.include Devise::Test::IntegrationHelpers, type: :feature
   config.include Devise::Test::ControllerHelpers, type: :controller
-
-  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :helper
 
   config.before :suite do
     DatabaseCleaner.clean_with(:truncation)


### PR DESCRIPTION
Fixes #174 

Added welcome page views
Added welcome page path in routes file
Changed controller files to redirect new users to welcome page
Added user_edit_profile_event_job to update if users need to update profiles
Added functions in user.rb to check if users waived welcome page and if users are student
Added two columns in db migrate, waived welcome page and profile update not required

Added registrations controller to deliver welcome email after sign up and WelcomeMailer file.
Added welcome email veiws

Some links in welcome page and welcome mails don't have paths.