### PR TITLE
Customize note at top of batch upload form

### DIFF
--- a/app/views/hyrax/batch_uploads/_form.html.erb
+++ b/app/views/hyrax/batch_uploads/_form.html.erb
@@ -1,0 +1,22 @@
+<%= simple_form_for [hyrax, @form],
+                    html: {
+                      data: { behavior: 'work-form',
+                              'param-key' => @form.model_name.param_key },
+                      multipart: true
+                    } do |f| %>
+  <% provide :files_tab do %>
+    <p class="instructions"><%= t("hyrax.batch_uploads.files.instructions") %></p>
+    <p class="switch-upload-type"><%= t("hyrax.batch_uploads.files.upload_type_instructions") %>
+      <%= link_to t("hyrax.batch_uploads.files.button_label"), [main_app, :new, Hyrax.primary_work_type.model_name.singular_route_key] %>
+    </p>
+  <% end %>
+  <%= render 'hyrax/base/guts4form', f: f, tabs: %w[files metadata relationships] %>
+  <%= f.hidden_field :payload_concern, value: @form.payload_concern %>
+<% end %>
+
+<script type="text/javascript">
+  Blacklight.onLoad(function() {
+    $("#fileupload").fileupload('option', 'downloadTemplateId', 'batch-template-download')
+  });
+</script>
+

--- a/app/views/hyrax/batch_uploads/_form.html.erb
+++ b/app/views/hyrax/batch_uploads/_form.html.erb
@@ -6,9 +6,7 @@
                     } do |f| %>
   <% provide :files_tab do %>
     <p class="instructions"><%= t("hyrax.batch_uploads.files.instructions") %></p>
-    <p class="switch-upload-type"><%= t("hyrax.batch_uploads.files.upload_type_instructions") %>
-      <%= link_to t("hyrax.batch_uploads.files.button_label"), [main_app, :new, Hyrax.primary_work_type.model_name.singular_route_key] %>
-    </p>
+    <p class="switch-upload-type"> <%= t("hyrax.batch_uploads.files.upload_type_instructions") %><%= link_to "Add New " + @form.payload_concern.constantize.model_name.human.titleize, main_app.new_polymorphic_path(@form.payload_concern.constantize) %>.</p> 
   <% end %>
   <%= render 'hyrax/base/guts4form', f: f, tabs: %w[files metadata relationships] %>
   <%= f.hidden_field :payload_concern, value: @form.payload_concern %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -55,6 +55,9 @@ en:
     base:
       form_progress:
         required_agreement: Check distribution license
+    batch_uploads:
+      files:
+        upload_type_instructions: 'Note: To create a single work for all the files, '
     passive_consent_to_agreement: I have read and agree to the
     homepage:
       featured_works:

--- a/spec/features/hyrax/batch_create_spec.rb
+++ b/spec/features/hyrax/batch_create_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Batch creation of works', type: :feature do
   end
 
   it "renders the batch create form" do
-    visit hyrax.new_batch_upload_path
+    visit hyrax.new_batch_upload_path(payload_concern: 'Document')
     expect(page).to have_content "Add New Works by Batch"
     within("li.active") do
       expect(page).to have_content("Files")
@@ -30,7 +30,7 @@ RSpec.describe 'Batch creation of works', type: :feature do
   end
 
   it 'defaults to public visibility' do
-    visit hyrax.new_batch_upload_path
+    visit hyrax.new_batch_upload_path(payload_concern: 'Document')
     expect(page).to have_checked_field('batch_upload_item_visibility_open')
   end
 

--- a/spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'hyrax/batch_uploads/_form.html.erb', type: :view do
+  let(:work) { Article.new }
+  let(:ability) { double('ability', current_user: user) } # rubocop:disable RSpec/VerifiedDoubles
+  let(:form) { Hyrax::Forms::BatchUploadForm.new(work, ability, controller) }
+  let(:user) { stub_model(User) }
+  let(:page) do
+    render
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  before do
+    stub_template "hyrax/base/_guts4form.html.erb" => "Form guts"
+    assign(:form, form)
+    allow(form).to receive(:payload_concern).and_return('Article')
+  end
+
+  it "draws the page" do
+    expect(page).to have_selector("form[action='/batch_uploads']")
+    expect(page).to have_selector("form[action='/batch_uploads'][data-behavior='work-form']")
+    expect(page).to have_selector("form[action='/batch_uploads'][data-param-key='batch_upload_item']")
+    # No title, because it's captured per file (e.g. Display label)
+    expect(page).not_to have_selector("input#generic_work_title")
+    expect(view.content_for(:files_tab)).to have_link("Add New Article", href: "/concern/articles/new")
+  end
+end


### PR DESCRIPTION
Fixes #401 

Change note and link at top of batch upload form for single work creation. Make the link dynamic so that it reflects the current work type.

Changes proposed in this pull request:
* Add hyrax override for `app/views/batch_uploads/_form.html.erb.rb`
* Add view spec
