### PR TITLE
Add collection branding and avatar uploads to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ coverage/*
 
 # Application files to ingore
 fits.log
+
+# Ignore uploaded avatars and banners
+public/branding/*
+public/system/avatars/*


### PR DESCRIPTION
The application creates files in `public/` when avatars and collection banners are uploaded:

```
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#       public/branding/d217qp48j/banner/download.jpeg
#       public/system/avatars/14/medium/1209_cincinnati_bearcats-misc-2006.png
#       public/system/avatars/14/original/1209_cincinnati_bearcats-misc-2006.png
#       public/system/avatars/14/thumb/1209_cincinnati_bearcats-misc-2006.png
#       public/system/avatars/2/medium/DIGCAM_4808-copy.jpg
#       public/system/avatars/2/original/DIGCAM_4808-copy.jpg
#       public/system/avatars/2/thumb/DIGCAM_4808-copy.jpg
```

Adding them to .gitignore so they don't show as untracked files.