### PR TITLE
Removes TODOs from model spec test.

### DIFF
--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -22,18 +22,6 @@ RSpec.describe Article do
     end
   end
 
-  #  describe "created for someone (proxy)" do
-  #    TODO : Examine this feature in Hyrax 2
-  #    let(:work) { described_class.new(title: ['demoname']) { |gw| gw.apply_depositor_metadata("user") } }
-  #    let(:transfer_to) { create(:user) }
-
-  #    it "transfers the request" do
-  #      work.on_behalf_of = transfer_to.user_key
-  #      expect(ContentDepositorChangeEventJob).to receive(:perform_later).once
-  #      work.save!
-  #    end
-  #  end
-
   describe "delegations" do
     let(:work) { described_class.new { |gw| gw.apply_depositor_metadata("user") } }
     let(:proxy_depositor) { create(:user) }
@@ -47,48 +35,6 @@ RSpec.describe Article do
       expect(work.proxy_depositor).to eq proxy_depositor.user_key
     end
   end
-
-  #  describe "trophies" do
-  #    TODO : Examine these features in Hyrax 2
-  #    let(:user) { create(:user) }
-  #    let(:w) { create(:work, user: user) }
-  #    let!(:t) { Trophy.create(user_id: user.id, work_id: w.id) }
-  #
-  #    it "has a trophy" do
-  #      expect(Trophy.where(work_id: w.id).count).to eq 1
-  #    end
-  #    it "removes all trophies when work is deleted" do
-  #      w.destroy
-  #      expect(Trophy.where(work_id: w.id).count).to eq 0
-  #    end
-  #  end
-
-  #  describe "featured works" do
-  #    TODO : Examine these features in Hyrax 2
-  #    let(:work) { create(:public_work) }
-  #
-  #    before { FeaturedWork.create(work_id: work.id) }
-
-  #    subject { work }
-
-  #    it { is_expected.to be_featured }
-
-  #    context "when a previously featured work is deleted" do
-  #      it "deletes the featured work as well" do
-  #        expect { work.destroy }.to change { FeaturedWork.all.count }.from(1).to(0)
-  #      end
-  #    end
-
-  #    context "when the work becomes private" do
-  #      it "deletes the featured work" do
-  #        expect do
-  #          work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-  #          work.save!
-  #        end.to change { FeaturedWork.all.count }.from(1).to(0)
-  #        expect(work).not_to be_featured
-  #      end
-  #    end
-  #  end
 
   describe "metadata" do
     it { is_expected.to respond_to(:relative_path) }

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -22,18 +22,6 @@ RSpec.describe Dataset do
     end
   end
 
-  #  describe "created for someone (proxy)" do
-  #    TODO:  Determine if this is covered in Hyrax 2
-  #    let(:work) { described_class.new(title: ['demoname']) { |gw| gw.apply_depositor_metadata("user") } }
-  #    let(:transfer_to) { create(:user) }
-
-  #    it "transfers the request" do
-  #      work.on_behalf_of = transfer_to.user_key
-  #      expect(ContentDepositorChangeEventJob).to receive(:perform_later).once
-  #      work.save!
-  #    end
-  #  end
-
   describe "delegations" do
     let(:work) { described_class.new { |gw| gw.apply_depositor_metadata("user") } }
     let(:proxy_depositor) { create(:user) }
@@ -47,47 +35,6 @@ RSpec.describe Dataset do
       expect(work.proxy_depositor).to eq proxy_depositor.user_key
     end
   end
