### PR TITLE
[WIP] Use test adapter for active job

### DIFF
--- a/spec/features/batch_create_spec.rb
+++ b/spec/features/batch_create_spec.rb
@@ -10,13 +10,7 @@ RSpec.describe 'Batch creation of works', type: :feature do
           with_permission_template: { deposit_groups: [::Ability.registered_group_name] })
   end
 
-  before do
-    # stub out characterization and derivatives. Travis doesn't have fits installed, and it's not relevant to the test.
-    allow(CharacterizeJob).to receive(:perform_later)
-    allow(CreateDerivativesJob).to receive(:perform_later)
-
-    sign_in user
-  end
+  before { sign_in user }
 
   it "renders the batch create form" do
     visit hyrax.new_batch_upload_path
@@ -27,10 +21,13 @@ RSpec.describe 'Batch creation of works', type: :feature do
     expect(page).to have_content("Each file will be uploaded to a separate new work resulting in one work per uploaded file.")
   end
 
-  context 'when the user is a proxy', :js, :workflow do
+  context 'when the user is a proxy', :js, :workflow, :perform_enqueued do
     let(:second_user) { create(:user) }
 
     before do
+      allow(CharacterizeJob).to receive(:perform_later).and_return(true)
+      allow(CreateDerivativesJob).to receive(:perform_later).and_return(true)
+
       create(:permission_template_access,
              :deposit,
              permission_template: create(:permission_template, with_admin_set: true, with_active_workflow: true),

--- a/spec/features/create_work_admin_spec.rb
+++ b/spec/features/create_work_admin_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Creating a new Work as admin', :js, :workflow do
+RSpec.describe 'Creating a new Work as admin', :js, :workflow, perform_enqueued: [AttachFilesToWorkJob, IngestJob] do
   let(:user) { create(:admin) }
   let(:admin_set_1) do
     create(:admin_set, id: AdminSet::DEFAULT_ID,

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
     end
   end
 
-  context 'when the user is a proxy' do
+  context 'when the user is a proxy', perform_enqueued: [ContentDepositorChangeEventJob, AttachFilesToWorkJob, IngestJob] do
     let(:second_user) { create(:user) }
 
     before do

--- a/spec/jobs/user_edit_profile_event_job_spec.rb
+++ b/spec/jobs/user_edit_profile_event_job_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserEditProfileEventJob do
+  let(:user) { create(:user) }
+  let(:mock_time) { Time.zone.at(1) }
+  let(:event) { { action: "User <a href=\"/users/#{user.to_param}\">#{user.user_key}</a> has edited their profile", timestamp: '1' } }
+
+  before do
+    allow(Time).to receive(:now).at_least(:once).and_return(mock_time)
+  end
+
+  it "logs the event to the editor's dashboards" do
+    expect do
+      described_class.perform_now(user)
+    end.to change { user.events.length }.by(1)
+
+    expect(user.events.first).to eq(event)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,6 +64,8 @@ Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+ActiveJob::Base.queue_adapter = :test
+
 require 'active_fedora/cleaner'
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
@@ -144,4 +146,37 @@ RSpec.configure do |config|
 
   # Allow cookies to be set in feature tests (for UC Shibboleth testing)
   config.include ShowMeTheCookies, type: :feature
+
+  # Use this example metadata when you want to perform jobs inline during testing.
+  #
+  #   describe '#my_method`, :perform_enqueued do
+  #     ...
+  #   end
+  #
+  # If you pass an `Array` of job classes, they will be treated as the filter list.
+  #
+  #   describe '#my_method`, perform_enqueued: [MyJobClass] do
+  #     ...
+  #   end
+  #
+  # Limit to specific job classes with:
+  #
+  #   ActiveJob::Base.queue_adapter.filter = [JobClass]
+  #
+  config.before(:example, :perform_enqueued) do |example|
+    ActiveJob::Base.queue_adapter.filter =
+      example.metadata[:perform_enqueued].try(:to_a)
+
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = true
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
+  end
+
+  config.after(:example, :perform_enqueued) do
+    ActiveJob::Base.queue_adapter.filter         = nil
+    ActiveJob::Base.queue_adapter.enqueued_jobs  = []
+    ActiveJob::Base.queue_adapter.performed_jobs = []
+
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = false
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = false
+  end
 end


### PR DESCRIPTION
Fixes #155  

Present short summary (50 characters or less)

Borrowed the relevant changes from [Hyrax](https://github.com/samvera/hyrax/pull/2911). But, the average finish time to run the complete test suite came down only by about 18 secs. Considering the number of tests that we have in place for ucrate, I am assuming this to be significant. 


Changes proposed in this pull request:
* Enabling test adapter for Active job and using the same for running specs.
* Refer https://github.com/samvera/hyrax/pull/2911 for more info.