### PR TITLE
Removes degree and advisor from GenericWork and Image.

### DIFF
--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -19,14 +19,6 @@ class GenericWork < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
-  property :degree, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#degree') do |index|
-    index.as :stored_searchable
-  end
-
-  property :advisor, predicate: ::RDF::URI.new('http://purl.org/dc/terms/contributor#advisor') do |index|
-    index.as :stored_searchable
-  end
-
   property :genre, predicate: ::RDF::URI.new('http://purl.org/dc/terms/type#genre') do |index|
     index.as :stored_searchable, :facetable
   end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -19,14 +19,6 @@ class Image < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
-  property :degree, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#degree') do |index|
-    index.as :stored_searchable
-  end
-
-  property :advisor, predicate: ::RDF::URI.new('http://purl.org/dc/terms/contributor#advisor') do |index|
-    index.as :stored_searchable
-  end
-
   property :genre, predicate: ::RDF::URI.new('http://purl.org/dc/terms/type#genre'), multiple: false do |index|
     index.as :stored_searchable, :facetable
   end


### PR DESCRIPTION
Fixes #343 
Present short summary (50 characters or less)

These fields are not needed on these two work types.
