### PR TITLE
[WIP] Configures facets to display the same as in Scholar

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,6 +71,7 @@ RSpec/ExampleLength:
     - 'spec/features/browse_dashboard_works_spec.rb'
     - 'spec/features/browse_catalog_spec.rb'
     - 'spec/features/catalog_search_spec.rb'
+    - 'spec/features/catalog_facet_spec.rb'
     - 'spec/features/collection_export_spec.rb'
     - 'spec/features/collection_multi_membership_spec.rb'
     - 'spec/features/collection_spec.rb'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -41,19 +41,15 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
-    config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type", limit: 5
-    config.add_facet_field solr_name("resource_type", :facetable), label: "Resource Type", limit: 5
+    config.add_facet_field solr_name("human_readable_type", :facetable), limit: 5
     config.add_facet_field solr_name("creator", :facetable), limit: 5
-    config.add_facet_field solr_name("contributor", :facetable), label: "Contributor", limit: 5
-    config.add_facet_field solr_name("keyword", :facetable), limit: 5
+    config.add_facet_field solr_name("contributor", :facetable), limit: 5
     config.add_facet_field solr_name("subject", :facetable), limit: 5
-    config.add_facet_field solr_name("college", :facetable), label: "College", limit: 5
-    config.add_facet_field solr_name("department", :facetable), label: "Program or Dept.", limit: 5
+    config.add_facet_field solr_name("college", :facetable), limit: 5
+    config.add_facet_field solr_name("department", :facetable), limit: 5
     config.add_facet_field solr_name("language", :facetable), limit: 5
-    config.add_facet_field solr_name("geo_subject", :facetable), label: "Geographic Subject", limit: 5
     config.add_facet_field solr_name("publisher", :facetable), limit: 5
-    config.add_facet_field solr_name("file_format", :facetable), limit: 5
-    config.add_facet_field solr_name('member_of_collection_ids', :symbol), limit: 5, label: 'Collections', helper_method: :collection_title_by_id
+    config.add_facet_field solr_name('member_of_collection_ids', :symbol), limit: 5, helper_method: :collection_title_by_id
 
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -3,14 +3,16 @@ en:
     search:
       fields:
         facet:
+          human_readable_type_sim: Type of Work
           based_near_label_sim: Location
-          creator_sim: Creator
+          creator_sim: Creator/Author
           file_format_sim: Format
           generic_type_sim: Type
           keyword_sim: Keyword
           language_sim: Language
           publisher_sim: Publisher
           subject_sim: Subject
+          member_of_collection_ids_ssim: Collection
         index:
           based_near_tesim: Location
           contributor_tesim: Contributor

--- a/spec/features/catalog_facet_spec.rb
+++ b/spec/features/catalog_facet_spec.rb
@@ -28,20 +28,23 @@ RSpec.describe 'catalog searching', js: true, type: :feature do
         fill_in('search-field-header', with: 'shared_keyword')
         click_button('Go')
       end
-
-      expect(page).to have_selector('.facet-field-heading', text: 'Type of Work')
-      expect(page).to have_selector('.facet-field-heading', text: 'Creator/Author')
-      expect(page).to have_selector('.facet-field-heading', text: 'Subject')
-      expect(page).to have_selector('.facet-field-heading', text: 'College')
-      expect(page).to have_selector('.facet-field-heading', text: 'Language')
-      expect(page).to have_selector('.facet-field-heading', text: 'Publisher')
-
-      expect(page).to have_selector('.facet-field-heading', count: 6)
-
       expect(page).to have_content('Search Results')
       expect(page).to have_content(jills_work.title.first)
       expect(page).to have_content(jacks_work.title.first)
       expect(page).to have_content(collection.title.first)
+    end
+
+    it 'has the right facets' do
+      expect(page).to have_selector('.facet-field-heading', text: 'Type of Work')
+      expect(page).to have_selector('.facet-field-heading', text: 'Language')
+      expect(page).to have_selector('.facet-field-heading', text: 'Publisher')
+      expect(page).to have_selector('.facet-field-heading', text: 'College')
+      expect(page).to have_selector('.facet-field-heading', text: 'Creator/Author')
+      expect(page).to have_selector('.facet-field-heading', text: 'Subject')
+    end
+
+    it 'has the right number of facets' do
+      expect(page).to have_selector('.facet-field-heading', count: 6)
     end
   end
 

