### PR TITLE
Make active form tab agree with content

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,4 +33,5 @@
 //= require lodash
 //= require license-selector
 //= require select-license
+//= require form-tab-nav
 

--- a/app/assets/javascripts/form-tab-nav.js
+++ b/app/assets/javascripts/form-tab-nav.js
@@ -1,0 +1,8 @@
+$(document).ready( function() {
+  $("a[href='#files']").last().click( function() {
+    //    Remove .active class from all .tab class elements
+    $('li').removeClass('active');
+    //    Add .active class to currently clicked element
+    $("a[href='#files']").parent().addClass('active');
+  });
+});

--- a/spec/features/form_tab_nav_js_spec.rb
+++ b/spec/features/form_tab_nav_js_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Navigating between tabs in create work form', :js, :workflow do
+  let(:user) { create(:user) }
+  let!(:ability) { ::Ability.new(user) }
+
+  before do
+    # Grant the user access to deposit into an admin set.
+    create(:permission_template_access,
+           :deposit,
+           permission_template: create(:permission_template, with_admin_set: true, with_active_workflow: true),
+           agent_type: 'user',
+           agent_id: user.user_key)
+    # stub out characterization. Travis doesn't have fits installed, and it's not relevant to the test.
+    allow(CharacterizeJob).to receive(:perform_later)
+
+    sign_in user
+    visit '/dashboard'
+
+    within('.sidebar') do
+      click_link 'Works'
+    end
+    click_link "Add new work"
+    expect(page).to have_link('Add New', href: '/concern/generic_works/new?locale=en')
+    click_link('Add New', href: '/concern/generic_works/new?locale=en')
+  end
+
+  it 'matches active tab to form content' do
+    click_link "Attaching a file"
+    expect(page).to have_content('You can add one or more files ')
+    expect(page).to have_selector("ul li.active a", 'Files')
+  end
+end


### PR DESCRIPTION
Fixes #409 

Bootstrap js tabs can get out of sync with their content. Sometimes links with anchors are not acknowledged by the nav and won't show the correct tab as active. I added a small script to watch for changes to the anchor and and click correct tab when a change is detected.

Changes proposed in this pull request:
* Add `app/assets/javascripts/form-tab-nav.js`
* Add feature spec `spec/features/form_tab_nav_js_spec.rb`
