### PR TITLE
Set max sidekiq retries to 3

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,5 @@
 ---
+max_retries: 3
 :queues:
   - default
   - ingest


### PR DESCRIPTION
Fixes #431 

Set the maximum sidekiq retries to 3.

Changes proposed in this pull request:
* `config/sidekiq.yml`
