### PR TITLE
Update Collection Form

### DIFF
--- a/app/assets/javascripts/select-license.js
+++ b/app/assets/javascripts/select-license.js
@@ -1,5 +1,5 @@
 var ls = function() {
-      $('<a href="#" id="license-wizard" class="pull-right btn btn-success selector">License Wizard</a>')
+      $('<a href="#" id="license-wizard" class="pull-left btn btn-success selector">License Wizard</a>')
       .insertBefore('.rights-selector')
       .licenseSelector({
         // Options

--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require Hyrax::Engine.root.join('app/forms/hyrax/forms/collection_form.rb')
+module Hyrax
+  module Forms
+    class CollectionForm
+      self.terms = [:title, :creator, :description, :license, :thumbnail_id, :representative_id, :visibility]
+
+      self.required_fields = [:title, :creator, :description, :license]
+
+      def self.model_attributes(_)
+        attrs = super
+        attrs[:title] = Array(attrs[:title]) if attrs[:title]
+        attrs[:description] = Array(attrs[:description]) if attrs[:description]
+        attrs
+      end
+
+      # Terms that appear above the accordion
+      def primary_terms
+        [:title, :creator, :description, :license]
+      end
+
+      # Terms that appear within the accordion
+      def secondary_terms
+        []
+      end
+
+      def title
+        @attributes['title'].first || ''
+      end
+
+      def description
+        @attributes['description'].first || ''
+      end
+    end
+  end
+end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -7,4 +7,16 @@ class Collection < ActiveFedora::Base
   # You can replace these metadata if they're not suitable
   include Hyrax::BasicMetadata
   self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
+
+  def self.multiple?(field)
+    if [:title, :description].include? field.to_sym
+      false
+    else
+      super
+    end
+  end
+
+  def multiple?(field)
+    CollectionForm.multiple? field
+  end
 end

--- a/app/views/hyrax/dashboard/collections/edit.html.erb
+++ b/app/views/hyrax/dashboard/collections/edit.html.erb
@@ -1,0 +1,12 @@
+<% provide :page_title, construct_page_title( t('.header', type_title: @collection.collection_type.title, title: @form.title) ) %>
+
+<% provide :page_header do %>
+  <h1><span class="fa fa-edit" aria-hidden="true"></span><%= t('.header', type_title: @collection.collection_type.title, title: @form.title) %></h1>
+<% end %>
+
+<div class="row">
+  <div class="col-md-12">
+    <%= render 'flash_msg' %>
+    <%= render 'form' %>
+  </div>
+</div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -50,6 +50,11 @@ en:
           rights_statement_tesim: Rights Statement
           subject_tesim: Subject
           title_tesim: Title
+  simple_form:
+    labels:
+      defaults:
+        description: Description
+        license: Rights
   hyrax:
     active_consent_to_agreement: I have read and agree to the
     base:

--- a/spec/features/hyrax/dashboard/collection_spec.rb
+++ b/spec/features/hyrax/dashboard/collection_spec.rb
@@ -235,6 +235,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
   describe 'create collection' do
     let(:title) { "Test Collection" }
+    let(:creator) { "Test Creator" }
     let(:description) { "Description for collection we are testing." }
 
     context 'when user can create collections of multiple types' do
@@ -254,20 +255,21 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         click_on('Create collection')
 
         expect(page).to have_selector('h1', text: 'New User Collection')
-        expect(page).to have_selector "input.collection_title.multi_value"
-
-        click_link('Additional fields')
-        expect(page).to have_selector "input.collection_creator.multi_value"
+        expect(page).to have_selector "input#collection_title"
+        expect(page).to have_selector "input#collection_creator"
 
         title_element = find_by_id("collection_title")
         title_element.set("Test Collection") # Add whitespace to test it getting removed
 
-        fill_in('Abstract or Summary', with: description)
-        fill_in('Related URL', with: 'http://example.com/')
+        creator_element = find_by_id("collection_creator")
+        creator_element.set("Test Creator") # Add whitespace to test it getting removed
+
+        fill_in('Description', with: description)
         select('Attribution 4.0 International', from: 'License')
 
         click_button("Save")
         expect(page).to have_content title
+        find("input#collection_creator").should have_content(:creator)
         expect(page).to have_content description
       end
 
@@ -290,17 +292,16 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
           click_link "New Collection"
         end
         expect(page).to have_selector('h1', text: 'New User Collection')
-        expect(page).to have_selector "input.collection_title.multi_value"
-
-        click_link('Additional fields')
-        expect(page).to have_selector "input.collection_creator.multi_value"
+        expect(page).to have_selector "input#collection_title"
+        expect(page).to have_selector "input#collection_creator"
 
         fill_in('Title', with: title)
-        fill_in('Abstract or Summary', with: description)
-        fill_in('Related URL', with: 'http://example.com/')
+        fill_in('Creator', with: creator)
+        fill_in('Description', with: description)
 
         click_button("Save")
         expect(page).to have_content title
+        find("input#collection_creator").should have_content(:creator)
         expect(page).to have_content description
       end
     end
@@ -858,7 +859,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
           creators = ["Dorje Trollo", "Vajrayogini"]
 
           fill_in('Title', with: new_title)
-          fill_in('Abstract or Summary', with: new_description)
+          fill_in('Description', with: new_description)
           fill_in('Creator', with: creators.first)
           within('.panel-footer') do
             click_button('Save changes')

--- a/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'hyrax/dashboard/collections/edit.html.erb', type: :view do
+  let(:collection) { build(:collection, id: 'xyz123z4', title: ["Make Collections Great Again"]) }
+  let(:form) { Hyrax::Forms::CollectionForm.new(collection, double, double) }
+
+  before do
+    assign(:collection, collection)
+    assign(:form, form)
+    stub_template '_form.html.erb' => 'my-edit-form partial'
+    stub_template '_flash_msg.html.erb' => 'flash_msg partial'
+
+    render
+  end
+
+  it 'displays the page' do
+    expect(rendered).to have_content 'my-edit-form partial'
+    expect(rendered).to have_content 'flash_msg partial'
+  end
+end


### PR DESCRIPTION
Fixes #399 

Merged the collection form from Scholar to ucrate. Made all fields except creator single value (required pulling in the edit.html to fix the displayed title), moved the license wizard to the left side, and updated the specs.