### PR TITLE
Adds geo_subject to work type presenters.

### DIFF
--- a/app/presenters/hyrax/dataset_presenter.rb
+++ b/app/presenters/hyrax/dataset_presenter.rb
@@ -4,6 +4,6 @@
 #  `rails generate hyrax:work Dataset`
 module Hyrax
   class DatasetPresenter < Hyrax::WorkShowPresenter
-    delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, to: :solr_document
+    delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, :geo_subject, to: :solr_document
   end
 end

--- a/app/presenters/hyrax/document_presenter.rb
+++ b/app/presenters/hyrax/document_presenter.rb
@@ -4,6 +4,6 @@
 #  `rails generate hyrax:work Document`
 module Hyrax
   class DocumentPresenter < Hyrax::WorkShowPresenter
-    delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, to: :solr_document
+    delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, :geo_subject, to: :solr_document
   end
 end

--- a/app/presenters/hyrax/etd_presenter.rb
+++ b/app/presenters/hyrax/etd_presenter.rb
@@ -4,6 +4,6 @@
 #  `rails generate hyrax:work Etd`
 module Hyrax
   class EtdPresenter < Hyrax::WorkShowPresenter
-    delegate :college, :department, :genre, :alternate_title, :time_period, :required_software, :note, :advisor, :geo_subject, to: :solr_document
+    delegate :college, :department, :genre, :alternate_title, :time_period, :required_software, :note, :advisor, :degree, :geo_subject, :etd_publisher, to: :solr_document
   end
 end

--- a/app/presenters/hyrax/generic_work_presenter.rb
+++ b/app/presenters/hyrax/generic_work_presenter.rb
@@ -4,6 +4,6 @@
 #  `rails generate hyrax:work GenericWork`
 module Hyrax
   class GenericWorkPresenter < Hyrax::WorkShowPresenter
-    delegate :college, :department, :genre, :alternate_title, :time_period, :required_software, :note, to: :solr_document
+    delegate :college, :department, :alternate_title, :time_period, :required_software, :note, :geo_subject, to: :solr_document
   end
 end

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -4,6 +4,6 @@
 #  `rails generate hyrax:work Image`
 module Hyrax
   class ImagePresenter < Hyrax::WorkShowPresenter
-    delegate :college, :department, :alternate_title, :date_photographed, :genre, :time_period, :required_software, :note, :cultural_context, to: :solr_document
+    delegate :college, :department, :alternate_title, :date_photographed, :genre, :time_period, :required_software, :note, :cultural_context, :geo_subject, to: :solr_document
   end
 end

--- a/app/presenters/hyrax/medium_presenter.rb
+++ b/app/presenters/hyrax/medium_presenter.rb
@@ -4,6 +4,6 @@
 #  `rails generate hyrax:work Medium`
 module Hyrax
   class MediumPresenter < Hyrax::WorkShowPresenter
-    delegate :college, :department, :genre, :alternate_title, :time_period, :required_software, :note, to: :solr_document
+    delegate :college, :department, :genre, :alternate_title, :time_period, :required_software, :note, :geo_subject, to: :solr_document
   end
 end

--- a/app/presenters/hyrax/student_work_presenter.rb
+++ b/app/presenters/hyrax/student_work_presenter.rb
@@ -4,6 +4,6 @@
 #  `rails generate hyrax:work StudentWork`
 module Hyrax
   class StudentWorkPresenter < Hyrax::WorkShowPresenter
-    delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, :college, :department, :degree, :advisor, :geo_subject, to: :solr_document
+    delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, :degree, :advisor, :geo_subject, to: :solr_document
   end
 end

--- a/spec/presenters/hyrax/dataset_presenter_spec.rb
+++ b/spec/presenters/hyrax/dataset_presenter_spec.rb
@@ -17,4 +17,5 @@ RSpec.describe Hyrax::DatasetPresenter do
   it { is_expected.to delegate_method(:genre).to(:solr_document) }
   it { is_expected.to delegate_method(:college).to(:solr_document) }
   it { is_expected.to delegate_method(:department).to(:solr_document) }
+  it { is_expected.to delegate_method(:geo_subject).to(:solr_document) }
 end

--- a/spec/presenters/hyrax/document_presenter_spec.rb
+++ b/spec/presenters/hyrax/document_presenter_spec.rb
@@ -17,4 +17,5 @@ RSpec.describe Hyrax::DocumentPresenter do
   it { is_expected.to delegate_method(:time_period).to(:solr_document) }
   it { is_expected.to delegate_method(:required_software).to(:solr_document) }
   it { is_expected.to delegate_method(:note).to(:solr_document) }
+  it { is_expected.to delegate_method(:geo_subject).to(:solr_document) }
 end

--- a/spec/presenters/hyrax/etd_presenter_spec.rb
+++ b/spec/presenters/hyrax/etd_presenter_spec.rb
@@ -17,4 +17,6 @@ RSpec.describe Hyrax::EtdPresenter do
   it { is_expected.to delegate_method(:advisor).to(:solr_document) }
   it { is_expected.to delegate_method(:college).to(:solr_document) }
   it { is_expected.to delegate_method(:department).to(:solr_document) }
+  it { is_expected.to delegate_method(:degree).to(:solr_document) }
+  it { is_expected.to delegate_method(:etd_publisher).to(:solr_document) }
 end

--- a/spec/presenters/hyrax/image_presenter_spec.rb
+++ b/spec/presenters/hyrax/image_presenter_spec.rb
@@ -16,4 +16,5 @@ RSpec.describe Hyrax::ImagePresenter do
   it { is_expected.to delegate_method(:note).to(:solr_document) }
   it { is_expected.to delegate_method(:college).to(:solr_document) }
   it { is_expected.to delegate_method(:department).to(:solr_document) }
+  it { is_expected.to delegate_method(:geo_subject).to(:solr_document) }
 end

--- a/spec/presenters/hyrax/medium_presenter_spec.rb
+++ b/spec/presenters/hyrax/medium_presenter_spec.rb
@@ -16,4 +16,5 @@ RSpec.describe Hyrax::MediumPresenter do
   it { is_expected.to delegate_method(:note).to(:solr_document) }
   it { is_expected.to delegate_method(:college).to(:solr_document) }
   it { is_expected.to delegate_method(:department).to(:solr_document) }
+  it { is_expected.to delegate_method(:geo_subject).to(:solr_document) }
 end

--- a/spec/presenters/hyrax/student_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/student_work_presenter_spec.rb
@@ -18,4 +18,5 @@ RSpec.describe Hyrax::StudentWorkPresenter do
   it { is_expected.to delegate_method(:required_software).to(:solr_document) }
   it { is_expected.to delegate_method(:note).to(:solr_document) }
   it { is_expected.to delegate_method(:advisor).to(:solr_document) }
+  it { is_expected.to delegate_method(:genre).to(:solr_document) }
 end


### PR DESCRIPTION
Fixes #344 

Present short summary (50 characters or less)

This is a follow up from comparing the presenters in scholar to the presenters in ucrate.  It looks like we missed the geo_subject delegation in some of our presenters.  This cleans up the presenters to be inline with Scholar. 
