### PR TITLE
Make create work specs more reliable

### DIFF
--- a/spec/features/cloud_upload_spec.rb
+++ b/spec/features/cloud_upload_spec.rb
@@ -17,6 +17,7 @@ describe "Selecting files to import from cloud providers", js: true, type: :feat
     visit '/dashboard'
     click_link 'Works'
     click_link "Add new work"
+    expect(page).to have_content "Select type of work"
     choose "payload_concern", option: "GenericWork"
     click_button 'Create work'
   end

--- a/spec/features/create_article_spec.rb
+++ b/spec/features/create_article_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe 'Create a Article', js: true do
       click_link "Add new work"
 
       # If you generate more than one work uncomment these lines
+      expect(page).to have_content "Select type of work"
       choose "payload_concern", option: "Article"
       click_button "Create work"
 

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe 'Create a Dataset', js: true do
       click_link "Add new work"
 
       # If you generate more than one work uncomment these lines
+      expect(page).to have_content "Select type of work"
       choose "payload_concern", option: "Dataset"
       click_button "Create work"
 

--- a/spec/features/create_document_spec.rb
+++ b/spec/features/create_document_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe 'Create a Document', js: true do
       click_link "Add new work"
 
       # If you generate more than one work uncomment these lines
+      expect(page).to have_content "Select type of work"
       choose "payload_concern", option: "Document"
       click_button "Create work"
 

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe 'Create a Etd', js: true do
       click_link "Add new work"
 
       # If you generate more than one work uncomment these lines
+      expect(page).to have_content "Select type of work"
       choose "payload_concern", option: "Etd"
       click_button "Create work"
 

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe 'Create a Image', js: true do
       click_link "Add new work"
 
       # If you generate more than one work uncomment these lines
+      expect(page).to have_content "Select type of work"
       choose "payload_concern", option: "Image"
       click_button "Create work"
 

--- a/spec/features/create_medium_spec.rb
+++ b/spec/features/create_medium_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe 'Create a Medium', js: true do
       click_link "Add new work"
 
       # If you generate more than one work uncomment these lines
+      expect(page).to have_content "Select type of work"
       choose "payload_concern", option: "Medium"
       click_button "Create work"
 

--- a/spec/features/create_student_work_spec.rb
+++ b/spec/features/create_student_work_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe 'Create a StudentWork', js: true do
       click_link "Add new work"
 
       # If you generate more than one work uncomment these lines
+      expect(page).to have_content "Select type of work"
       choose "payload_concern", option: "StudentWork"
       click_button "Create work"
 

--- a/spec/features/create_work_admin_spec.rb
+++ b/spec/features/create_work_admin_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe 'Creating a new Work as admin', :js, :workflow do
       visit '/dashboard'
       click_link 'Works'
       click_link "Add new work"
+      expect(page).to have_content "Select type of work"
       choose "payload_concern", option: "GenericWork"
       click_button 'Create work'
       click_link "Relationship" # switch tab

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
       visit '/dashboard'
       click_link 'Works'
       click_link "Add new work"
+      expect(page).to have_content "Select type of work"
       choose "payload_concern", option: "GenericWork"
       click_button 'Create work'
     end

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -672,6 +672,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         click_link 'Deposit new work through this collection'
 
         # verify the collection is pre-selected
+        expect(page).to have_content "Select type of work"
         choose "payload_concern", option: "GenericWork"
         click_button 'Create work'
         click_link "Relationships" # switch tab


### PR DESCRIPTION
Adds a `expect(page).to have_content "Select type of work"` line to all feature specs that create a work.  The current specs don't wait for the new work modal to show before moving forward.  So if the modal is a little slow the test breaks.

The `expect` I added causes the test to wait for the modal's "Select type of work" title to appear.

I ran the specs with this change many times locally and on Travis.  The spec/features/create_* tests are not randomly failing anymore.

We won't need this fix after #249 is merged, but it will help in the meantime.