### PR TITLE
Update agreement checkbox on new work form

### DIFF
--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -1,0 +1,57 @@
+<aside id="form-progress" class="form-progress panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title"><%= t("hyrax.works.progress.header") %></h3>
+  </div>
+  <div class="list-group">
+    <div class="list-group-item">
+      <fieldset>
+        <legend class="legend-save-work"><%= t('.requirements') %></legend>
+        <ul class="requirements">
+          <li class="incomplete" id="required-metadata"><%= t('.required_descriptions') %></li>
+          <% if Hyrax.config.work_requires_files? %>
+            <li class="incomplete" id="required-files"><%= t('.required_files') %></li>
+          <% end %>
+          <% if Flipflop.active_deposit_agreement_acceptance? %>
+            <li class="incomplete" id="required-agreement"><%= t('.required_agreement') %></li>
+          <% end %>
+        </ul>
+      </fieldset>
+    </div>
+
+    <div class="set-access-controls list-group-item">
+      <%= render 'form_visibility_component', f: f %>
+    </div>
+    <% if Flipflop.proxy_deposit? && current_user.can_make_deposits_for.any? %>
+        <div class="list-group-item">
+          <%= f.input :on_behalf_of, collection: current_user.can_make_deposits_for.map(&:user_key), prompt: "Yourself" %>
+        </div>
+    <% end %>
+  </div>
+  <div class="panel-footer text-center">
+    <% if ::Flipflop.show_deposit_agreement? %>
+      <% if ::Flipflop.active_deposit_agreement_acceptance? %>
+        <label>
+          <%= check_box_tag 'agreement', 1, f.object.agreement_accepted, required: true %>
+          <%= t('hyrax.active_consent_to_agreement') %><br />
+          <%= link_to t('hyrax.pages.tabs.agreement_page'),
+                      main_app.distribution_license_request_path,
+                      target: '_blank' %>
+        </label>
+      <% else %>
+        <%= t('hyrax.passive_consent_to_agreement') %><br />
+        <%= link_to t('hyrax.pages.tabs.agreement_page'),
+                    main_app.distribution_license_request_path,
+                    target: '_blank' %>
+      <% end %>
+    <% end %>
+    <br />
+    <% cancel_path = f.object.persisted? ? polymorphic_path([main_app, f.object]) : hyrax.my_works_path %>
+    <%= link_to t(:'helpers.action.cancel'),
+                cancel_path,
+                class: 'btn btn-default' %>
+    <%# TODO: If we start using ActionCable, we could listen for object updates and
+              alert the user that the object has changed by someone else %>
+    <%= f.input Hyrax::Actors::OptimisticLockValidator.version_field, as: :hidden if f.object.persisted? %>
+    <%= f.submit class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
+  </div>
+</aside>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -51,6 +51,11 @@ en:
           subject_tesim: Subject
           title_tesim: Title
   hyrax:
+    active_consent_to_agreement: I have read and agree to the
+    base:
+      form_progress:
+        required_agreement: Check distribution license
+    passive_consent_to_agreement: I have read and agree to the
     homepage:
       featured_works:
         tab_label:          'Featured Works'
@@ -62,6 +67,9 @@ en:
       featured_collections:
         title:              'FEATURED COLLECTION'
         no_collections:     'No collections have been featured'
+    pages:
+      tabs:
+        agreement_page: 'Distribution License'
     workform_help_html: '<p>The more descriptive information you provide the better we can serve your needs.</p>'
     workform_attach_file_html: '<p>%{href} is highly recommended but not required.</p>'
     workform_attach_file_href: 'Attaching a file'
@@ -112,7 +120,7 @@ en:
       show:
         adobe_reader_link: 'Download Adobe Acrobat Reader'
     toolbar:
-      dashboard: 
+      dashboard:
         my: 'My Dashboard'
       works:
         batch: 'Batch Create'

