### PR TITLE
Bug/#351 fix video player

### DIFF
--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,0 +1,25 @@
+<% if Hyrax.config.display_media_download_link? %>
+    <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">
+        <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
+        <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
+        <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" />
+        Your browser does not support the video tag.
+      </video>
+      <%= link_to t('hyrax.file_set.show.downloadable_content.video_link'),
+                  hyrax.download_path(file_set),
+                  data: { label: file_set.id },
+                  target: :_blank,
+                  id: "file_download" %>
+    </div>
+<% else %>
+    <div>
+      <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">
+        <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
+        <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
+        <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" />  
+        Your browser does not support the video tag.
+      </video>
+    </div>
+<% end %>

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -4,7 +4,7 @@
       <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">
         <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
         <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
-        <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" />
+        <source src="<%= hyrax.download_path(file_set) %>" />
         Your browser does not support the video tag.
       </video>
       <%= link_to t('hyrax.file_set.show.downloadable_content.video_link'),
@@ -18,7 +18,7 @@
       <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">
         <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
         <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
-        <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" />  
+        <source src="<%= hyrax.download_path(file_set) %>" />  
         Your browser does not support the video tag.
       </video>
     </div>


### PR DESCRIPTION
Fixes #351 

Present short summary (50 characters or less)

Overrides the partial from hyrax to get the video player to work in Safari. Adds this line
`<source src="<%= hyrax.download_path(file_set) %>" />`