### PR TITLE
Sets select user profile fields to readonly.

### DIFF
--- a/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
@@ -51,7 +51,7 @@
       <%= t('hyrax.user_profile.ucdepartment') %>
     <% end %>
     <div class="col-xs-8">
-       <%= f.text_field :ucdepartment, class: "form-control" %>
+       <%= f.text_field :ucdepartment, class: "form-control", readonly: true %>
     </div>
   </div>
 
@@ -60,9 +60,16 @@
       <%= t('hyrax.user_profile.uc_affiliation') %>
     <% end %>
     <div class="col-xs-8">
-       <%= f.text_field :uc_affiliation, class: "form-control" %>
+       <%= f.text_field :uc_affiliation, class: "form-control", readonly: true %>
     </div>
   </div>
+ 
+   <div class="form-group">
+      <%= f.label :email, 'Email', class: 'col-xs-4 control-label' %>
+      <div class="col-xs-8">
+         <%= f.text_field :email, class: "form-control", readonly: true %>
+      </div>
+    </div><!-- .form-group -->
 
   <div class="form-group">
     <%= f.label :alternate_email, class: 'col-xs-4 control-label' do %>

--- a/spec/views/hyrax/dashboard/profiles/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/profiles/edit.html.erb_spec.rb
@@ -25,8 +25,16 @@ RSpec.describe 'hyrax/dashboard/profiles/edit.html.erb', type: :view do
     expect(rendered).to match(/UC affiliation/)
   end
 
+  it "shows select fields as readonly" do
+    render
+    expect(rendered).to have_selector('input[id="user_ucdepartment"][readonly="readonly"]')
+    expect(rendered).to have_selector('input[id="user_uc_affiliation"][readonly="readonly"]')
+    expect(rendered).to have_selector('input[id="user_email"][readonly="readonly"]')
+  end
+
   it "shows the user's contact fields" do
     render
+    expect(rendered).to match(/Email/)
     expect(rendered).to match(/Alternate email/)
     expect(rendered).to match(/Campus phone number/)
     expect(rendered).to match(/Alternate phone number/)


### PR DESCRIPTION
Fixes #301 

Present short summary (50 characters or less)

Includes the email field.
Sets email, department, and affiliation to readonly in the edit view.
