### PR TITLE
Preserve returns in multiline descriptions.

### DIFF
--- a/app/views/hyrax/base/_work_description.erb
+++ b/app/views/hyrax/base/_work_description.erb
@@ -1,0 +1,3 @@
+<% presenter.description.each do |description| %>
+    <p class="work_description"><%= simple_format iconify_auto_link(description) %></p>
+<% end %>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,7 @@ require 'capybara/rails'
 require 'selenium-webdriver'
 require 'database_cleaner'
 require 'rspec/its'
+require 'equivalent-xml'
 
 unless ENV['SKIP_MALEFICENT']
   # See https://github.com/jeremyf/capybara-maleficent

--- a/spec/views/hyrax/base/_work_description.erb_spec.rb
+++ b/spec/views/hyrax/base/_work_description.erb_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'rails_helper'
+
+describe "render description in a partial" do
+  Presenter = Struct.new(:description)
+  it "displays note with new lines" do
+    presenter = Presenter.new(["Paragraph One\r\n\r\nParagraph Two"])
+    render partial: "hyrax/base/work_description.erb", locals: { presenter: presenter }
+    expect(rendered).to include("<p>Paragraph One</p>")
+    expect(rendered).to include("<p>Paragraph Two</p>")
+  end
+end


### PR DESCRIPTION
Fixes #267  ; 

Preserves new lines in multiline descriptions.

Changes proposed in this pull request:
* When displaying a description on the work show page, we should format new lines as paragraph delinators.
