### PR TITLE
Fix flaky tests that fail unreliably

### DIFF
--- a/spec/features/uc_shibboleth_spec.rb
+++ b/spec/features/uc_shibboleth_spec.rb
@@ -70,7 +70,6 @@ describe 'UC account workflow', type: :feature do
 
   describe 'overridden devise sign-in page' do
     it 'shows a shibboleth login link if shibboleth is enabled' do
-      AUTH_CONFIG['shibboleth_enabled'] = true
       visit new_user_session_path
       if yaml['test']['shibboleth_enabled'] == true
         expect(page).to have_link('Central Login form', href: '/users/auth/shibboleth')
@@ -110,6 +109,7 @@ describe 'UC account workflow', type: :feature do
 
       it 'shows the local log in page' do
         page.should have_field('user[email]')
+        AUTH_CONFIG['shibboleth_enabled'] = true
       end
     end
   end

--- a/spec/features/welcome_mailer_spec.rb
+++ b/spec/features/welcome_mailer_spec.rb
@@ -19,6 +19,7 @@ describe WelcomeMailer do
   after do
     ActionMailer::Base.deliveries = []
     User.find_by_email(user_email).delete
+    AUTH_CONFIG['signups_enabled'] = false
   end
   it 'sends welcome email to user upon registration' do
     email.to.should eq([user_email])


### PR DESCRIPTION
Fixes #213

Present short summary (50 characters or less)

This PR aims to fix some of the flaky tests that fail when run in specific order. Introduced [here](https://github.com/uclibs/ucrate/blob/b31fb43fb113ac8ed4381f09177f8c8e09237824/spec/features/welcome_mailer_spec.rb#L11).

Description can have multiple paragraphs and you can use code examples inside:

Tests fail when run in the following order:
```ruby
rspec './spec/features/uc_shibboleth_spec.rb[1:3:1,1:4:2]' './spec/features/welcome_mailer_spec.rb[1:3:1]' --seed 42315
```

Changes proposed in this pull request:
* Revert any changes made to test configurations in the same examples where they were changed in the first place.
