### PR TITLE
Feature/#251 visibility labels should match scholar

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -815,7 +815,7 @@ GEM
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
     slop (4.6.2)
-    solr_wrapper (1.2.0)
+    solr_wrapper (2.0.0)
       faraday
       retriable
       ruby-progressbar

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -52,7 +52,7 @@ en:
     footer:
       copyright_html: "<strong>Copyright &copy; 2017 Samvera</strong> Licensed under the Apache License, Version 2.0"
       service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
-    institution_name:       "Institution"
+    institution_name:       "University of Cicninnati"
     institution_name_full:  "The Institution Name"
     product_name:           "UCrate"
     description:            "University of Cincinnati's library collections"
@@ -78,3 +78,9 @@ en:
           export_collection: "Export collection"
     welcome:
       waive_page: "Click here to hide this welcome page from displaying when you log in"
+    visibility:
+      open: 
+        text: "Open Access"
+        note_html: Make available to all<br />(see <a href="/creators_rights" target=\"_blank\">Creator's Rights</a> for more information)
+      authenticated:
+        note_html: Restrict access to logged-in users

--- a/spec/features/batch_create_spec.rb
+++ b/spec/features/batch_create_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Batch creation of works', type: :feature do
       find('body').click
 
       choose('batch_upload_item_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       select(second_user.user_key, from: 'On behalf of')
       check('agreement')
       click_on('Save')

--- a/spec/features/create_article_spec.rb
+++ b/spec/features/create_article_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Create a Article', js: true do
       # its element
       find('body').click
       choose('article_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Create a Dataset', js: true do
       # its element
       find('body').click
       choose('dataset_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')

--- a/spec/features/create_document_spec.rb
+++ b/spec/features/create_document_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Create a Document', js: true do
       # its element
       find('body').click
       choose('document_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Create a Etd', js: true do
       # its element
       find('body').click
       choose('etd_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Create a Image', js: true do
       # its element
       find('body').click
       choose('image_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')

--- a/spec/features/create_medium_spec.rb
+++ b/spec/features/create_medium_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Create a Medium', js: true do
       # its element
       find('body').click
       choose('medium_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')

--- a/spec/features/create_student_work_spec.rb
+++ b/spec/features/create_student_work_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Create a StudentWork', js: true do
       # its element
       find('body').click
       choose('student_work_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
       # its element
       find('body').click
       choose('generic_work_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
       # These lines are for debugging, should this test fail
       # puts "Required metadata: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').requiredFields.areComplete})}"
@@ -94,7 +94,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
       # its element
       find('body').click
       choose('generic_work_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       select(second_user.user_key, from: 'On behalf of')
       sleep 1
       check('agreement')

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
       it "has collection type and visibility filters" do
         expect(page).to have_button 'Visibility'
-        expect(page).to have_link 'Public',
+        expect(page).to have_link 'Open Access',
                                   href: /visibility_ssi.+#{Regexp.escape(CGI.escape(collection3.visibility))}/
         expect(page).to have_button 'Collection Type'
         expect(page).to have_link collection_type.title,
@@ -114,7 +114,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
       it "has collection type and visibility filters" do
         expect(page).to have_button 'Visibility'
-        expect(page).to have_link 'Public',
+        expect(page).to have_link 'Open Access',
                                   href: /visibility_ssi.+#{Regexp.escape(CGI.escape(collection3.visibility))}/
         expect(page).to have_button 'Collection Type'
         expect(page).to have_link collection_type.title,
@@ -158,7 +158,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       expect(page).to have_link 'All Collection'
       click_link 'All Collections'
       expect(page).to have_button 'Visibility'
-      expect(page).to have_link 'Public',
+      expect(page).to have_link 'Open Access',
                                 href: /visibility_ssi.+#{Regexp.escape(CGI.escape(collection1.visibility))}/
       expect(page).to have_button 'Collection Type'
       expect(page).to have_link collection_type.title,
@@ -219,7 +219,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       expect(page).to have_link 'Managed Collections'
       click_link 'Managed Collections'
       expect(page).to have_button 'Visibility'
-      expect(page).to have_link 'Public',
+      expect(page).to have_link 'Open Access',
                                 href: /visibility_ssi.+#{Regexp.escape(CGI.escape(collection1.visibility))}/
       expect(page).to have_button 'Collection Type'
       expect(page).to have_link collection_type.title,

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Editing a work', type: :feature do
       expect(page).not_to have_content "Powered by Hyrax"
       click_on("No. I'll update it manually.")
       within(".panel-heading") do
-        expect(page).to have_content('Public')
+        expect(page).to have_content('Open Access')
       end
     end
   end

--- a/spec/features/embargo_spec.rb
+++ b/spec/features/embargo_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'embargo' do
       choose 'Embargo'
       fill_in 'generic_work_embargo_release_date', with: future_date
       select 'Private', from: 'Restricted to'
-      select 'Public', from: 'then open it up to'
+      select 'Open Access', from: 'then open it up to'
       click_button 'Save'
 
       # chosen embargo date is on the show page

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "display a work as its owner" do
       expect(page).to have_content '%T Magnificent splendor'
       expect(page).to have_content '%R http://localhost/files/'
       expect(page).to have_content '%~ UCrate'
-      expect(page).to have_content '%W Institution'
+      expect(page).to have_content '%W University of Cicninnati'
     end
   end
 end


### PR DESCRIPTION
Fixes #251 ;

Visibility labels in UCrate should match those in scholar.

```ruby
<nav class="navbar navbar-default navbar-static-top" role="navigation">
  <div class="container-fluid">
    <div class="row">
      <ul class="nav navbar-nav col-sm-5 col-md-6">
        <li <%= 'class=active' if current_page?(hyrax.users_path) %>>
          <%= link_to(t(:'hyrax.controls.users'), hyrax.users_path) %></li>
        <li <%= 'class=active' if current_page?(hyrax.about_path) %>>
          <%= link_to(t(:'hyrax.controls.about'), hyrax.about_path) %></li>
        <li <%= 'class=active' if current_page?(hyrax.contact_path) %>>
          <%= link_to(t(:'hyrax.controls.contact'), hyrax.contact_path) %></li>
        <li <%= 'class=active' if action_name == "help" %>>
          <%= link_to t(:'hyrax.controls.help'), hyrax.help_path %></li>
      </ul>
      <div class="searchbar-right navbar-right col-sm-7 col-md-6">
        <%= render partial: 'catalog/search_form' %>
      </div>
    </div>
  </div>
</nav>
```

``` ymal
visibility:
      open: 
        text: "Open Access"
        note_html: Make available to all<br />(see <a href="/creators_rights" target=\"_blank\">Creator's Rights</a> for more information)
      authenticated:
        note_html: Restrict access to logged-in users
```

Changes proposed in this pull request:
* Edit the Hyrax YAML file to make 
* Edit tests that require open `public` rather than `open access`
