### PR TITLE
Add help to top of workform

### DIFF
--- a/app/views/hyrax/base/_form_metadata.html.erb
+++ b/app/views/hyrax/base/_form_metadata.html.erb
@@ -1,0 +1,21 @@
+        <div class="base-terms">
+          <% f.object.primary_terms.each do |term| %>
+            <%= render_edit_field_partial(term, f: f) %>
+          <% end %>
+        </div>
+        <% if f.object.display_additional_fields? %>
+          <%= link_to t('hyrax.works.form.additional_fields'),
+                      '#extended-terms',
+                      class: 'btn btn-default additional-fields',
+                      data: { toggle: 'collapse' },
+                      role: "button",
+                      'aria-expanded'=> "false",
+                      'aria-controls'=> "extended-terms" %>
+          <div id="extended-terms" class='collapse'>
+            <%= render 'form_media', f: f %>
+            <% f.object.secondary_terms.each do |term| %>
+              <%= render_edit_field_partial(term, f: f) %>
+            <% end %>
+          </div>
+        <% end %>
+

--- a/app/views/hyrax/base/_form_metadata.html.erb
+++ b/app/views/hyrax/base/_form_metadata.html.erb
@@ -1,3 +1,9 @@
+        <div class="form-instructions">
+          <%= t('hyrax.workform_help_html') %>
+        </div>
+        <div class="contextual-help">
+          <%= t('hyrax.workform_attach_file_html', href: link_to(t("hyrax.workform_attach_file_href"), '#files', 'aria-controls': 'files', 'data-toggle': 'tab')) %>
+        </div>
         <div class="base-terms">
           <% f.object.primary_terms.each do |term| %>
             <%= render_edit_field_partial(term, f: f) %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -56,6 +56,9 @@ en:
       featured_collections:
         title:              'FEATURED COLLECTION'
         no_collections:     'No collections have been featured'
+    workform_help_html: '<p>The more descriptive information you provide the better we can serve your needs.</p>'
+    workform_attach_file_html: '<p>%{href} is highly recommended but not required.</p>'
+    workform_attach_file_href: 'Attaching a file'
     deposit_agreement: "Distribution License"
     account_name:           "My Institution Account Id"
     directory:

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
+  before do
+    allow(form).to receive(:display_additional_fields?).and_return(additional_fields)
+    allow(controller).to receive(:current_user).and_return(stub_model(User, user_key: 'userX'))
+  end
+  let(:additional_fields) {}
+  let(:ability) { double }
+  let(:work) { GenericWork.new }
+  let(:form) do
+    Hyrax::GenericWorkForm.new(work, ability, controller)
+  end
+
+  let(:form_template) do
+    %(
+      <%= simple_form_for [main_app, @form] do |f| %>
+        <%= render "hyrax/base/form_metadata", f: f %>
+      <% end %>
+     )
+  end
+
+  let(:page) do
+    assign(:form, form)
+    render inline: form_template
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  it "renders scholar workform help" do
+    expect(page).to have_content('The more descriptive information you provide')
+  end
+
+  context 'with secondary terms' do
+    let(:additional_fields) { true }
+
+    it "renders the additional fields button" do
+      expect(page).to have_content('Additional fields')
+    end
+  end
+
+  context 'without secondary terms' do
+    let(:additional_fields) { false }
+
+    it 'does not render the addtional fields button' do
+      expect(page).not_to have_content('Additional fields')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #289 

Add help text to top of work-form for all worktypes.

Changes proposed in this pull request:
* Add view partial override ` app/views/hyrax/base/_form_metadata.html.erb`
* Add locales for help text and links
* Add spec
