### PR TITLE
Customize contact form

### DIFF
--- a/app/models/hyrax/contact_form.rb
+++ b/app/models/hyrax/contact_form.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+module Hyrax
+  class ContactForm
+    include ActiveModel::Model
+    attr_accessor :contact_method, :category, :name, :email, :subject, :message
+    validates :email, :name, :subject, :message, presence: true
+    validates :email, format: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i, allow_blank: true
+
+    # - can't use this without ActiveRecord::Base validates_inclusion_of :category, in: self.class.issue_types_for_locale
+
+    # They should not have filled out the `contact_method' field. That's there to prevent spam.
+    def spam?
+      contact_method.present?
+    end
+
+    # Declare the e-mail headers. It accepts anything the mail method
+    # in ActionMailer accepts.
+    def headers
+      {
+        subject: "#{Hyrax.config.subject_prefix} #{subject}",
+        to: Hyrax.config.contact_email,
+        from: email
+      }
+    end
+
+    def self.issue_types_for_locale
+      [
+        I18n.t('hyrax.contact_form.issue_types.depositing'),
+        I18n.t('hyrax.contact_form.issue_types.changing'),
+        I18n.t('hyrax.contact_form.issue_types.browsing'),
+        I18n.t('hyrax.contact_form.issue_types.reporting'),
+        I18n.t('hyrax.contact_form.issue_types.general')
+      ]
+    end
+  end
+end

--- a/app/views/hyrax/contact_form/_directions.html.erb
+++ b/app/views/hyrax/contact_form/_directions.html.erb
@@ -1,0 +1,1 @@
+<%= t('hyrax.contact_form.notice_html', href: link_to(t("hyrax.contact_form.help_resources_href"), main_app.help_path)) %>

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -18,14 +18,6 @@
 <%= form_for @contact_form, url: hyrax.contact_form_index_path,
                             html: { class: 'form-horizontal' } do |f| %>
   <%= f.text_field :contact_method, class: 'hide' %>
-  <div class="form-group">
-    <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 control-label" %>
-    <% issue_types = Hyrax::ContactForm.issue_types_for_locale.dup %>
-    <% issue_types.unshift([t('hyrax.contact_form.select_type'), nil]) %>
-    <div class="col-sm-10">
-      <%= f.select 'category', options_for_select(issue_types), {}, {class: 'form-control', required: true } %>
-    </div>
-  </div>
 
   <div class="form-group">
     <%= f.label :name, t('hyrax.contact_form.name_label'), class: "col-sm-2 control-label" %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -58,6 +58,10 @@ en:
     batch_uploads:
       files:
         upload_type_instructions: 'Note: To create a single work for all the files, '
+    contact_form:
+      header: Contact the Scholar@UC Team
+      notice_html: 'Please us this form to send questions, feedback, or report a problem to the Scholar@UC team. You can also check %{href} for more information'
+      help_resources_href: 'Help Resources'
     passive_consent_to_agreement: I have read and agree to the
     homepage:
       featured_works:

--- a/spec/controllers/hyrax/contact_form_controller_spec.rb
+++ b/spec/controllers/hyrax/contact_form_controller_spec.rb
@@ -49,12 +49,6 @@ RSpec.describe Hyrax::ContactFormController do
         its(:notice) { is_expected.to eq("Thank you for your message!") }
       end
 
-      context "without a category" do
-        let(:params)  { required_params.except(:category) }
-
-        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. You must complete the Captcha to confirm the form. Category can't be blank") }
-      end
-
       context "without a name" do
         let(:params)  { required_params.except(:name) }
 

--- a/spec/features/hyrax/contact_form_spec.rb
+++ b/spec/features/hyrax/contact_form_spec.rb
@@ -19,12 +19,13 @@ RSpec.describe "Sending an email via the contact form", type: :feature do
     it "sends mail" do
       visit '/'
       click_link "Contact", match: :first
-      expect(page).to have_content "Contact Form"
+      expect(page).to have_content "Contact the Scholar@UC Team"
+      expect(page).to have_link "Help Resources"
+      expect(page).not_to have_content "Issue Type"
       fill_in "Your Name", with: "Test McPherson"
       fill_in "Your Email", with: "archivist1@example.com"
       fill_in "Message", with: "I am contacting you regarding ScholarSphere."
       fill_in "Subject", with: "My Subject is Cool"
-      select "Depositing content", from: "Issue Type"
       click_button "Send"
       expect(page).to have_content "Thank you for your message!"
     end


### PR DESCRIPTION
Fixes #393 
Customize contact form to match Scholar.

Changes proposed in this pull request:
* Change flash notice and embed link to Help Resources
* Change header and add "Scholar@UC Team"
* Remove `Issue` form select

<img width="1280" alt="screen shot 2018-09-13 at 4 30 53 pm" src="https://user-images.githubusercontent.com/1069588/45514418-46b21c80-b773-11e8-934c-50c74c36cd55.png">