--- a/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
+  let(:ability) { double }
+  let(:user) { stub_model(User) }
+  let(:form) do
+    Hyrax::GenericWorkForm.new(work, ability, controller)
+  end
+  let(:page) do
+    view.simple_form_for form do |f|
+      render 'hyrax/base/form_progress', f: f
+    end
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    # Stub visibility, or it will hit fedora
+    allow(work).to receive(:visibility).and_return('open')
+  end
+
+  context "for a new object" do
+    before { assign(:form, form) }
+
+    let(:work) { GenericWork.new }
+
+    context "with options for proxy" do
+      let(:proxies) { [stub_model(User, email: 'bob@example.com')] }
+
+      before do
+        allow(Flipflop).to receive(:proxy_deposit?).and_return(true)
+        allow(user).to receive(:can_make_deposits_for).and_return(proxies)
+      end
+
+      it "shows options for proxy" do
+        expect(page).to have_content 'On behalf of'
+        expect(page).to have_selector("select#generic_work_on_behalf_of option[value=\"\"]", text: 'Yourself')
+        expect(page).to have_selector("select#generic_work_on_behalf_of option[value=\"bob@example.com\"]")
+      end
+
+      context 'when feature disabled' do
+        before do
+          allow(Flipflop).to receive(:proxy_deposit?).and_return(false)
+        end
+
+        it "does not show options for proxy" do
+          expect(page).not_to have_content 'On behalf of'
+          expect(page).not_to have_selector("select#generic_work_on_behalf_of option[value=\"\"]", text: 'Yourself')
+          expect(page).not_to have_selector("select#generic_work_on_behalf_of option[value=\"bob@example.com\"]")
+        end
+      end
+    end
+
+    context "without options for proxy" do
+      let(:proxies) { [] }
+
+      before do
+        allow(user).to receive(:can_make_deposits_for).and_return(proxies)
+      end
+      it "doesn't show options for proxy" do
+        expect(page).not_to have_content 'On behalf of'
+        expect(page).not_to have_selector 'select#generic_work_on_behalf_of'
+      end
+    end
+
+    context "with active deposit agreement" do
+      before do
+        allow(Flipflop).to receive(:active_deposit_agreement_acceptance?)
+          .and_return(true)
+      end
+      it "shows accept text" do
+        expect(page).to have_content 'Check distribution license'
+        expect(page).to have_content 'I have read and agree to the'
+        expect(page).to have_link 'Distribution License', href: '/distribution_license_request'
+        expect(page).not_to have_selector("#agreement[checked]")
+      end
+    end
+
+    context "with passive deposit agreement" do
+      before do
+        allow(Flipflop).to receive(:active_deposit_agreement_acceptance?)
+          .and_return(false)
+      end
+      it "shows accept text" do
+        expect(page).not_to have_content 'Check distribution license'
+        expect(page).to have_content 'I have read and agree to the'
+        expect(page).to have_link 'Distribution License', href: '/distribution_license_request'
+      end
+    end
+
+    context "with no deposit agreement" do
+      before do
+        allow(Flipflop).to receive(:show_deposit_agreement?).and_return(false)
+      end
+      it "does not display active accept text" do
+        expect(page).not_to have_content 'I have read and agree to the'
+        expect(page).not_to have_selector("#agreement[checked]")
+      end
+      it "does not display passive accept text" do
+        expect(page).not_to have_content 'By saving this work I agree to the'
+        expect(page).not_to have_link 'Deposit Agreement', href: '/agreement'
+      end
+    end
+
+    context "with active deposit acceptance but no show deposit agreement" do
+      before do
+        allow(Flipflop).to receive(:show_deposit_agreement?).and_return(false)
+        allow(Flipflop).to receive(:active_deposit_agreement_acceptance?)
+          .and_return(true)
+      end
+      it "displays the deposit agreement in the requirements" do
+        expect(page).to have_selector("#required-agreement")
+      end
+    end
+  end
+
+  context "when the work has been saved before" do
+    before do
+      # TODO: stub_model is not stubbing new_record? correctly on ActiveFedora models.
+      allow(work).to receive(:new_record?).and_return(false)
+      assign(:form, form)
+      allow(Hyrax.config).to receive(:active_deposit_agreement_acceptance)
+        .and_return(true)
+    end
+
+    let(:work) { stub_model(GenericWork, id: '456', etag: '123456') }
+
+    it "renders the deposit agreement already checked and the version" do
+      expect(page).to have_selector("#agreement[checked]")
+      expect(page).to have_selector("input#generic_work_version[value=\"123456\"]", visible: false)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #369 

Fixes the agreement checkbox on new work form by changing the text above the box, and the link for the Distribution License.

