### PR TITLE
Update spec for deleting non-empty collection types

### DIFF
--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -380,18 +380,10 @@ RSpec.describe 'collection_type', type: :feature, clean_repo: true do
 
         within('div#deleteDenyModal') do
           expect(page).to have_content(deny_delete_modal_text)
-
-          sleep 5
-
-          find(:xpath, "/html/body/div[2]/div[2]/div[2]/div[3]/div/div/div[2]/a", text: 'View collections of this type').click
-          find(:xpath, "//tr[td[contains(.,'#{not_empty_collection_type.title}')]]/td/button", text: 'Delete').click
+          click_link('View collections of this type')
         end
 
         # forwards to Dashboard -> Collections -> All Collections
-        # needs a sleep to finalize delete
-
-        sleep 5
-
         within('li.active') do
           expect(page).to have_link('All Collections')
         end


### PR DESCRIPTION
Partial fix for #310 

The test https://github.com/uclibs/ucrate/blob/develop/spec/features/collection_type_spec.rb#L376-L408 was failing very frequently.  I determined that it always failed when it ran after https://github.com/uclibs/ucrate/blob/develop/spec/features/collection_multi_membership_spec.rb#L99-L113

It turns out the test had some problems and was only passing sometimes for the wrong reasons.  The test incorrectly tried twice to delete a collection type.  That problem had since been fixed in the Hyrax version of `collection_type_spec.rb`.  So I updated our `collection_type_spec.rb` to match https://github.com/samvera/hyrax/blob/v2.1.0/spec/features/collection_type_spec.rb#L366-L390

You can replicate the failure on the `develop` branch by running 
`bundle exec rspec ./spec/features/collection_multi_membership_spec.rb[1:2:2:1:1] ./spec/features/collection_type_spec.rb[1:4:2:1] --seed 17037`

If you then switch to this branch and run the same two tests again, you shouldn't get any failures.