### PR TITLE
Check for presence and whitelist payload_concern param on batch upload

### DIFF
--- a/app/controllers/hyrax/batch_uploads_controller.rb
+++ b/app/controllers/hyrax/batch_uploads_controller.rb
@@ -18,5 +18,16 @@ module Hyrax
                                      attributes_for_actor.to_h.merge!(model: klass),
                                      operation)
       end
+
+      # Hyrax override to check for presense and validity of payload_concern param
+      def build_form
+        super
+        raise ActionController::RoutingError, 'Not Found' unless work_type_specified?
+        @form.payload_concern = params[:payload_concern]
+      end
+
+      def work_type_specified?
+        Hyrax.config.registered_curation_concern_types.include? params[:payload_concern]
+      end
   end
 end

--- a/spec/controllers/hyrax/batch_uploads_controller_spec.rb
+++ b/spec/controllers/hyrax/batch_uploads_controller_spec.rb
@@ -82,5 +82,26 @@ describe Hyrax::BatchUploadsController do
         expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.dashboard_works_path(locale: 'en')
       end
     end
+    context "with blank payload_concern param" do
+      let(:batch_upload_item) do
+        {}
+      end
+
+      it 'returns not found' do
+        allow(BatchCreateJob).to receive(:perform_later)
+        expect { get :new, params: post_params }.to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    context "with bad payload_concern param" do
+      let(:batch_upload_item) do
+        { payload_concern: 'foo' }
+      end
+
+      it 'returns not found' do
+        allow(BatchCreateJob).to receive(:perform_later)
+        expect { get :new, params: post_params }.to raise_error(ActionController::RoutingError)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #406 

Checks for presence and validity of payload_concern params on batch upload :new action. If the param is absent or not valid, show a `Not Found` routing error.

I attempted to override the new action in the controller but had difficulty because this is very form oriented and any new action override would result in error.

Changes proposed in this pull request:
* Add form builder function override to batch_uploads_controller.rb
* Add test to batch_uploads_controller_spec.rb
