### PR TITLE
Redirect to new_classify_concern_path after login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
       if !resource.waived_welcome_page
         Rails.application.routes.url_helpers.welcome_page_index_path
       else
-        Hyrax::Engine.routes.url_helpers.root_path
+        Rails.application.routes.url_helpers.new_classify_concern_path
       end
     end
 

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'sign in when user has waived welcome page, type', :feature do
+describe 'sign in and redirects user to what are you uploading page, type', :feature do
   let(:user) { FactoryBot.create(:user, waived_welcome_page: true) }
   let(:password) { FactoryBot.attributes_for(:user).fetch(:password) }
 


### PR DESCRIPTION
Fixes #408 

Modifies the behavior of the login to redirect to the new_classify_concern_path (What are you uploading? page) if the user has modified their profile and has accepted to skip the welcome page.