### PR TITLE
People search label and placeholder text

### DIFF
--- a/app/views/hyrax/users/_search_form.html.erb
+++ b/app/views/hyrax/users/_search_form.html.erb
@@ -1,8 +1,8 @@
 <div>
   <% # this form is used on the public users page and the admin users page, so submit to current path %>
   <%= form_tag request.path, method: :get, class: "form-search" do %>
-    <label class="sr-only" for="user_search">Search Users</label>
-    <%= text_field_tag :uq, params[:uq], class: "q", placeholder: "Search Users", size: '30', type: "search", id: "user_search" %>
+    <label class="sr-only" for="user_search"><%= t('hyrax.users.search_placeholder') %></label>
+    <%= text_field_tag :uq, params[:uq], class: "q", placeholder: t('hyrax.users.search_placeholder'), size: '30', type: "search", id: "user_search" %>
     <%= hidden_field_tag :sort, params[:sort], id: 'user_sort' %>
     <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:uq, :sort, :qt, :page, :utf8)) %>
     <button type="submit" class="btn btn-primary" id="user_submit"> 

--- a/app/views/hyrax/users/_search_form.html.erb
+++ b/app/views/hyrax/users/_search_form.html.erb
@@ -1,0 +1,13 @@
+<div>
+  <% # this form is used on the public users page and the admin users page, so submit to current path %>
+  <%= form_tag request.path, method: :get, class: "form-search" do %>
+    <label class="sr-only" for="user_search">Search Users</label>
+    <%= text_field_tag :uq, params[:uq], class: "q", placeholder: "Search Users", size: '30', type: "search", id: "user_search" %>
+    <%= hidden_field_tag :sort, params[:sort], id: 'user_sort' %>
+    <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:uq, :sort, :qt, :page, :utf8)) %>
+    <button type="submit" class="btn btn-primary" id="user_submit"> 
+      <i class="glyphicon glyphicon-search"></i> Go
+    </button>
+  <% end %>
+</div>
+

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -77,6 +77,8 @@ en:
     pages:
       tabs:
         agreement_page: 'Distribution License'
+    users:
+      search_placeholder: 'Search People'
     workform_help_html: '<p>The more descriptive information you provide the better we can serve your needs.</p>'
     workform_attach_file_html: '<p>%{href} is highly recommended but not required.</p>'
     workform_attach_file_href: 'Attaching a file'

--- a/spec/features/hyrax/users_spec.rb
+++ b/spec/features/hyrax/users_spec.rb
@@ -72,6 +72,12 @@ RSpec.describe "User Spec", type: :feature do
     let(:profile2_path) { Hyrax::Engine.routes.url_helpers.user_path(user2, locale: 'en') }
     let(:profiles_path) { Hyrax::Engine.routes.url_helpers.users_path }
 
+    it "has a Search People field label and placeholder text" do
+      visit profiles_path
+      expect(page).to have_css("label", text: "Search People")
+      expect(page).to have_field(id: 'user_search', placeholder: "Search People")
+    end
+
     context "when the user doesn't own works" do
       before do
         visit profiles_path


### PR DESCRIPTION
Fixes #407 

Add Hyrax override to change label and placeholder text for people search.

Changes proposed in this pull request:
* add view partial override `app/views/hyrax/users/_search_form.html.erb`
* add i18n translation for 'People Search'
* Add spec test
