### PR TITLE
Fixes user search bug with trailing whitespace

### DIFF
--- a/app/controllers/display_users_controller.rb
+++ b/app/controllers/display_users_controller.rb
@@ -8,7 +8,7 @@ class DisplayUsersController < Hyrax::UsersController
   end
 
   def search(query)
-    clause = query.blank? ? nil : "%" + query.downcase + "%"
+    clause = query.blank? ? nil : "%" + query.downcase.strip + "%"
     base = ::User.where(*base_query)
     if clause.present?
       base = base.where("#{Devise.authentication_keys.first} like lower(?)
@@ -16,8 +16,7 @@ class DisplayUsersController < Hyrax::UsersController
                            OR first_name like lower(?)
                            OR last_name like lower(?)", clause, clause, clause, clause)
     end
-    base.where("#{Devise.authentication_keys.first} not in (?)",
-               [::User.batch_user_key, ::User.audit_user_key])
+    base.where("#{Devise.authentication_keys.first} not in (?)", [::User.batch_user_key, ::User.audit_user_key])
         .where(guest: false)
         .references(:trophies)
         .order(sort_value)

--- a/spec/controllers/display_users_controller_spec.rb
+++ b/spec/controllers/display_users_controller_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe DisplayUsersController, type: :controller do
+  let!(:user) { FactoryBot.create(:user, first_name: "Robert") }
+
+  context 'search for a user' do
+    it 'works when you add trailing whitespace' do
+      users = controller.search("Robert ")
+      expect(users.count).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
Fixes #277  ;

Previously, searching with trailing whitespace broke search.  Now, trailing and leading whitespace is stripped before being sent to the search method.

I wrote a controller test for this one, but I think it'll need some extra 

Changes proposed in this pull request:
* Strip trailing and leading whitespace in search string. 
