### PR TITLE
Feature/#261 hide admin set controls displays

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -38,3 +38,7 @@
  //    line-height: 150%;
  //    margin-top: 3.5%;
  }
+
+ div[class*="_admin_set_id"] {
+  display: none;
+ }

--- a/app/views/hyrax/base/_relationships_parent_rows.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_rows.html.erb
@@ -1,0 +1,12 @@
+<%# Render presenters which aren't specified in the 'presenter_types' %>
+<% presenter.grouped_presenters(except: presenter.presenter_types).each_pair do |model_name, items| %>
+  <%= render 'relationships_parent_row', type: model_name, items: items, presenter: presenter %>
+<% end %>
+
+<%# Render grouped presenters. Show rows if there are any items of that type %>
+<% presenter.presenter_types.each do |type| %>
+  <% presenter.grouped_presenters(filtered_by: type).each_pair do |_, items| %>
+    <%= render 'relationships_parent_row', type: type, items: items, presenter: presenter %>
+  <% end %>
+<% end %>
+

--- a/spec/features/create_work_admin_spec.rb
+++ b/spec/features/create_work_admin_spec.rb
@@ -44,11 +44,11 @@ RSpec.describe 'Creating a new Work as admin', :js, :workflow do
       choose "payload_concern", option: "GenericWork"
       click_button 'Create work'
       click_link "Relationship" # switch tab
-      expect(page).to have_content('Administrative Set')
-      expect(page).to have_content('Another Admin Set')
-      expect(page).to have_content('Default Admin Set')
-      expect(page).to have_selector('select#generic_work_admin_set_id')
-      expect(page).to have_select('generic_work_admin_set_id', selected: 'Default Admin Set')
+      expect(page).not_to have_content('Administrative Set')
+      expect(page).not_to have_content('Another Admin Set')
+      expect(page).not_to have_content('Default Admin Set')
+      expect(page).not_to have_selector('select#generic_work_admin_set_id')
+      expect(page).not_to have_select('generic_work_admin_set_id', selected: 'Default Admin Set')
     end
   end
 end

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
       end
+      click_link "Relationships"
+      expect(page).to have_css("div.generic_work_admin_set_id", visible: false)
       click_link "Descriptions" # switch tab
       expect(page).to have_field("Creator", with: user.name_for_works)
       fill_in('Title', with: 'My Test Work')

--- a/spec/features/embargo_spec.rb
+++ b/spec/features/embargo_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'embargo' do
 
       click_button 'Update Embargo'
       expect(page).to have_content(later_future_date.to_date.to_formatted_s(:standard))
-      expect(page).to have_content(my_admin_set.title.first)
+      expect(page).not_to have_content(my_admin_set.title.first)
     end
 
     it 'cannot be updated with an invalid date' do

--- a/spec/views/hyrax/base/_relationships.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_relationships.html.erb_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/base/relationships', type: :view do
+  let(:user) { create(:user, groups: 'admin') }
+  let(:ability) { Ability.new(user) }
+  let(:solr_doc) { instance_double(SolrDocument, id: '123', human_readable_type: 'Work', admin_set: nil) }
+  let(:presenter) { Hyrax::WorkShowPresenter.new(solr_doc, ability) }
+  context "with admin sets" do
+    it "renders using attribute_to_html" do
+      allow(controller).to receive(:current_user).and_return(user)
+      allow(solr_doc).to receive(:member_of_collection_ids).and_return([])
+      expect(presenter).not_to receive(:attribute_to_html).with(:admin_set, render_as: :faceted, html_dl: true)
+      render 'hyrax/base/relationships', presenter: presenter
+    end
+  end
+end


### PR DESCRIPTION
Closes #261  ; 

Hides admin set controls and displays for works.

Changes proposed in this pull request:
* Hides admin set controls and displays for works