### PR TITLE
Rename descriptions tab to metadata

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -126,3 +126,7 @@ en:
       profile:
         view: 'View Profile'
         edit: 'Edit Profile'
+    works:
+      form:
+        tab:
+          metadata: "Metadata"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -56,3 +56,10 @@ es:
     institution_name_full: El nombre de la institución
     product_name: Hyrax
     product_twitter_handle: "@SamveraRepo"
+    workform_help_html: '<p>Mientras más información descriptiva pueda proporcionar, mejor podremos satisfacer sus necesidades.</p>'
+    workform_attach_file_html: '<p>Se recomienda encarecidamente %{href}, pero no es obligatorio.</p>'
+    workform_attach_file_href: 'adjuntar un archivo'
+    works:
+      form:
+        tab:
+          metadata: "Metadatos"

--- a/spec/features/create_article_spec.rb
+++ b/spec/features/create_article_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Create a Article', js: true do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
       end
-      click_link "Descriptions" # switch tab
+      click_link "Metadata" # switch tab
 
       title_element = find_by_id("article_title")
       title_element.set("My Test Work  ") # Add whitespace to test it getting removed

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Create a Dataset', js: true do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
       end
-      click_link "Descriptions" # switch tab
+      click_link "Metadata" # switch tab
 
       title_element = find_by_id("dataset_title")
       title_element.set("My Test Work  ") # Add whitespace to test it getting removed

--- a/spec/features/create_document_spec.rb
+++ b/spec/features/create_document_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Create a Document', js: true do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
       end
-      click_link "Descriptions" # switch tab
+      click_link "Metadata" # switch tab
 
       title_element = find_by_id("document_title")
       title_element.set("My Test Work  ") # Add whitespace to test it getting removed

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Create a Etd', js: true do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
       end
-      click_link "Descriptions" # switch tab
+      click_link "Metadata" # switch tab
 
       title_element = find_by_id("etd_title")
       title_element.set("My Test Work  ") # Add whitespace to test it getting removed

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Create a Image', js: true do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
       end
-      click_link "Descriptions" # switch tab
+      click_link "Metadata" # switch tab
       title_element = find_by_id("image_title")
       title_element.set("My Test Work  ") # Add whitespace to test it getting removed
 

--- a/spec/features/create_medium_spec.rb
+++ b/spec/features/create_medium_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Create a Medium', js: true do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
       end
-      click_link "Descriptions" # switch tab
+      click_link "Metadata" # switch tab
 
       title_element = find_by_id("medium_title")
       title_element.set("My Test Work  ") # Add whitespace to test it getting removed

--- a/spec/features/create_student_work_spec.rb
+++ b/spec/features/create_student_work_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Create a StudentWork', js: true do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
       end
-      click_link "Descriptions" # switch tab
+      click_link "Metadata" # switch tab
 
       title_element = find_by_id("student_work_title")
       title_element.set("My Test Work  ") # Add whitespace to test it getting removed

--- a/spec/features/hyrax/batch_create_spec.rb
+++ b/spec/features/hyrax/batch_create_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Batch creation of works', type: :feature do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/small_file.txt", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/png_fits.xml", visible: false)
       end
-      click_link "Descriptions" # switch tab
+      click_link "Metadata" # switch tab
       fill_in('Creator', with: 'Doe, Jane')
       fill_in('Keyword', with: 'testing')
       select('In Copyright', from: 'Rights statement')

--- a/spec/features/hyrax/create_work_spec.rb
+++ b/spec/features/hyrax/create_work_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
       end
       click_link "Relationships"
       expect(page).to have_css("div.generic_work_admin_set_id", visible: false)
-      click_link "Descriptions" # switch tab
+      click_link "Metadata" # switch tab
 
       title_element = find_by_id("generic_work_title")
       title_element.set("My Test Work  ") # Add whitespace to test it getting removed
@@ -105,7 +105,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
       end
-      click_link "Descriptions" # switch tab
+      click_link "Metadata" # switch tab
       expect(page).to have_field("Creator", with: second_user.name_for_works)
 
       title_element = find_by_id("generic_work_title")

--- a/spec/features/hyrax/dashboard/collection_spec.rb
+++ b/spec/features/hyrax/dashboard/collection_spec.rb
@@ -690,7 +690,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
           attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
         end
         # set required metadata
-        click_link "Descriptions" # switch tab
+        click_link "Metadata" # switch tab
 
         title_element = find_by_id("generic_work_title")
         title_element.set("New Work for Collection")


### PR DESCRIPTION
Fixes #368 
Fixes #380 

Override Hyrax en/es locale to rename `Descriptions` on new work form to `Metadata`.
Also added Spanish translation for top of workform help.

Changes proposed in this pull request:
* Update `config/locales/hyrax.en.yml`
* Update `config/locales/hyrax.es.yml`
* Feature spec checking for presence of 'Metadata' on new work creation.
