### PR TITLE
Fix expiration service spec

### DIFF
--- a/spec/services/expiration_service_spec.rb
+++ b/spec/services/expiration_service_spec.rb
@@ -31,7 +31,7 @@ describe ExpirationService do
     end
   end
 
-  context 'with an expired embargo in the past' do
+  context 'with an expired embargo in the past', :clean_repo do
     let(:embargo_date_in_past) { (Time.zone.today + 1.day) }
     let(:embargoed_work) { create(:private_generic_work, :with_public_embargo, title: ['Embargoed Work'], embargo_release_date: embargo_date_in_past) }
 


### PR DESCRIPTION
Partial fix for #310 

The test `spec/services/expiration_service_spec.rb:38` frequently fails when we run the test suite.  The failure occurs when `spec/features/embargo_spec.rb:15` runs **before** the expiration_service_spec.  The embargo_spec leaves behind an embargoed work that causes expiration_service_spec to find the wrong work.

The failure can be reproduced on `develop` using this
```
bundle exec rspec spec/features/embargo_spec.rb[1:1:1] spec/services/expiration_service_spec.rb[1:3:1] --seed 63688
```

I fixed it by adding a `:clean_repo` to the expiration_service_spec so the test starts with no existing works in Fedora.  Running the command above with the fix in place allows all tests to pass.