-
-  #  describe "trophies" do
-  #    TODO: Is this covered in Hyrax 2
-  #    let(:user) { create(:user) }
-  #    let(:w) { create(:work, user: user) }
-  #    let!(:t) { Trophy.create(user_id: user.id, work_id: w.id) }
-
-  #    it "has a trophy" do
-  #      expect(Trophy.where(work_id: w.id).count).to eq 1
-  #    end
-  #    it "removes all trophies when work is deleted" do
-  #      w.destroy
-  #      expect(Trophy.where(work_id: w.id).count).to eq 0
-  #    end
-  #  end
-
-  #  describe "featured works" do
-  #    let(:work) { create(:public_work) }
-
-  #    before { FeaturedWork.create(work_id: work.id) }
-
-  #    subject { work }
-
-  #    it { is_expected.to be_featured }
-
-  #    context "when a previously featured work is deleted" do
-  #      it "deletes the featured work as well" do
-  #        expect { work.destroy }.to change { FeaturedWork.all.count }.from(1).to(0)
-  #      end
-  #    end
-
-  #    context "when the work becomes private" do
-  #      it "deletes the featured work" do
-  #        expect do
-  #          work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-  #          work.save!
-  #        end.to change { FeaturedWork.all.count }.from(1).to(0)
-  #        expect(work).not_to be_featured
-  #      end
-  #    end
-  #  end
 
   describe "metadata" do
     it { is_expected.to respond_to(:relative_path) }

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -22,18 +22,6 @@ RSpec.describe Document do
     end
   end
 
-  #  describe "created for someone (proxy)" do
-  #    TODO :  Examine feature in Hyrax 2
-  #    let(:work) { described_class.new(title: ['demoname']) { |gw| gw.apply_depositor_metadata("user") } }
-  #    let(:transfer_to) { create(:user) }
-
-  #    it "transfers the request" do
-  #      work.on_behalf_of = transfer_to.user_key
-  #      expect(ContentDepositorChangeEventJob).to receive(:perform_later).once
-  #      work.save!
-  #    end
-  #  end
-
   describe "delegations" do
     let(:work) { described_class.new { |gw| gw.apply_depositor_metadata("user") } }
     let(:proxy_depositor) { create(:user) }
@@ -47,48 +35,6 @@ RSpec.describe Document do
       expect(work.proxy_depositor).to eq proxy_depositor.user_key
     end
   end
-
-  #  describe "trophies" do
-  #    TODO: Examine features in Hyrax 2
-  #    let(:user) { create(:user) }
-  #    let(:w) { create(:work, user: user) }
-  #    let!(:t) { Trophy.create(user_id: user.id, work_id: w.id) }
-
-  #    it "has a trophy" do
-  #      expect(Trophy.where(work_id: w.id).count).to eq 1
-  #    end
-  #    it "removes all trophies when work is deleted" do
-  #      w.destroy
-  #      expect(Trophy.where(work_id: w.id).count).to eq 0
-  #    end
-  #  end
-
-  #  describe "featured works" do
-  #   TODO: Examine features in Hyrax 2
-  #    let(:work) { create(:public_work) }
-  #
-  #    before { FeaturedWork.create(work_id: work.id) }
-  #
-  #    subject { work }
-  #
-  #    it { is_expected.to be_featured }
-  #
-  #    context "when a previously featured work is deleted" do
-  #      it "deletes the featured work as well" do
-  #        expect { work.destroy }.to change { FeaturedWork.all.count }.from(1).to(0)
-  #      end
-  #    end
-
-  #    context "when the work becomes private" do
-  #      it "deletes the featured work" do
-  #        expect do
-  #          work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-  #          work.save!
-  #        end.to change { FeaturedWork.all.count }.from(1).to(0)
-  #        expect(work).not_to be_featured
-  #      end
-  #    end
-  #  end
 
   describe "metadata" do
     it { is_expected.to respond_to(:relative_path) }

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -22,18 +22,6 @@ RSpec.describe Etd do
     end
   end
 
-  #  describe "created for someone (proxy)" do
-  #    TODO: Examine this feature in Hyrax 2
-  #    let(:work) { described_class.new(title: ['demoname']) { |gw| gw.apply_depositor_metadata("user") } }
-  #    let(:transfer_to) { create(:user) }
-
-  #    it "transfers the request" do
-  #      work.on_behalf_of = transfer_to.user_key
-  #      expect(ContentDepositorChangeEventJob).to receive(:perform_later).once
-  #      work.save!
-  #    end
-  #  end
-
   describe "delegations" do
     let(:work) { described_class.new { |gw| gw.apply_depositor_metadata("user") } }
     let(:proxy_depositor) { create(:user) }
