### PR TITLE
Fix missing license wizard button

### DIFF
--- a/app/assets/javascripts/select-license.js
+++ b/app/assets/javascripts/select-license.js
@@ -13,7 +13,7 @@ var ls = function() {
             name: 'All rights reserved',
             priority: 1,
             available: true,
-            url: 'http://www.europeana.eu/portal/rights/rr-r.html',
+            url: 'http://rightsstatements.org/vocab/InC/1.0/',
             description: '\"All rights reserved\" is a phrase that originated in copyright law as a formal requirement for copyright notice. It indicates that the copyright holder reserves, or holds for their own use, all the rights provided by copyright law under one specific copyright treaty.',
             categories: ['reserved', 'by', 'nd', 'nc'],
             labels: ['reserved'],

--- a/app/assets/stylesheets/licenses.css
+++ b/app/assets/stylesheets/licenses.css
@@ -1,26 +1,12 @@
-.vertical-align {
-  display: flex;
-  align-items: center;
-}
-
 .selector, .selector:active {
   background-color: #fff !important;
   border-color: #ccc !important;
-  margin-bottom: 10px;
+  margin-bottom: 20px;
   color: #000 !important;
 }
 
 .selector:hover {
   background-color: #ececec !important;
-}
-
-#license-wizard {
-  margin-bottom: 20px;
-}
-
-
-.license-wrapper {
-  max-width: 40em;
 }
 
 @media only screen and (max-width: 768px) {

--- a/app/views/records/edit_fields/_license.html.erb
+++ b/app/views/records/edit_fields/_license.html.erb
@@ -5,17 +5,11 @@
   <span class="label label-info required-tag">required</span>
 <% end %>
 
-<div class="license-wrapper">
-  <div class="row">
-      <div class="col-sm-9">
         <%= f.input :license, as: :select,
           collection: license_service.select_active_options,
           include_blank: 'Use License Wizard or choose directly from the dropdown.',
           item_helper: license_service.method(:include_current_value),
-          input_html: { class: 'form-control' },
+          input_html: { class: 'rights-selector form-control' },
           label: false,
           required: true
         %>
-    </div>
-  </div>
-</div>

--- a/spec/features/create_article_spec.rb
+++ b/spec/features/create_article_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe 'Create a Article', js: true do
       college_element.select("Business")
 
       select 'In Copyright', from: "article_rights_statement"
+      expect(page).to have_content("License Wizard")
       select 'Attribution-ShareAlike 4.0 International', from: 'article_license'
 
       fill_in('Author', with: 'Doe, Jane')

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe 'Create a Dataset', js: true do
       title_element.set("My Test Work  ") # Add whitespace to test it getting removed
 
       select 'In Copyright', from: "dataset_rights_statement"
+      expect(page).to have_content("License Wizard")
       select 'Attribution-ShareAlike 4.0 International', from: "dataset_license"
 
       college_element = find_by_id("dataset_college")

--- a/spec/features/create_document_spec.rb
+++ b/spec/features/create_document_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe 'Create a Document', js: true do
       college_element.select("Business")
 
       select 'In Copyright', from: "document_rights_statement"
+      expect(page).to have_content("License Wizard")
       select 'Attribution-ShareAlike 4.0 International', from: 'document_license'
 
       fill_in('Creator', with: 'Doe, Jane')

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe 'Create a Etd', js: true do
       college_element.select("Business")
 
       select 'In Copyright', from: "etd_rights_statement"
+      expect(page).to have_content("License Wizard")
       select 'Attribution-ShareAlike 4.0 International', from: 'etd_license'
 
       fill_in('Creator', with: 'Doe, Jane')

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe 'Create a Image', js: true do
       fill_in('Description', with: 'This is a description')
 
       select 'In Copyright', from: "image_rights_statement"
+      expect(page).to have_content("License Wizard")
       select 'Attribution-ShareAlike 4.0 International', from: "image_license"
 
       choose('image_visibility_open')

--- a/spec/features/create_medium_spec.rb
+++ b/spec/features/create_medium_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe 'Create a Medium', js: true do
       college_element.select("Business")
 
       select 'In Copyright', from: "medium_rights_statement"
+      expect(page).to have_content("License Wizard")
       select 'Attribution-ShareAlike 4.0 International', from: 'medium_license'
 
       fill_in('Creator', with: 'Doe, Jane')

--- a/spec/features/create_student_work_spec.rb
+++ b/spec/features/create_student_work_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe 'Create a StudentWork', js: true do
       title_element.set("My Test Work  ") # Add whitespace to test it getting removed
 
       select 'In Copyright', from: "student_work_rights_statement"
+      expect(page).to have_content("License Wizard")
       select 'Attribution-ShareAlike 4.0 International', from: 'student_work_license'
 
       college_element = find_by_id("student_work_college")

--- a/spec/features/hyrax/create_work_spec.rb
+++ b/spec/features/hyrax/create_work_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
       college_element.select("Business")
 
       select 'In Copyright', from: "generic_work_rights_statement"
+      expect(page).to have_content("License Wizard")
       select 'Attribution-ShareAlike 4.0 International', from: 'generic_work_license'
 
       expect(page).to have_field("Creator", with: user.name_for_works)

--- a/spec/features/hyrax/edit_work_spec.rb
+++ b/spec/features/hyrax/edit_work_spec.rb
@@ -61,5 +61,10 @@ RSpec.describe 'Editing a work', type: :feature do
       click_link "Relationships" # switch tab
       expect(page).to have_select('generic_work_admin_set_id', selected: another_admin_set.title)
     end
+
+    it 'shows license wizard on edit form' do
+      visit edit_hyrax_generic_work_path(work)
+      expect(page).to have_content("License Wizard")
+    end
   end
 end


### PR DESCRIPTION
Fixes #365 
Depends on #366 

The JS for the license wizard was missing a div in the view to render the button. I added a div class and simplified the style. Also added some feature specs to check that the button is showing where it should.
