### PR TITLE
Remove hyrax orcid form field

### DIFF
--- a/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
@@ -114,15 +114,6 @@
   <% end %>
 
   <div class="form-group">
-    <%= f.label :orcid, class: 'col-xs-4 control-label' do %>
-      <%= orcid_label %>
-    <% end %>
-    <div class="col-xs-8">
-       <%= f.text_field :orcid, class: "form-control" %>
-    </div>
-  </div><!-- .form-group -->
-
-  <div class="form-group">
     <%= f.label :twitter_handle, '<i class="fa fa-twitter"></i> Twitter Handle'.html_safe, class: 'col-xs-4 control-label' %>
     <div class="col-xs-8">
        <%= f.text_field :twitter_handle, class: "form-control" %>

--- a/spec/views/hyrax/dashboard/profiles/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/profiles/edit.html.erb_spec.rb
@@ -37,4 +37,9 @@ RSpec.describe 'hyrax/dashboard/profiles/edit.html.erb', type: :view do
     expect(rendered).to match(/Personal webpage/)
     expect(rendered).to match(/Blog/)
   end
+
+  it "does not show hyrax orcid field" do
+    render
+    expect(rendered).not_to match(/ORCID Profile/)
+  end
 end


### PR DESCRIPTION
Fixes #302 

Hyrax ships with a form field for the user to enter their Orcid ID but we rely on the Orcid gem for enhanced features around ORCID. We want to hide the form field and rely solely on the widget from the gem.

Changes proposed in this pull request:
* Remove form field from the edit view
* Add a test to the view spec
