### PR TITLE
Fix collection license persistence

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -8,8 +8,10 @@ class Collection < ActiveFedora::Base
   include Hyrax::BasicMetadata
   self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
 
+  property :license, predicate: ::RDF::Vocab::DC.rights, multiple: false
+
   def self.multiple?(field)
-    if [:title, :description].include? field.to_sym
+    if [:title, :description, :license].include? field.to_sym
       false
     else
       super

--- a/spec/features/hyrax/collection_spec.rb
+++ b/spec/features/hyrax/collection_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'collection', type: :feature, js: true, clean_repo: true do
 
   describe 'collection show page' do
     let(:collection) do
-      create(:public_collection, user: user, description: ['collection description'], collection_type_settings: :nestable)
+      create(:public_collection, user: user, license: 'http://creativecommons.org/licenses/by-nc-nd/4.0/', description: ['collection description'], collection_type_settings: :nestable)
     end
     let!(:work1) { create(:work, title: ["King Louie"], member_of_collections: [collection], user: user) }
     let!(:work2) { create(:work, title: ["King Kong"], member_of_collections: [collection], user: user) }
@@ -29,6 +29,7 @@ RSpec.describe 'collection', type: :feature, js: true, clean_repo: true do
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
       expect(page).to have_content(collection.title.first)
       expect(page).to have_content(collection.description.first)
+      expect(page).to have_content(collection.license.first)
       expect(page).to have_content("Collection Details")
       # Should not show title and description a second time
       expect(page).not_to have_css('.metadata-collections', text: collection.title.first)


### PR DESCRIPTION
Fixes #438 

Collection license form values weren't persisting due to single/multi value issue. 
Add property override to local collection model and the problem is resolved.
