### PR TITLE
Change hyrax initializers for contact form

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -28,10 +28,10 @@ Hyrax.config do |config|
   # config.admin_set_predicate = ::RDF::DC.isPartOf
 
   # Email recipient of messages sent via the contact form
-  # config.contact_email = "repo-admin@example.org"
+  config.contact_email = "scholar@uc.edu"
 
   # Text prefacing the subject entered in the contact form
-  # config.subject_prefix = "Contact form:"
+  config.subject_prefix = "Scholar@UC Contact form:"
 
   # How many notifications should be displayed on the dashboard
   # config.max_notifications_for_dashboard = 5

--- a/spec/controllers/hyrax/contact_form_controller_spec.rb
+++ b/spec/controllers/hyrax/contact_form_controller_spec.rb
@@ -95,6 +95,17 @@ RSpec.describe Hyrax::ContactFormController do
       end
     end
 
+    describe "test configuration values" do
+      context "for the contact form" do
+        it "check contact email" do
+          expect(Hyrax.config.contact_email).to eq 'scholar@uc.edu'
+        end
+        it "check form name" do
+          expect(Hyrax.config.subject_prefix).to eq 'Scholar@UC Contact form:'
+        end
+      end
+    end
+
     context "when encoutering a RuntimeError" do
       let(:logger) { double(info?: true) }
 


### PR DESCRIPTION
Fixes #405 
Updated the contact email and the subject prefix for the contact form in the hyrax initializer, as well as tested the values in a spec.