### PR TITLE
Feature/#282 Ports over Adobe Acrobat download link from scholar

### DIFF
--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,0 +1,47 @@
+<% provide :page_title, @presenter.page_title %>
+
+<%= render 'shared/citations' %>
+
+<div class="row work-type">
+  <div class="col-xs-12">
+    <%= render 'work_type', presenter: @presenter %>
+  </div>
+  <div class="col-xs-12">&nbsp;</div>
+  <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <%= render 'work_title', presenter: @presenter %>
+      </div>
+      <div class="panel-body">
+        <div class="row">
+          <%= render 'workflow_actions_widget', presenter: @presenter %>
+          <% if @presenter.universal_viewer? %>
+            <div class="col-sm-12">
+              <%= render 'representative_media', presenter: @presenter, viewer: true %>
+            </div>
+          <% end %>
+          <div class="col-sm-3 text-center">
+            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.universal_viewer? %>
+            <% if !@presenter.representative_presenter.nil? && @presenter.representative_presenter.mime_type == "application/pdf" %>
+              <%= render 'hyrax/file_sets/show_pdf_helper' %>
+            <% end %>
+            <%= render 'citations', presenter: @presenter %>
+            <%= render 'social_media' %>
+          </div>
+          <div class="col-sm-9">
+            <%= render 'work_description', presenter: @presenter %>
+            <%= render 'metadata', presenter: @presenter %>
+          </div>
+          <div class="col-sm-12">
+            <%= render 'relationships', presenter: @presenter %>
+            <%= render 'items', presenter: @presenter %>
+            <%# TODO: we may consider adding these partials in the future %>
+            <%# = render 'sharing_with', presenter: @presenter %>
+            <%# = render 'user_activity', presenter: @presenter %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/app/views/hyrax/file_sets/_show_pdf_helper.html.erb
+++ b/app/views/hyrax/file_sets/_show_pdf_helper.html.erb
@@ -1,0 +1,4 @@
+<%= link_to t('hyrax.file_set.show.adobe_reader_link'),
+'https://get.adobe.com/reader/otherversions/',
+        target: :_blank,
+        class: "btn btn-link.add"%>

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -1,0 +1,21 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-xs-12 col-sm-4">
+      <%= media_display @presenter %>
+      <% if @presenter.pdf? %>
+        <%= render 'show_pdf_helper' %>
+      <% end %>
+      <%= render 'show_actions', presenter: @presenter %>
+      <%= render 'single_use_links', presenter: @presenter if @presenter.editor? %>
+    </div>
+    <div itemscope itemtype="<%= @presenter.itemtype %>" class="col-xs-12 col-sm-8">
+      <header>
+        <%= render 'file_set_title', presenter: @presenter %>
+      </header>
+
+      <%# TODO: render 'show_descriptions' See https://github.com/samvera/hyrax/issues/1481 %>
+      <%= render 'show_details' %>
+      <%= render 'hyrax/users/activity_log', events: @presenter.events %>
+    </div><!-- /columns second -->
+  </div> <!-- /.row -->
+</div><!-- /.container-fluid -->

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -88,3 +88,6 @@ en:
       users: "People"
     dataset:
       help_text: If you would like guidance on submitting a dataset, please read the <a href="/documenting_data" target="_blank">Documenting Data</a> help page.
