### PR TITLE
#371 - Makes links on work creation page the correct color.

### DIFF
--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -428,3 +428,12 @@ label[for=user_password] {
     margin-bottom: 20px;
   }
 }
+
+.btn-link {
+  color: #e00122;
+}
+
+#savewidget a {
+  color: #e00122;
+}
+ 


### PR DESCRIPTION
Fixes #371  ; 
Present short summary (50 characters or less)
Some link like options we're not red.  Added css rules to the scholar style sheet to fix this.

Description can have multiple paragraphs and you can use code examples inside:
I searched for a way to implement a test here, however based on the dearth of solutions, it doesn't seem like RSpec + Capybara we're intended to do UI tests
