### PR TITLE
Disable cloud upload for batch create

### DIFF
--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -1,0 +1,63 @@
+     <div id="fileupload">
+        <!-- Redirect browsers with JavaScript disabled to the origin page -->
+        <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>" /></noscript>
+        <!-- The table listing the files available for upload/download -->
+        <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
+        <% if Hyrax.config.browse_everything? %>
+          <%= t('hyrax.base.form_files.local_upload_browse_everything_html', contact_href: link_to(t("hyrax.upload.alert.contact_href_text"), hyrax.contact_form_index_path)) %>
+        <% else %>
+          <%= t('hyrax.base.form_files.local_upload_html') %>
+        <% end %>
+        <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
+        <div class="fileupload-buttonbar">
+          <div class="row">
+            <div class="col-xs-12">
+                <!-- The fileinput-button span is used to style the file input field as button -->
+                <span id="addfiles" class="btn btn-success fileinput-button">
+                    <span class="glyphicon glyphicon-plus"></span>
+                    <span>Add files...</span>
+                    <input type="file" name="files[]" multiple />
+                </span>
+                <!-- The fileinput-button span is used to style the file input field as button -->
+                <span id="addfolder" class="btn btn-success fileinput-button">
+                    <span class="glyphicon glyphicon-plus"></span>
+                    <span>Add folder...</span>
+                    <input type="file" name="files[]" multiple directory webkitdirectory />
+                </span>
+                <% if Hyrax.config.browse_everything? %>
+                  <%= button_tag(type: 'button', class: 'btn btn-success', id: "browse-btn",
+                    'data-toggle' => 'browse-everything', 'data-route' => browse_everything_engine.root_path,
+                    'data-target' => "#{f.object.persisted? ? "#edit_#{f.object.model.model_name.param_key}_#{f.object.model.id}" : "#new_#{f.object.model.model_name.param_key}"}" ) do %>
+                    <span class="glyphicon glyphicon-plus"></span>
+                    <%= t('hyrax.upload.browse_everything.browse_files_button') %>
+                  <% end %>
+                <% end %>
+                <button type="reset" class="btn btn-warning cancel hidden">
+                    <span class="glyphicon glyphicon-ban-circle"></span>
+                    <span>Cancel upload</span>
+                </button>
+                <!-- The global file processing state -->
+                <span class="fileupload-process"></span>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-xs-12">
+              <!-- The global progress state -->
+              <div class="fileupload-progress fade">
+                  <!-- The global progress bar -->
+                  <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+                      <div class="progress-bar progress-bar-success" style="width:0%;"></div>
+                  </div>
+                  <!-- The extended global progress state -->
+                  <div class="progress-extended">&nbsp;</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="dropzone">
+          <%= t('hyrax.base.form_files.dropzone') %>
+        </div>
+     </div>
+
+<%= render 'hyrax/uploads/js_templates' %>
+

--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -3,7 +3,7 @@
         <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>" /></noscript>
         <!-- The table listing the files available for upload/download -->
         <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
-        <% if Hyrax.config.browse_everything? %>
+				<% if Hyrax.config.browse_everything? && !(f.object_name == 'batch_upload_item') %>
           <%= t('hyrax.base.form_files.local_upload_browse_everything_html', contact_href: link_to(t("hyrax.upload.alert.contact_href_text"), hyrax.contact_form_index_path)) %>
         <% else %>
           <%= t('hyrax.base.form_files.local_upload_html') %>
@@ -24,7 +24,7 @@
                     <span>Add folder...</span>
                     <input type="file" name="files[]" multiple directory webkitdirectory />
                 </span>
-                <% if Hyrax.config.browse_everything? %>
+								<% if Hyrax.config.browse_everything? && !(f.object_name == 'batch_upload_item') %>
                   <%= button_tag(type: 'button', class: 'btn btn-success', id: "browse-btn",
                     'data-toggle' => 'browse-everything', 'data-route' => browse_everything_engine.root_path,
                     'data-target' => "#{f.object.persisted? ? "#edit_#{f.object.model.model_name.param_key}_#{f.object.model.id}" : "#new_#{f.object.model.model_name.param_key}"}" ) do %>

--- a/spec/features/hyrax/batch_create_spec.rb
+++ b/spec/features/hyrax/batch_create_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe 'Batch creation of works', type: :feature do
     expect(page).to have_checked_field('batch_upload_item_visibility_open')
   end
 
+  it 'hides cloud upload button' do
+    visit hyrax.new_batch_upload_path(payload_concern: 'Document')
+    expect(page).to have_no_content('Add cloud files')
+  end
+
   context 'when the user is a proxy', :js, :workflow do
     let(:second_user) { create(:user) }
 

--- a/spec/features/hyrax/create_work_spec.rb
+++ b/spec/features/hyrax/create_work_spec.rb
@@ -99,7 +99,6 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
     end
 
     it "allows on-behalf-of deposit" do
-      page.save_screenshot('virus.png')
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
       within('span#addfiles') do


### PR DESCRIPTION
Fixes #416 

scholar-dev - tested box.com cloud upload on batch create and resulted in error. 
Added view partial override to remove the cloud upload option for batch create.

Changes proposed in this pull request:
* Add view partial override `app/views/hyrax/base/_form_files.html.erb`
* Add spec to verify button is not showing on batch create