@@ -47,48 +35,6 @@ RSpec.describe Etd do
       expect(work.proxy_depositor).to eq proxy_depositor.user_key
     end
   end
-
-  #  describe "trophies" do
-  #    TODO:
-  #    let(:user) { create(:user) }
-  #    let(:w) { create(:work, user: user) }
-  #    let!(:t) { Trophy.create(user_id: user.id, work_id: w.id) }
-
-  #    it "has a trophy" do
-  #      expect(Trophy.where(work_id: w.id).count).to eq 1
-  #    end
-  #    it "removes all trophies when work is deleted" do
-  #      w.destroy
-  #      expect(Trophy.where(work_id: w.id).count).to eq 0
-  #    end
-  #  end
-
-  #  describe "featured works" do
-  #    TODO: Examine this feature in Hyrax 2
-  #    let(:work) { create(:public_work) }
-
-  #    before { FeaturedWork.create(work_id: work.id) }
-
-  #    subject { work }
-
-  #    it { is_expected.to be_featured }
-
-  #    context "when a previously featured work is deleted" do
-  #      it "deletes the featured work as well" do
-  #        expect { work.destroy }.to change { FeaturedWork.all.count }.from(1).to(0)
-  #      end
-  #    end
-
-  #    context "when the work becomes private" do
-  #      it "deletes the featured work" do
-  #        expect do
-  #          work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-  #          work.save!
-  #        end.to change { FeaturedWork.all.count }.from(1).to(0)
-  #        expect(work).not_to be_featured
-  #      end
-  #    end
-  #  end
 
   describe "metadata" do
     it { is_expected.to respond_to(:relative_path) }

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -20,18 +20,6 @@ describe GenericWork do
     end
   end
 
-  #  describe "created for someone (proxy)" do
-  #    TODO:  Examine these features in Hyrax 2
-  #    let(:work) { described_class.new(title: ['demoname']) { |gw| gw.apply_depositor_metadata("user") } }
-  #    let(:transfer_to) { create(:user) }
-
-  #    it "transfers the request" do
-  #      work.on_behalf_of = transfer_to.user_key
-  #      expect(ContentDepositorChangeEventJob).to receive(:perform_later).once
-  #      work.save!
-  #    end
-  #  end
-
   describe "delegations" do
     let(:work) { described_class.new { |gw| gw.apply_depositor_metadata("user") } }
     let(:proxy_depositor) { create(:user) }
@@ -45,48 +33,6 @@ describe GenericWork do
       expect(work.proxy_depositor).to eq proxy_depositor.user_key
     end
   end
-
-  #  describe "trophies" do
-  #   TODO:  Examine these features in Hyrax 2
-  #    let(:user) { create(:user) }
-  #    let(:w) { create(:work, user: user) }
-  #    let!(:t) { Trophy.create(user_id: user.id, work_id: w.id) }
-
-  #    it "has a trophy" do
-  #      expect(Trophy.where(work_id: w.id).count).to eq 1
-  #    end
-  #    it "removes all trophies when work is deleted" do
-  #      w.destroy
-  #      expect(Trophy.where(work_id: w.id).count).to eq 0
-  #    end
-  #  end
-
-  #  describe "featured works" do
-  #  TODO: Examine this feature in Hyrax 2
-  #   let(:work) { create(:public_work) }
-
-  #    before { FeaturedWork.create(work_id: work.id) }
-
-  #    subject { work }
-
-  #    it { is_expected.to be_featured }
-
-  #    context "when a previously featured work is deleted" do
-  #      it "deletes the featured work as well" do
-  #        expect { work.destroy }.to change { FeaturedWork.all.count }.from(1).to(0)
-  #      end
-  #    end
-
-  #    context "when the work becomes private" do
-  #      it "deletes the featured work" do
-  #        expect do
-  #          work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-  #          work.save!
-  #        end.to change { FeaturedWork.all.count }.from(1).to(0)
-  #        expect(work).not_to be_featured
-  #      end
-  #    end
-  #  end
 
   describe "metadata" do
     it { is_expected.to respond_to(:relative_path) }

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -22,18 +22,6 @@ RSpec.describe Image do
     end
   end
 
