### PR TITLE
Reopened visibility file from the engine, updated default to public.

### DIFF
--- a/app/models/concerns/hydra/access_controls/visibility.rb
+++ b/app/models/concerns/hydra/access_controls/visibility.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "pathname"
+visibility_path = Pathname.new(Gem.loaded_specs['hydra-access-controls'].full_gem_path + '/app/models/concerns/hydra/access_controls/visibility.rb')
+require visibility_path
+module Hydra::AccessControls
+  module Visibility
+    def visibility
+      return AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC if id.nil?
+      if read_groups.include? AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
+        AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      elsif read_groups.include? AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED
+        AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      else
+        AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      end
+    end
+  end
+end

--- a/spec/features/batch_create_spec.rb
+++ b/spec/features/batch_create_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe 'Batch creation of works', type: :feature do
     expect(page).to have_content("Each file will be uploaded to a separate new work resulting in one work per uploaded file.")
   end
 
+  it 'defaults to public visibility' do
+    visit hyrax.new_batch_upload_path
+    expect(page).to have_checked_field('batch_upload_item_visibility_open')
+  end
+
   context 'when the user is a proxy', :js, :workflow do
     let(:second_user) { create(:user) }
 

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
       click_button 'Create work'
     end
 
+    it 'defaults to public visibility' do
+      expect(page).to have_checked_field('generic_work_visibility_open')
+    end
+
     it 'creates the work' do
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"


### PR DESCRIPTION
Refactor using the re-opening technique, instead of using whole file.

Added tests for create work and batch create works.

Comply with rubocop.

Provide explicit conversion of path to string.

Path figured out, tests working?

Add method guard, fix test for batch create spec.

Fixes #250 ;

Changed the visibility method so that it defaults to open rather than private.

``` ruby
# frozen_string_literal: true

require "pathname"
visibility_path = Pathname.new(Gem.loaded_specs['hydra-access-controls'].full_gem_path + '/app/models/concerns/hydra/access_controls/visibility.rb')
require visibility_path
module Hydra::AccessControls
  module Visibility
    def visibility
      return AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC if id.nil?
      if read_groups.include? AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
        AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
      elsif read_groups.include? AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED
        AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
      else
        AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
      end
    end
  end
end
```

Changes proposed in this pull request:
* Visibility should be open by default, instead of private.
* Added tests
