### PR TITLE
Fix flaky catalog search spec

### DIFF
--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'catalog searching', type: :feature do
   let(:user) { create(:user) }
   let!(:collection_type) { create(:collection_type, id: 1) }
+  let!(:collection_type_2) { create(:collection_type, id: 2) }
 
   before do
     allow(User).to receive(:find_by_user_key).and_return(stub_model(User, twitter_handle: 'bob'))


### PR DESCRIPTION
Partial fix for #310

Depending on the random order tests run in, the test `spec/features/catalog_search_spec.rb:26` expects a collection type with id = 2 to exist.  Without this collection type, the test sometimes fails with

```
 1) catalog searching with works and collections performing a search
     Failure/Error: @collection_type ||= Hyrax::CollectionType.find_by_gid!(collection_type_gid)
     
     ActionView::Template::Error:
       Couldn't find Hyrax::CollectionType matching GID 'gid://ucrate-hyrax2/hyrax-collectiontype/2'
```