+    file_set:
+      show:
+        adobe_reader_link: 'Download Adobe Acrobat Reader'

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'spec_helper'
+
+RSpec.describe 'hyrax/base/show.html.erb', type: :view do
+  let(:work_solr_document) do
+    SolrDocument.new(id: '999',
+                     title_tesim: ['My Title'],
+                     creator_tesim: ['Doe, John', 'Doe, Jane'],
+                     date_modified_dtsi: '2011-04-01',
+                     has_model_ssim: ['GenericWork'],
+                     depositor_tesim: depositor.user_key,
+                     description_tesim: ['Lorem ipsum lorem ipsum.'],
+                     keyword_tesim: ['bacon', 'sausage', 'eggs'],
+                     rights_statement_tesim: ['http://example.org/rs/1'],
+                     date_created_tesim: ['1984-01-02'])
+  end
+
+  let(:file_set_solr_document) do
+    SolrDocument.new(id: '123',
+                     title_tesim: ['My FileSet'],
+                     depositor_tesim: depositor.user_key)
+  end
+
+  let(:ability) { double }
+
+  let(:presenter) do
+    Hyrax::WorkShowPresenter.new(work_solr_document, ability, request)
+  end
+
+  let(:workflow_presenter) do
+    instance_double('workflow_presenter', badge: 'Foobar')
+  end
+
+  let(:representative_presenter) do
+    Hyrax::FileSetPresenter.new(file_set_solr_document, ability)
+  end
+
+  let(:page) { Capybara::Node::Simple.new(rendered) }
+
+  let(:request) { instance_double('request', host: 'test.host') }
+
+  let(:depositor) do
+    stub_model(User,
+               user_key: 'bob',
+               twitter_handle: 'bot4lib')
+  end
+
+  let(:search_state) { instance_double('SearchState', params_for_search: {}) }
+
+  before do
+    allow(presenter).to receive(:workflow).and_return(workflow_presenter)
+    allow(presenter).to receive(:representative_presenter).and_return(representative_presenter)
+    allow(presenter).to receive(:representative_id).and_return('123')
+    allow(presenter).to receive(:tweeter).and_return("@#{depositor.twitter_handle}")
+    allow(presenter).to receive(:human_readable_type).and_return("Work")
+    allow(controller).to receive(:current_user).and_return(depositor)
+    allow(User).to receive(:find_by_user_key).and_return(depositor.user_key)
+    allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+    allow(view).to receive(:signed_in?)
+    allow(view).to receive(:on_the_dashboard?).and_return(false)
+    stub_template 'hyrax/base/_show_actions.html.erb' => ''
+    stub_template 'hyrax/base/_metadata.html.erb' => ''
+    stub_template 'hyrax/base/_relationships.html.erb' => ''
+    stub_template 'hyrax/base/_social_media.html.erb' => ''
+    stub_template 'hyrax/base/_citations.html.erb' => ''
+    stub_template 'hyrax/base/_items.html.erb' => ''
+    stub_template 'hyrax/base/_workflow_actions_widget.html.erb' => ''
+    stub_template '_masthead.html.erb' => ''
+    assign(:presenter, presenter)
+    allow(presenter.representative_presenter).to receive(:mime_type).and_return('application/pdf')
+    allow(view).to receive(:search_state).and_return(search_state)
+    render template: 'hyrax/base/show.html.erb', layout: 'layouts/hyrax/1_column'
+  end
+
+  it "displays download link for Adobe Acrobat" do
+    expect(page).to have_text("Download Adobe Acrobat Reader")
+  end
+end

--- a/spec/views/hyrax/file_sets/show.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/show.html.erb_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'spec_helper'
+
+RSpec.describe 'hyrax/file_sets/show.html.erb', type: :view do
+  let(:user) { instance_double(user_key: 'sarah', twitter_handle: 'test') }
+  let(:ability) { double }
+  let(:doc) do
+    {
+      "has_model_ssim" => ["FileSet"],
+      :id => "123",
+      "title_tesim" => ["My Title"]
+    }
+  end
+  let(:solr_doc) { SolrDocument.new(doc) }
+  let(:presenter) { Hyrax::FileSetPresenter.new(solr_doc, ability) }
+  let(:mock_metadata) do
+    {
+      format: ["Tape"],
+      long_term: ["x" * 255],
+      multi_term: ["1", "2", "3", "4", "5", "6", "7", "8"],
+      string_term: 'oops, I used a string instead of an array',
+      logged_fixity_status: "Fixity checks have not yet been run on this file"
+    }
+  end
+
+  let(:page) { Capybara::Node::Simple.new(rendered) }
+
+  before do
+    view.lookup_context.prefixes.push 'hyrax/base'
+    allow(view).to receive(:can?).with(:edit, SolrDocument).and_return(false)
+    allow(ability).to receive(:can?).with(:edit, SolrDocument).and_return(false)
+    allow(presenter).to receive(:fixity_status).and_return(mock_metadata)
+    allow(presenter).to receive(:mime_type).and_return('application/pdf')
+    assign(:presenter, presenter)
+    assign(:document, solr_doc)
+    assign(:fixity_status, "none")
+    render template: 'hyrax/file_sets/_show_pdf_helper'
+    render template: 'hyrax/file_sets/show.html.erb'
+  end
+
+  it 'shows acrobat download link' do
+    expect(rendered).to have_content "Download Adobe Acrobat Reader"
+  end
+end


### PR DESCRIPTION
Fixes #282 

Present short summary (50 characters or less)

When we direct someone to download a pdf, they should also see a link to download Adobe Acrobat.

Changes proposed in this pull request:
* Add Adobe Acrobat link from scholar.
