### PR TITLE
Customize link and button colors

### DIFF
--- a/config/initializers/appearance.rb
+++ b/config/initializers/appearance.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+if ActiveRecord::Base.connection.table_exists? :content_blocks
+  appearance = Hyrax::Forms::Admin::Appearance.new(
+    header_background_color: '#222',
+    header_text_color: '#ffffff',
+    link_color: '#e00122',
+    footer_link_color: '#ffffff',
+    primary_button_background_color: '#e00122'
+  )
+  appearance.update!
+end

--- a/spec/features/appearance.rb
+++ b/spec/features/appearance.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe "Default UI colors", type: :feature do
+  let(:user) { create(:admin) }
+
+  before do
+    admin = Role.find_or_create_by(name: "admin")
+    admin.users << user
+    admin.save
+    require_relative '../../config/initializers/appearance.rb'
+  end
+
+  it "are set" do # rubocop:disable RSpec/ExampleLength
+    sign_in user
+    visit hyrax.admin_appearance_path
+    expect(page).to have_field(id: 'admin_appearance_header_background_color', with: '#222')
+    expect(page).to have_field(id: 'admin_appearance_header_text_color', with: '#ffffff')
+    expect(page).to have_field(id: 'admin_appearance_link_color', with: '#e00122')
+    expect(page).to have_field(id: 'admin_appearance_footer_link_color', with: '#ffffff')
+    expect(page).to have_field(id: 'admin_appearance_primary_button_background_color', with: '#e00122')
+  end
+end


### PR DESCRIPTION
Fixes #274 

Hyrax 2.x > has admin appearance form to set colors in the app; such as button and link colors. To set these colors to UC red, etc, add an initializer to update the appearance form object at startup.

Changes proposed in this pull request:
* Add `appearance.rb` initializer
* Add feature test to check that the colors have persisted in the form
