### PR TITLE
Bug/#370 Resolves Template Error on Distirbution License Page

### DIFF
--- a/app/views/hyrax/homepage/_jumbotron.html.erb
+++ b/app/views/hyrax/homepage/_jumbotron.html.erb
@@ -20,5 +20,5 @@
       </div>
     </div>
   </div>
-  <%= render 'splash_controls' %>
+  <%= render 'hyrax/homepage/splash_controls' %>
 </div>

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:navbar) do %>
-  <%= render 'jumbotron' %>
+  <%= render 'hyrax/homepage/jumbotron' %>
 <% end %>
 
 <% content_for(:precontainer_content) do %>

--- a/spec/views/hyrax/static/agreement.html.erb_spec.rb
+++ b/spec/views/hyrax/static/agreement.html.erb_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe '/hyrax/static/agreement.html.erb', type: :view do
+  before do
+    render
+  end
+
+  it 'has the correct text and jumbotron' do
+    puts rendered
+    expect(rendered).to have_selector('h2', text: "Non-Exclusive Distribution License")
+  end
+end


### PR DESCRIPTION
Fixes #370  ; 

Present short summary (50 characters or less)
Resolved template error by providing a more explicit path to partials.

I'm not sure what caused this problem.  For some reason rails could no longer find the file with the partial.