-  #  describe "created for someone (proxy)" do
-  #    TODO:  Check these features in Hyrax 2
-  #    let(:work) { described_class.new(title: ['demoname']) { |gw| gw.apply_depositor_metadata("user") } }
-  #    let(:transfer_to) { create(:user) }
-
-  #    it "transfers the request" do
-  #      work.on_behalf_of = transfer_to.user_key
-  #      expect(ContentDepositorChangeEventJob).to receive(:perform_later).once
-  #      work.save!
-  #    end
-  #  end
-
   describe "delegations" do
     let(:work) { described_class.new { |gw| gw.apply_depositor_metadata("user") } }
     let(:proxy_depositor) { create(:user) }
@@ -47,46 +35,6 @@ RSpec.describe Image do
       expect(work.proxy_depositor).to eq proxy_depositor.user_key
     end
   end
-
-  #  describe "trophies" do
-  #    TODO:  Check these features in Hyrax 2
-  #   let(:user) { create(:user) }
-  #   let(:w) { create(:work, user: user) }
-  #   let!(:t) { Trophy.create(user_id: user.id, work_id: w.id) }
-
-  #   it "has a trophy" do
-  #     expect(Trophy.where(work_id: w.id).count).to eq 1
-  #   end
-  #   it "removes all trophies when work is deleted" do
-  #     w.destroy
-  #     expect(Trophy.where(work_id: w.id).count).to eq 0
-  #   end
-  #  end
-
-  #  describe "featured works" do
-  #    TODO:  Check these features in Hyrax 2
-  #    let(:work) { create(:public_work) }
-  #    before { FeaturedWork.create(work_id: work.id) }
-  #
-  #    subject { work }
-  #    it { is_expected.to be_featured }
-  #
-  #    context "when a previously featured work is deleted" do
-  #      it "deletes the featured work as well" do
-  #        expect { work.destroy }.to change { FeaturedWork.all.count }.from(1).to(0)
-  #      end
-  #    end
-
-  #    context "when the work becomes private" do
-  #      it "deletes the featured work" do
-  #        expect do
-  #          work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-  #          work.save!
-  #        end.to change { FeaturedWork.all.count }.from(1).to(0)
-  #        expect(work).not_to be_featured
-  #      end
-  #    end
-  #  end
 
   describe "metadata" do
     it { is_expected.to respond_to(:relative_path) }

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -22,18 +22,6 @@ RSpec.describe Medium do
     end
   end
 
-  #  describe "created for someone (proxy)" do
-  #    TODO: Examine how Hyrax 2 handles this coverage
-  #    let(:work) { described_class.new(title: ['demoname']) { |gw| gw.apply_depositor_metadata("user") } }
-  #    let(:transfer_to) { create(:user) }
-
-  #    it "transfers the request" do
-  #      work.on_behalf_of = transfer_to.user_key
-  #      expect(ContentDepositorChangeEventJob).to receive(:perform_later).once
-  #      work.save!
-  #    end
-  #  end
-
   describe "delegations" do
     let(:work) { described_class.new { |gw| gw.apply_depositor_metadata("user") } }
     let(:proxy_depositor) { create(:user) }
@@ -47,47 +35,6 @@ RSpec.describe Medium do
       expect(work.proxy_depositor).to eq proxy_depositor.user_key
     end
   end
