### PR TITLE
Adds flash message to datasets page.

### DIFF
--- a/app/controllers/hyrax/datasets_controller.rb
+++ b/app/controllers/hyrax/datasets_controller.rb
@@ -18,5 +18,10 @@ module Hyrax
       permalink_message = "Permanent link to this page"
       @permalinks_presenter = PermalinksPresenter.new(main_app.common_object_path(locale: nil), permalink_message)
     end
+
+    def new
+      super
+      flash[:notice] = t(:"hyrax.dataset.help_text")
+    end
   end
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -86,3 +86,5 @@ en:
         note_html: Restrict access to logged-in users
     controls:
       users: "People"
+    dataset:
+      help_text: If you would like guidance on submitting a dataset, please read the <a href="/documenting_data" target="_blank">Documenting Data</a> help page.

--- a/spec/controllers/hyrax/datasets_controller_spec.rb
+++ b/spec/controllers/hyrax/datasets_controller_spec.rb
@@ -5,7 +5,15 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::DatasetsController do
-  it "has tests" do
-    skip "Add your tests here"
+  let(:user) { create(:user) }
+  let(:actor) { controller.send(:actor) }
+
+  before do
+    sign_in user
+  end
+
+  it "has dataset flash message" do
+    get 'new'
+    expect(flash[:notice]).to match("If you would like guidance on submitting a dataset, please read the <a href=\"/documenting_data\" target=\"_blank\">Documenting Data</a> help page.")
   end
 end


### PR DESCRIPTION
Fixes #259 ; refs #issuenumber

Adds flash message to datasets page.

This change adds the flash message from scholar in to the ucrate.  Originally it looked like scholar implemented this functionality in a concern, however I found code in a reopened controller.  It looks like the controller code was the code actually showing the flash message, so I've implemented that here.

Changes proposed in this pull request:
* Adds flash message to datasets page.