### PR TITLE
Swap rights and license form element, make rights optional

### DIFF
--- a/app/forms/hyrax/article_form.rb
+++ b/app/forms/hyrax/article_form.rb
@@ -19,11 +19,11 @@ module Hyrax
     self.terms -= %i[keyword source contributor based_near identifier resource_type]
 
     ## Setting custom required fields
-    self.required_fields = %i[title creator college department description rights_statement license]
+    self.required_fields = %i[title creator college department description license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + %i[publisher date_created alternate_title journal_title issn subject
+      required_fields + %i[rights_statement publisher date_created alternate_title journal_title issn subject
                            geo_subject time_period language required_software note related_url]
     end
 

--- a/app/forms/hyrax/dataset_form.rb
+++ b/app/forms/hyrax/dataset_form.rb
@@ -20,11 +20,11 @@ module Hyrax
     self.terms -= %i[keyword source contributor based_near identifier resource_type]
 
     ## Setting custom required fields
-    self.required_fields = %i[title creator college department description required_software rights_statement license]
+    self.required_fields = %i[title creator college department description required_software license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      %i[title creator college department description required_software rights_statement license
+      %i[title creator college department description required_software license rights_statement
          publisher date_created alternate_title subject geo_subject time_period language
          note related_url]
     end

--- a/app/forms/hyrax/document_form.rb
+++ b/app/forms/hyrax/document_form.rb
@@ -19,11 +19,11 @@ module Hyrax
     self.terms -= %i[keyword source contributor based_near identifier resource_type]
 
     ## Setting custom required fields
-    self.required_fields = %i[title creator college department description rights_statement license]
+    self.required_fields = %i[title creator college department description license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + %i[publisher date_created alternate_title genre subject geo_subject time_period
+      required_fields + %i[rights_statement publisher date_created alternate_title genre subject geo_subject time_period
                            language required_software note related_url]
     end
 

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -21,11 +21,11 @@ module Hyrax
     self.terms -= %i[keyword source contributor publisher based_near identifier resource_type]
 
     ## Setting custom required fields
-    self.required_fields = %i[title creator college department description advisor rights_statement license]
+    self.required_fields = %i[title creator college department description advisor license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + %i[committee_member degree
+      required_fields + %i[rights_statement committee_member degree
                            date_created publisher etd_publisher alternate_title genre subject
                            geo_subject time_period language
                            required_software note related_url]

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -20,11 +20,11 @@ module Hyrax
     self.terms -= %i[keyword source contributor description based_near identifier resource_type]
 
     ## Setting custom required fields
-    self.required_fields = %i[title creator college department description rights_statement license]
+    self.required_fields = %i[title creator college department description license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + %i[publisher date_created alternate_title subject geo_subject time_period
+      required_fields + %i[rights_statement publisher date_created alternate_title subject geo_subject time_period
                            language required_software note related_url]
     end
 

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -20,11 +20,11 @@ module Hyrax
     self.terms -= %i[keyword source contributor identifier based_near resource_type]
 
     ## Setting custom required fields
-    self.required_fields = %i[title creator college department description rights_statement license]
+    self.required_fields = %i[title creator college department description license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + %i[publisher date_created alternate_title genre subject geo_subject time_period
+      required_fields + %i[rights_statement publisher date_created alternate_title genre subject geo_subject time_period
                            language required_software note related_url]
     end
 

--- a/app/forms/hyrax/medium_form.rb
+++ b/app/forms/hyrax/medium_form.rb
@@ -21,11 +21,11 @@ module Hyrax
     self.terms -= %i[keyword source contributor identifier based_near resource_type]
 
     ## Setting custom required fields
-    self.required_fields = %i[title creator college department description rights_statement license]
+    self.required_fields = %i[title creator college department description license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + %i[publisher date_created alternate_title subject geo_subject time_period
+      required_fields + %i[rights_statement publisher date_created alternate_title subject geo_subject time_period
                            language required_software note related_url]
     end
 

--- a/app/forms/hyrax/student_work_form.rb
+++ b/app/forms/hyrax/student_work_form.rb
@@ -21,11 +21,11 @@ module Hyrax
     self.terms -= %i[keyword source contributor identifier based_near resource_type]
 
     ## Setting custom required fields
-    self.required_fields = %i[title creator college department description advisor rights_statement license]
+    self.required_fields = %i[title creator college department description advisor license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + %i[degree publisher date_created alternate_title genre subject geo_subject time_period
+      required_fields + %i[rights_statement degree publisher date_created alternate_title genre subject geo_subject time_period
                            language required_software note related_url]
     end
 

--- a/spec/forms/hyrax/article_form_spec.rb
+++ b/spec/forms/hyrax/article_form_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Hyrax::ArticleForm do
   describe "#required_fields" do
     subject { form.required_fields }
 
-    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights_statement, :license] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :license] }
   end
 
   describe "#primary_terms" do
     subject { form.primary_terms }
 
     it {
-      is_expected.to eq [:title, :creator, :college, :department, :description, :rights_statement, :license, :publisher, :date_created,
+      is_expected.to eq [:title, :creator, :college, :department, :description, :license, :rights_statement, :publisher, :date_created,
                          :alternate_title, :journal_title, :issn, :subject, :geo_subject, :time_period,
                          :language, :required_software, :note, :related_url]
     }

--- a/spec/forms/hyrax/dataset_form_spec.rb
+++ b/spec/forms/hyrax/dataset_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::DatasetForm do
   describe "#required_fields" do
     subject { form.required_fields }
 
-    it { is_expected.to eq [:title, :creator, :college, :department, :description, :required_software, :rights_statement, :license] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :required_software, :license] }
   end
 
   describe "#primary_terms" do
@@ -19,7 +19,7 @@ RSpec.describe Hyrax::DatasetForm do
 
     it {
       is_expected.to eq [:title, :creator, :college, :department, :description,
-                         :required_software, :rights_statement, :license, :publisher, :date_created,
+                         :required_software, :license, :rights_statement, :publisher, :date_created,
                          :alternate_title, :subject, :geo_subject, :time_period,
                          :language, :note, :related_url]
     }

--- a/spec/forms/hyrax/document_form_spec.rb
+++ b/spec/forms/hyrax/document_form_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Hyrax::DocumentForm do
   describe "#required_fields" do
     subject { form.required_fields }
 
-    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights_statement, :license] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :license] }
   end
 
   describe "#primary_terms" do
     subject { form.primary_terms }
 
     it {
-      is_expected.to eq [:title, :creator, :college, :department, :description, :rights_statement, :license,
+      is_expected.to eq [:title, :creator, :college, :department, :description, :license, :rights_statement,
                          :publisher, :date_created, :alternate_title, :genre, :subject, :geo_subject,
                          :time_period, :language, :required_software, :note, :related_url]
     }

--- a/spec/forms/hyrax/etd_form_spec.rb
+++ b/spec/forms/hyrax/etd_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::EtdForm do
   describe "#required_fields" do
     subject { form.required_fields }
 
-    it { is_expected.to eq [:title, :creator, :college, :department, :description, :advisor, :rights_statement, :license] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :advisor, :license] }
   end
 
   describe "#primary_terms" do
@@ -19,7 +19,7 @@ RSpec.describe Hyrax::EtdForm do
 
     it {
       is_expected.to eq [:title, :creator, :college, :department, :description, :advisor,
-                         :rights_statement, :license, :committee_member, :degree, :date_created,
+                         :license, :rights_statement, :committee_member, :degree, :date_created,
                          :publisher, :etd_publisher, :alternate_title, :genre, :subject, :geo_subject,
                          :time_period, :language, :required_software, :note, :related_url]
     }

--- a/spec/forms/hyrax/generic_work_form_spec.rb
+++ b/spec/forms/hyrax/generic_work_form_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Hyrax::GenericWorkForm do
   describe "#required_fields" do
     subject { form.required_fields }
 
-    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights_statement, :license] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :license] }
   end
 
   describe "#primary_terms" do
     subject { form.primary_terms }
 
     it {
-      is_expected.to eq [:title, :creator, :college, :department, :description, :rights_statement, :license,
+      is_expected.to eq [:title, :creator, :college, :department, :description, :license, :rights_statement,
                          :publisher, :date_created, :alternate_title, :subject, :geo_subject,
                          :time_period, :language, :required_software, :note, :related_url]
     }

--- a/spec/forms/hyrax/image_form_spec.rb
+++ b/spec/forms/hyrax/image_form_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Hyrax::ImageForm do
   describe "#required_fields" do
     subject { form.required_fields }
 
-    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights_statement, :license] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :license] }
   end
 
   describe "#primary_terms" do
     subject { form.primary_terms }
 
     it {
-      is_expected.to eq [:title, :creator, :college, :department, :description, :rights_statement, :license,
+      is_expected.to eq [:title, :creator, :college, :department, :description, :license, :rights_statement,
                          :publisher, :date_created, :alternate_title, :genre, :subject, :geo_subject, :time_period,
                          :language, :required_software, :note, :related_url]
     }

--- a/spec/forms/hyrax/medium_form_spec.rb
+++ b/spec/forms/hyrax/medium_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::MediumForm do
   describe "#required_fields" do
     subject { form.required_fields }
 
-    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights_statement, :license] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :license] }
   end
 
   describe "#primary_terms" do
@@ -19,7 +19,7 @@ RSpec.describe Hyrax::MediumForm do
 
     it {
       is_expected.to eq [:title, :creator, :college, :department, :description,
-                         :rights_statement, :license, :publisher, :date_created, :alternate_title, :subject, :geo_subject,
+                         :license, :rights_statement, :publisher, :date_created, :alternate_title, :subject, :geo_subject,
                          :time_period, :language, :required_software, :note, :related_url]
     }
   end

--- a/spec/forms/hyrax/student_work_form_spec.rb
+++ b/spec/forms/hyrax/student_work_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::StudentWorkForm do
   describe "#required_fields" do
     subject { form.required_fields }
 
-    it { is_expected.to eq [:title, :creator, :college, :department, :description, :advisor, :rights_statement, :license] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :advisor, :license] }
   end
 
   describe "#primary_terms" do
@@ -19,7 +19,7 @@ RSpec.describe Hyrax::StudentWorkForm do
 
     it {
       is_expected.to eq [:title, :creator, :college, :department, :description,
-                         :advisor, :rights_statement, :license, :degree, :publisher,
+                         :advisor, :license, :rights_statement, :degree, :publisher,
                          :date_created, :alternate_title, :genre, :subject, :geo_subject,
                          :time_period, :language, :required_software, :note, :related_url]
     }


### PR DESCRIPTION
Fixes #338 

For all work types, swap order of rights_statement and license form elements, make rights optional.

Changes proposed in this pull request:
* Swap order of rights and license form elements
* Change specs