-
-  #  describe "trophies" do
-  #    TODO:  Examine trophy coverage in Hyrax 2
-  #    let(:user) { create(:user) }
-  #    let(:w) { create(:work, user: user) }
-  #    let!(:t) { Trophy.create(user_id: user.id, work_id: w.id) }
-
-  #    it "has a trophy" do
-  #      expect(Trophy.where(work_id: w.id).count).to eq 1
-  #    end
-  #    it "removes all trophies when work is deleted" do
-  #      w.destroy
-  #      expect(Trophy.where(work_id: w.id).count).to eq 0
-  #    end
-  #  end
-
-  #  describe "featured works" do
-  #    let(:work) { create(:public_work) }
-
-  #    before { FeaturedWork.create(work_id: work.id) }
-
-  #    subject { work }
-
-  #    it { is_expected.to be_featured }
-
-  #    context "when a previously featured work is deleted" do
-  #      it "deletes the featured work as well" do
-  #        expect { work.destroy }.to change { FeaturedWork.all.count }.from(1).to(0)
-  #      end
-  #    end
-
-  #    context "when the work becomes private" do
-  #      it "deletes the featured work" do
-  #        expect do
-  #          work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-  #          work.save!
-  #        end.to change { FeaturedWork.all.count }.from(1).to(0)
-  #        expect(work).not_to be_featured
-  #      end
-  #    end
-  #  end
 
   describe "metadata" do
     it { is_expected.to respond_to(:relative_path) }

--- a/spec/models/student_work_spec.rb
+++ b/spec/models/student_work_spec.rb
@@ -22,18 +22,6 @@ RSpec.describe StudentWork do
     end
   end
 
-  #  describe "created for someone (proxy)" do
-  #    TODO: Examine feature in Hyrax 2
-  #    let(:work) { described_class.new(title: ['demoname']) { |gw| gw.apply_depositor_metadata("user") } }
-  #    let(:transfer_to) { create(:user) }
-
-  #    it "transfers the request" do
-  #      work.on_behalf_of = transfer_to.user_key
-  #      expect(ContentDepositorChangeEventJob).to receive(:perform_later).once
-  #      work.save!
-  #    end
-  #  end
-
   describe "delegations" do
     let(:work) { described_class.new { |gw| gw.apply_depositor_metadata("user") } }
     let(:proxy_depositor) { create(:user) }
@@ -47,48 +35,6 @@ RSpec.describe StudentWork do
       expect(work.proxy_depositor).to eq proxy_depositor.user_key
     end
   end
-
-  #  describe "trophies" do
-  #    TODO:  Examine feature in Hyrax 2
-  #    let(:user) { create(:user) }
-  #    let(:w) { create(:work, user: user) }
-  #    let!(:t) { Trophy.create(user_id: user.id, work_id: w.id) }
-
-  #    it "has a trophy" do
-  #      expect(Trophy.where(work_id: w.id).count).to eq 1
-  #    end
-  #    it "removes all trophies when work is deleted" do
-  #      w.destroy
-  #      expect(Trophy.where(work_id: w.id).count).to eq 0
-  #    end
-  #  end
-
-  #  describe "featured works" do
-  #    TODO:  Examine this feature in Hyrax 2
-  #    let(:work) { create(:public_work) }
-
-  #    before { FeaturedWork.create(work_id: work.id) }
-
-  #    subject { work }
-
-  #    it { is_expected.to be_featured }
-
-  #    context "when a previously featured work is deleted" do
-  #      it "deletes the featured work as well" do
-  #        expect { work.destroy }.to change { FeaturedWork.all.count }.from(1).to(0)
-  #      end
-  #    end
-
-  #    context "when the work becomes private" do
-  #      it "deletes the featured work" do
-  #        expect do
-  #          work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-  #          work.save!
-  #        end.to change { FeaturedWork.all.count }.from(1).to(0)
-  #        expect(work).not_to be_featured
-  #      end
-  #    end
-  #  end
 
   describe "metadata" do
     it { is_expected.to respond_to(:relative_path) }


### PR DESCRIPTION
Fixes #232 

Present short summary (50 characters or less)
These TODO's were copied over from the Scholar code.   It looks like this test coverage is now in Hyrax.

Proxies - Callbacks are pulled out of the model and added to a transfer request actor. Removing test from model. samvera/hyrax@90d9b7f

Featured Work - The test of featured works is done in the hyrax controller. https://github.com/samvera/hyrax/blob/5a9d1be16ee1a9150646384471992b03aab527a5/spec/controllers/hyrax/featured_works_controller_spec.rb. Removing test from model.

This PR removes the commented out code in the model specs.