--- a/spec/features/catalog_facet_spec.rb
+++ b/spec/features/catalog_facet_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'catalog searching', js: true, type: :feature do
+  let(:user) { create(:user) }
+  let!(:collection_type) { create(:collection_type, id: 1) }
+
+  before do
+    allow(User).to receive(:find_by_user_key).and_return(stub_model(User, twitter_handle: 'bob'))
+    sign_in user
+    visit '/catalog'
+  end
+
+  context 'with works and collections' do
+    let!(:jills_work) do
+      create(:public_work, title: ["Jill's Research"], keyword: ['jills_keyword', 'shared_keyword'], creator: ["Jill Doe"], subject: ["jills_subject"], college: "CEAS", language: ["English"], publisher: ["UC Libraries"])
+    end
+
+    let!(:jacks_work) do
+      create(:public_work, title: ["Jack's Research"], keyword: ['jacks_keyword', 'shared_keyword'])
+    end
+
+    let!(:collection) { create(:public_collection, collection_type_gid: collection_type.gid, keyword: ['collection_keyword', 'shared_keyword']) }
+
+    it 'performing a search' do
+      within('#search-form-header') do
+        fill_in('search-field-header', with: 'shared_keyword')
+        click_button('Go')
+      end
+
+      expect(page).to have_selector('.facet-field-heading', text: 'Type of Work')
+      expect(page).to have_selector('.facet-field-heading', text: 'Creator/Author')
+      expect(page).to have_selector('.facet-field-heading', text: 'Subject')
+      expect(page).to have_selector('.facet-field-heading', text: 'College')
+      expect(page).to have_selector('.facet-field-heading', text: 'Language')
+      expect(page).to have_selector('.facet-field-heading', text: 'Publisher')
+
+      expect(page).to have_selector('.facet-field-heading', count: 6)
+
+      expect(page).to have_content('Search Results')
+      expect(page).to have_content(jills_work.title.first)
+      expect(page).to have_content(jacks_work.title.first)
+      expect(page).to have_content(collection.title.first)
+    end
+  end
+
+  context 'with public works and private collections', clean_repo: true do
+    let!(:collection) { create(:private_collection) }
+
+    let!(:jills_work) do
+      create(:public_work, title: ["Jill's Research"], keyword: ['jills_keyword'], member_of_collections: [collection])
+    end
+
+    it "hides collection facet values the user doesn't have access to view when performing a search" do
+      within('#search-form-header') do
+        fill_in('search-field-header', with: 'jills_keyword')
+        click_button('Go')
+      end
+
+      expect(page).to have_content('Search Results')
+      expect(page).to have_content(jills_work.title.first)
+      expect(page).not_to have_content(collection.title.first)
+      expect(page).not_to have_css('.blacklight-member_of_collection_ids_ssim')
+    end
+
+    context 'as an admin' do
+      let(:admin_user) { create :admin }
+
+      before do
+        admin = Role.create(name: "admin")
+        admin.users << admin_user
+        admin.save
+        sign_in admin_user
+        visit '/catalog'
+      end
+
+      it "shows collection facet values the user has access to view when performing a search" do
+        within('#search-form-header') do
+          fill_in('search-field-header', with: 'jills_keyword')
+          click_button('Go')
+        end
+
+        expect(page).to have_content('Search Results')
+        expect(page).to have_content(jills_work.title.first)
+        find('.blacklight-member_of_collection_ids_ssim').click
+        expect(page).to have_content(collection.title.first)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #245 ;

Present short summary (50 characters or less)
Configures facets to display the same as in Scholar

Tests explicitly expect the facets we want on the page, they also expect exactly 6 facets, instead of explicitly expecting a page not to have facets.  This gets around a scenario where the facet name we expect not to be there is present, but not the same display name due to translation or something in that vein.

Changes proposed in this pull request:
* Configures facets to display the same as in Scholar
