### PR TITLE
Featured researcher image upload instructions

### DIFF
--- a/app/views/hyrax/content_blocks/_form.html.erb
+++ b/app/views/hyrax/content_blocks/_form.html.erb
@@ -48,6 +48,15 @@
       <div class="panel panel-default labels">
         <%= simple_form_for ContentBlock.for(:researcher), url: hyrax.content_block_path(ContentBlock.for(:researcher)), html: {class: 'nav-safety'} do |f| %>
           <div class="panel-body">
+            <div class="alert alert-warning">
+              <h4>Scholar featured researcher image upload instructions</h4>
+              <ul>
+                <li>Image upload only works with Firefox - last tested with 61.0.1 (64-bit).</li>
+                <li>Drag and drop image (270x270px) into form</li>
+                <li> See <%=link_to "https://github.com/uclibs/ucrate/issues/293", 'github' %></li>
+
+              </ul>
+            </div>
             <div class="field form-group">
                 <%= f.label :researcher %><br />
                 <%= f.text_area :researcher, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>

--- a/app/views/hyrax/content_blocks/_form.html.erb
+++ b/app/views/hyrax/content_blocks/_form.html.erb
@@ -1,0 +1,66 @@
+<%= render "shared/nav_safety_modal" %>
+<div class="panel panel-default tabs">
+  <ul class="nav nav-tabs" role="tablist">
+    <li class="active">
+      <a href="#announcement_text" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t(:'hyrax.content_blocks.tabs.announcement_text') %></a>
+    </li>
+    <li>
+      <a href="#marketing" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t(:'hyrax.content_blocks.tabs.marketing_text') %></a>
+    </li>
+    <li>
+      <a href="#researcher" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t(:'hyrax.content_blocks.tabs.featured_researcher') %></a>
+    </li>
+  </ul>
+  <div class="tab-content">
+    <div id="announcement_text" class="tab-pane active">
+      <div class="panel panel-default labels">
+        <%= simple_form_for ContentBlock.for(:announcement), url: hyrax.content_block_path(ContentBlock.for(:announcement)), html: {class: 'nav-safety'} do |f| %>
+          <div class="panel-body">
+            <div class="field form-group">
+                <%= f.label :announcement %><br />
+                <%= f.text_area :announcement, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="panel-footer">
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
+            <%= f.button :submit, class: 'btn btn-primary pull-right' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="marketing" class="tab-pane">
+      <div class="panel panel-default labels">
+        <%= simple_form_for ContentBlock.for(:marketing), url: hyrax.content_block_path(ContentBlock.for(:marketing)), html: {class: 'nav-safety'} do |f| %>
+          <div class="panel-body">
+            <div class="field form-group">
+                <%= f.label :marketing %><br />
+                <%= f.text_area :marketing, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="panel-footer">
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
+            <%= f.button :submit, class: 'btn btn-primary pull-right' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="researcher" class="tab-pane">
+      <div class="panel panel-default labels">
+        <%= simple_form_for ContentBlock.for(:researcher), url: hyrax.content_block_path(ContentBlock.for(:researcher)), html: {class: 'nav-safety'} do |f| %>
+          <div class="panel-body">
+            <div class="field form-group">
+                <%= f.label :researcher %><br />
+                <%= f.text_area :researcher, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="panel-footer">
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
+            <%= f.button :submit, class: 'btn btn-primary pull-right' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+<%= tinymce :content_block %>
+

--- a/spec/views/content_blocks/edit.html.erb_spec.rb
+++ b/spec/views/content_blocks/edit.html.erb_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "hyrax/content_blocks/edit", type: :view do
+  before { render }
+
+  it "renders the announcement form" do
+    assert_select "form[action=?][method=?]", hyrax.content_block_path(ContentBlock.for(:announcement)), "post" do
+      assert_select "textarea#content_block_announcement[name=?]", "content_block[announcement]"
+    end
+  end
+
+  it "renders the marketing form" do
+    assert_select "form[action=?][method=?]", hyrax.content_block_path(ContentBlock.for(:marketing)), "post" do
+      assert_select "textarea#content_block_marketing[name=?]", "content_block[marketing]"
+    end
+  end
+
+  it "renders the researcher form" do
+    assert_select "form[action=?][method=?]", hyrax.content_block_path(ContentBlock.for(:researcher)), "post" do
+      assert_select "textarea#content_block_researcher[name=?]", "content_block[researcher]"
+    end
+  end
+  it "shows featured researcher image uplaod instructions for scholar" do
+    expect(rendered).to have_content("Scholar featured researcher image upload instructions")
+  end
+end


### PR DESCRIPTION
Fixes #356 

Add alert div to featured researcher content block form. Include instruction on how to upload image for featured researcher.

Changes proposed in this pull request:
* Add partial override for featured researcher content block form
* Add alert div with details instructions on image upload
* Add spec

<img width="1220" alt="screen shot 2018-08-16 at 8 36 40 pm" src="https://user-images.githubusercontent.com/1069588/44241793-20a95480-a194-11e8-8861-b454e379718c.png">
