### PR TITLE
Remove extra text under open access visibility, update specs

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -102,6 +102,7 @@ en:
       open:
         text: "Open Access"
         note_html: Make available to all<br />(see <a href="/creators_rights" target=\"_blank\">Creator's Rights</a> for more information)
+        warning_html: ""
       authenticated:
         note_html: Restrict access to logged-in users
     controls:
@@ -112,7 +113,7 @@ en:
       show:
         adobe_reader_link: 'Download Adobe Acrobat Reader'
     toolbar:
-      dashboard: 
+      dashboard:
         my: 'My Dashboard'
       works:
         batch: 'Batch Create'

--- a/spec/features/create_article_spec.rb
+++ b/spec/features/create_article_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Create a Article', js: true do
       fill_in('Program or Department', with: 'University Department')
 
       choose('article_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
+      expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Create a Dataset', js: true do
       fill_in('Required Software', with: 'Software')
 
       choose('dataset_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
+      expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')

--- a/spec/features/create_document_spec.rb
+++ b/spec/features/create_document_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Create a Document', js: true do
       fill_in('Program or Department', with: 'University Department')
 
       choose('document_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
+      expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'Create a Etd', js: true do
       fill_in('Degree Program', with: 'Test Department')
 
       choose('etd_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
+      expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Create a Image', js: true do
       select 'Attribution-ShareAlike 4.0 International', from: "image_license"
 
       choose('image_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
+      expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')

--- a/spec/features/create_medium_spec.rb
+++ b/spec/features/create_medium_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Create a Medium', js: true do
       fill_in('Program or Department', with: 'University Department')
 
       choose('medium_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
+      expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')

--- a/spec/features/create_student_work_spec.rb
+++ b/spec/features/create_student_work_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Create a StudentWork', js: true do
       fill_in('Degree', with: 'Degree')
 
       choose('student_work_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
+      expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')

--- a/spec/features/hyrax/create_work_spec.rb
+++ b/spec/features/hyrax/create_work_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
       fill_in('Description', with: 'This is a description.')
 
       choose('generic_work_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
+      expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')
       # These lines are for debugging, should this test fail
       # puts "Required metadata: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').requiredFields.areComplete})}"
@@ -124,7 +124,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
       fill_in('Description', with: 'This is a description.')
 
       choose('generic_work_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
+      expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       select(second_user.user_key, from: 'On behalf of')
       sleep 1
       check('agreement')

--- a/spec/views/hyrax/base/_form_visibility_component.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_visibility_component.html.erb_spec.rb
@@ -26,4 +26,8 @@ describe 'hyrax/base/_form_visibility_component.html.erb', type: :view do
   it 'does not have a Lease option for visibility' do
     expect(rendered).not_to have_selector('div#collapseLease')
   end
+
+  it 'does not show open access warning text' do
+    expect(rendered).not_to have_content("making something visible to the world")
+  end
 end


### PR DESCRIPTION
Fixes #372 

Removes the text under open accessibility in the create work page. Updated specs to accommodate the change.
