### PR TITLE
Fix div in featured collection partial

### DIFF
--- a/app/views/hyrax/homepage/_featured_collections.html.erb
+++ b/app/views/hyrax/homepage/_featured_collections.html.erb
@@ -10,6 +10,6 @@
                 alt: "Thumbnail for featured collection: #{collection.title.first}",
                 role: "presentation" %>
     <% end %>
-    <% end %>
   </div>
+    <% end %>
 <p><%= t('hyrax.homepage.featured_collections.title') %></p>


### PR DESCRIPTION
Fixes #377 
Featured Collections view partial had a misplaced closing div tag, causing wonky layout. Moved to appropriate spot within conditional block.

Changes proposed in this pull request:
* Moved closing div tag in ` app/views/hyrax/homepage/_featured_collections.html.erb`

