### PR TITLE
Add rspec-retry gem and fix batch_edit_spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ group :test do
   gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'rspec-activemodel-mocks'
+  gem 'rspec-retry'
   gem 'selenium-webdriver', '3.12.0'
   gem 'shoulda-matchers', '~> 3.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -756,6 +756,8 @@ GEM
       rspec-expectations (~> 3.7.0)
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
+    rspec-retry (0.6.1)
+      rspec-core (> 3.3)
     rspec-support (3.7.1)
     rubocop (0.52.1)
       parallel (~> 1.10)
@@ -945,6 +947,7 @@ DEPENDENCIES
   rspec-activemodel-mocks
   rspec-its
   rspec-rails
+  rspec-retry
   sass-rails (~> 5.0)
   selenium-webdriver (= 3.12.0)
   shoulda-matchers (~> 3.1)

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
       end
     end
 
-    it 'updates permissions and roles' do
+    it 'updates permissions and roles', retry: 3, retry_wait: 10 do
       click_on 'batch-edit'
       find('#edit_permissions_link').click
       expect(page).to have_content('Batch Edit Descriptions')


### PR DESCRIPTION
Partial fix for #310 

`spec/features/batch_edit_spec.rb:85` has been failing pretty frequently.  Samvera folks added a `wait: 5` to the test, but it doesn't seem to be enough.  Sometimes the batch takes a **long** time to save and the test gives up.  Increasing the wait to 1 minute helps some, but we don't want to always wait that long.

So I added the `rspec-retry` gem that lets us configure certain test to automatically run again and give them another chance to pass.  I've configured `spec/features/batch_edit_spec.rb:85` to try running 3 times before giving up.  After running it locally and on Travis many times, that spec has always passed.  So this should get rid of false failures for that test.