### PR TITLE
Fileset edit rights

### DIFF
--- a/app/services/hyrax/change_content_depositor_service.rb
+++ b/app/services/hyrax/change_content_depositor_service.rb
@@ -1,0 +1,18 @@
+module Hyrax
+  class ChangeContentDepositorService
+    # @param [ActiveFedora::Base] work
+    # @param [User] user
+    # @param [TrueClass, FalseClass] reset
+    def self.call(work, user, reset)
+      work.proxy_depositor = work.depositor
+      work.permissions = [] if reset
+      work.apply_depositor_metadata(user)
+      work.file_sets.each do |f|
+        f.apply_depositor_metadata(user)
+        f.save!
+      end
+      work.save!
+      work
+    end
+  end
+end

--- a/app/services/hyrax/change_content_depositor_service.rb
+++ b/app/services/hyrax/change_content_depositor_service.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hyrax
   class ChangeContentDepositorService
     # @param [ActiveFedora::Base] work
@@ -8,6 +9,8 @@ module Hyrax
       work.permissions = [] if reset
       work.apply_depositor_metadata(user)
       work.file_sets.each do |f|
+        # Clear the fileset permissions too!
+        f.permissions = [] if reset
         f.apply_depositor_metadata(user)
         f.save!
       end

--- a/spec/services/hyrax/change_content_depositor_service_spec.rb
+++ b/spec/services/hyrax/change_content_depositor_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+require 'rails_helper'
 RSpec.describe Hyrax::ChangeContentDepositorService do
   let!(:depositor) { create(:user) }
   let!(:receiver) { create(:user) }
@@ -40,11 +42,10 @@ RSpec.describe Hyrax::ChangeContentDepositorService do
       expect(work.edit_users).to contain_exactly(receiver.user_key)
     end
 
-    it "changes the depositor of the child file sets" do
+    it "excludes the depositor from the edit users of the child file sets" do
       file.reload
       expect(file.depositor).to eq receiver.user_key
-      expect(file.edit_users).to include(receiver.user_key, depositor.user_key)
+      expect(file.edit_users).to contain_exactly(receiver.user_key)
     end
   end
 end
-

--- a/spec/services/hyrax/change_content_depositor_service_spec.rb
+++ b/spec/services/hyrax/change_content_depositor_service_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe Hyrax::ChangeContentDepositorService do
+  let!(:depositor) { create(:user) }
+  let!(:receiver) { create(:user) }
+  let!(:file) do
+    create(:file_set, user: depositor)
+  end
+  let!(:work) do
+    create(:work, title: ['Test work'], user: depositor)
+  end
+
+  before do
+    work.members << file
+    described_class.call(work, receiver, reset)
+  end
+
+  context "by default, when permissions are not reset" do
+    let(:reset) { false }
+
+    it "changes the depositor and records an original depositor" do
+      work.reload
+      expect(work.depositor).to eq receiver.user_key
+      expect(work.proxy_depositor).to eq depositor.user_key
+      expect(work.edit_users).to include(receiver.user_key, depositor.user_key)
+    end
+
+    it "changes the depositor of the child file sets" do
+      file.reload
+      expect(file.depositor).to eq receiver.user_key
+      expect(file.edit_users).to include(receiver.user_key, depositor.user_key)
+    end
+  end
+
+  context "when permissions are reset" do
+    let(:reset) { true }
+
+    it "excludes the depositor from the edit users" do
+      work.reload
+      expect(work.depositor).to eq receiver.user_key
+      expect(work.proxy_depositor).to eq depositor.user_key
+      expect(work.edit_users).to contain_exactly(receiver.user_key)
+    end
+
+    it "changes the depositor of the child file sets" do
+      file.reload
+      expect(file.depositor).to eq receiver.user_key
+      expect(file.edit_users).to include(receiver.user_key, depositor.user_key)
+    end
+  end
+end
+


### PR DESCRIPTION
Fixes #362 

Work transfer does not reset edit rights on attached file_sets when the receiving user opts to remove depositor access.

Override change_content_depositor_service to clear the permissions for attached filesets as well.


```ruby
      work.file_sets.each do |f|
        f.permissions = [] if reset
        f.apply_depositor_metadata(user)
        f.save!
      end
```
Changes proposed in this pull request:
* Add override `app/services/hyrax/change_content_depositor_service.rb`
* Add override `spec/services/hyrax/change_content_depositor_service_spec.rb`
* Add `f.permissions = [] if reset` to fileset block and tweak specs.
