### PR TITLE
Implement Change Manager from Scholar

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -173,3 +173,7 @@ Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/models/ability.rb'
     - 'app/forms/hyrax/forms/batch_upload_form.rb'
+
+Lint/HandleExceptions:
+  Exclude:
+    - 'app/controllers/concerns/scholar/works_controller_behavior.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # gem 'clamav'
 gem 'active_attr'
+gem 'change_manager', git: "https://github.com/uclibs/change_manager.git", ref: '8d151d1123aa35658f061a63bc72435afdf0ec8a'
 gem 'devise'
 gem 'devise-guests', '~> 0.6'
 gem 'devise-multi_auth', git: 'https://github.com/uclibs/devise-multi_auth', branch: 'rails-5-1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,15 @@ GIT
       signet
 
 GIT
+  remote: https://github.com/uclibs/change_manager.git
+  revision: 8d151d1123aa35658f061a63bc72435afdf0ec8a
+  ref: 8d151d1123aa35658f061a63bc72435afdf0ec8a
+  specs:
+    change_manager (1.0.0)
+      activejob
+      rails
+
+GIT
   remote: https://github.com/uclibs/devise-multi_auth
   revision: 49073374277f94c3bb2e1cc654c8732da37ec4ce
   branch: rails-5-1
@@ -921,6 +930,7 @@ DEPENDENCIES
   byebug
   capybara (~> 2.4, < 2.18.0)
   capybara-maleficent (~> 0.2)
+  change_manager!
   chromedriver-helper
   coffee-rails (~> 4.2)
   coveralls (~> 0.7.1)

--- a/app/controllers/concerns/scholar/works_controller_behavior.rb
+++ b/app/controllers/concerns/scholar/works_controller_behavior.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+# Generated via
+#  `rails generate hyrax:work GenericWork`
+
+module Scholar
+  module WorksControllerBehavior
+    include ChangeManager::ChangeManagerHelper
+
+    def create
+      super
+      # the to_s_u method must be implemented for every model
+      editors = params.to_unsafe_hash[curation_concern.class.to_s_u][:permissions_attributes]
+      queue_notifications_for_editors(editors) if editors
+    end
+
+    def update
+      super
+      # the to_s_u method must be implemented for every model
+      editors = params.to_unsafe_hash[curation_concern.class.to_s_u][:permissions_attributes]
+      queue_notifications_for_editors(editors) if editors
+    end
+  end
+end

--- a/app/controllers/hyrax/articles_controller.rb
+++ b/app/controllers/hyrax/articles_controller.rb
@@ -7,6 +7,7 @@ module Hyrax
   class ArticlesController < ApplicationController
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
+    include Scholar::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
     self.curation_concern_type = ::Article
 

--- a/app/controllers/hyrax/datasets_controller.rb
+++ b/app/controllers/hyrax/datasets_controller.rb
@@ -7,6 +7,7 @@ module Hyrax
   class DatasetsController < ApplicationController
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
+    include Scholar::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
     self.curation_concern_type = ::Dataset
 

--- a/app/controllers/hyrax/depositors_controller.rb
+++ b/app/controllers/hyrax/depositors_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require Hyrax::Engine.root.join('app/controllers/hyrax/depositors_controller.rb')
+module Hyrax
+  class DepositorsController < ApplicationController
+    def destroy
+      grantor = authorize_and_return_grantor
+      grantee = ::User.from_url_component(params[:id])
+      send_removed_proxy_email(grantor, grantee) if grantor.can_receive_deposits_from.delete(grantee)
+      head :ok
+    end
+
+    def send_granted_proxy_email(grantor, grantee)
+      ChangeManager::EmailManager.queue_change(grantor, 'added_as_proxy', '', grantee)
+    rescue NotImplementedError # needed for specs and development environments
+      ChangeManager::EmailManager.skip_sidekiq_for_emails(grantor, 'added_as_proxy', '', grantee)
+    end
+
+    def send_removed_proxy_email(grantor, grantee)
+      ChangeManager::EmailManager.queue_change(grantor, 'removed_as_proxy', '', grantee)
+    rescue NotImplementedError # needed for specs and development environments
+      ChangeManager::EmailManager.skip_sidekiq_for_emails(grantor, 'removed_as_proxy', '', grantee)
+    end
+
+    private
+
+      def send_proxy_depositor_added_messages(grantor, grantee)
+        message_to_grantee = "#{grantor.name} has assigned you as a proxy depositor"
+        message_to_grantor = "You have assigned #{grantee.name} as a proxy depositor"
+        ::User.batch_user.send_message(grantor, message_to_grantor, "Proxy Depositor Added")
+        ::User.batch_user.send_message(grantee, message_to_grantee, "Proxy Depositor Added")
+        send_granted_proxy_email(grantor, grantee)
+      end
+  end
+end

--- a/app/controllers/hyrax/documents_controller.rb
+++ b/app/controllers/hyrax/documents_controller.rb
@@ -7,6 +7,7 @@ module Hyrax
   class DocumentsController < ApplicationController
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
+    include Scholar::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
     self.curation_concern_type = ::Document
 

--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -7,6 +7,7 @@ module Hyrax
   class EtdsController < ApplicationController
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
+    include Scholar::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
     self.curation_concern_type = ::Etd
 

--- a/app/controllers/hyrax/generic_works_controller.rb
+++ b/app/controllers/hyrax/generic_works_controller.rb
@@ -7,6 +7,7 @@ module Hyrax
   class GenericWorksController < ApplicationController
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
+    include Scholar::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
     self.curation_concern_type = ::GenericWork
 

--- a/app/controllers/hyrax/images_controller.rb
+++ b/app/controllers/hyrax/images_controller.rb
@@ -7,6 +7,7 @@ module Hyrax
   class ImagesController < ApplicationController
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
+    include Scholar::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
     self.curation_concern_type = ::Image
 

--- a/app/controllers/hyrax/media_controller.rb
+++ b/app/controllers/hyrax/media_controller.rb
@@ -7,6 +7,7 @@ module Hyrax
   class MediaController < ApplicationController
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
+    include Scholar::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
     self.curation_concern_type = ::Medium
     # Use this line if you want to use a custom presenter

--- a/app/controllers/hyrax/student_works_controller.rb
+++ b/app/controllers/hyrax/student_works_controller.rb
@@ -7,6 +7,7 @@ module Hyrax
   class StudentWorksController < ApplicationController
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
+    include Scholar::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
     self.curation_concern_type = ::StudentWork
 

--- a/app/helpers/change_manager/change_manager_helper.rb
+++ b/app/helpers/change_manager/change_manager_helper.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+# helper for the WorksControllerBehavior class
+# cleaner to keep all change manager code in here
+module ChangeManager
+  module ChangeManagerHelper
+    def queue_notifications_for_editors(editors)
+      editors.each do |editor_wrapper|
+        editor = editor_wrapper[1]
+        EmailManager.queue_change(curation_concern.depositor, 'added_as_editor', curation_concern.id, editor['name']) if new_editor? editor
+        # uncomment this once the `Ldp::Gone` error is resolved
+        # elsif removed_editor? editor
+        #   EmailManager.queue_change(curation_concern.depositor, 'removed_as_editor', curation_concern.id, editor[:name])
+        # end
+      end
+    rescue NotImplementedError
+      editors.each do |editor_wrapper|
+        editor = editor_wrapper[1]
+        EmailManager.skip_sidekiq_for_emails(curation_concern.depositor, 'added_as_editor', curation_concern.id, editor['name']) if new_editor? editor
+        # uncomment this once the `Ldp::Gone` error is resolved
+        # elsif removed_editor? editor
+        #   EmailManager.skip_sidekiq_for_emails(curation_concern.depositor, 'removed_as_editor', curation_concern.id, editor['name'])
+        # end
+      end
+    end
+
+    private
+
+      def new_editor?(editor)
+        edit_access?(editor) && name_key?(editor)
+      end
+
+      # implement once Ldp::Gone error is resolved
+      # def removed_editor?(_editor)
+      #   false
+      # end
+
+      def name_key?(hash)
+        hash.key? 'name'
+      end
+
+      def edit_access?(hash)
+        hash.key?('access') && hash['access'] == 'edit'
+      end
+  end
+end

--- a/app/jobs/change_manager/process_change_job.rb
+++ b/app/jobs/change_manager/process_change_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'yaml'
+module ChangeManager
+  class ProcessChangeJob < ActiveJob::Base
+    queue_as :change
+
+    def perform(change_id)
+      config_file ||= YAML.load_file(Rails.root.join('config', 'change_manager_config.yml'))
+      config_file['manager_class'].constantize.process_change(change_id)
+    end
+  end
+end

--- a/app/mailers/change_manager/scholar_notification_mailer.rb
+++ b/app/mailers/change_manager/scholar_notification_mailer.rb
@@ -1,20 +1,18 @@
 # frozen_string_literal: true
-
 ###
 # This mailer makes many assumptions as to the content contained in changes. Take care to ensure these assumptions are met
 # or create your own mailer that extends ChangeManager::NotificationMailer
 ####
-
 require 'yaml'
 
 module ChangeManager
   class ScholarNotificationMailer < ChangeManager::NotificationMailer
     def notify_changes(changes)
       @changes = changes
-      @change_types ||= YAML.load_file(Rails.root.join('path', 'to'))
-      subject = 'Changes to your ' + @change_types[changes.first.change_type]['print'] + ' status in ' + t('hyrax.product_name')
+      @change_types ||= YAML.load_file(Rails.root.join('config', 'change_types.yml'))
+      subject = 'Changes to your ' + @change_types[changes.first.change_type]['print'] + ' status in Scholar@UC.'
       mail(to: changes.first.target,
-           from: t('hyrax.product_email'),
+           from: 'scholar@uc.edu',
            subject: subject).deliver
     end
   end

--- a/app/models/concerns/change_manager/comparison_concern.rb
+++ b/app/models/concerns/change_manager/comparison_concern.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module ChangeManager
+  module ComparisonConcern
+    extend ActiveSupport::Concern
+
+    def proxy_change?
+      change_type == 'added_as_proxy' || change_type == 'removed_as_proxy'
+    end
+
+    def editor_change?
+      change_type == 'added_as_editor' || change_type == 'removed_as_editor'
+    end
+  end
+end

--- a/app/services/change_manager/email_manager.rb
+++ b/app/services/change_manager/email_manager.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+module ChangeManager
+  class EmailManager
+    extend ChangeManager::Manager
+
+    def self.queue_change(owner, change_type, context, target)
+      change_id = Change.new_change(owner, change_type, context, target)
+      ChangeManager::ProcessChangeJob.set(wait: 15.minutes).perform_later(change_id)
+    end
+
+    def self.skip_sidekiq_for_emails(owner, change_type, context, target)
+      # Note: For some reason, it duplicates the items in the final email, but only when not using sidekiq
+      change_id = Change.new_change(owner, change_type, context, target)
+      process_change change_id
+    end
+
+    def self.process_change(change_id)
+      change = Change.find change_id
+      return if change.cancelled?
+      verified_changes = process_changes_similar_to change
+      notify_target_of verified_changes unless verified_changes.empty?
+      true
+    end
+
+    def self.notify_target_of(changes)
+      grouped_changes = group_changes(changes)
+      if grouped_changes['proxies']
+        grouped_changes['proxies'].each(&:notify) if ChangeManager::ScholarNotificationMailer.notify_changes(grouped_changes['proxies']).deliver
+      end
+
+      return unless grouped_changes['editors']
+      grouped_changes['editors'].each(&:notify) if ChangeManager::ScholarNotificationMailer.notify_changes(grouped_changes['editors']).deliver
+    end
+
+    def self.group_changes(changes)
+      proxy_changes = []
+      editor_changes = []
+      changes.each do |change|
+        if change.proxy_change?
+          proxy_changes << change
+        elsif change.editor_change?
+          editor_changes << change
+        end
+      end
+      grouped_changes = {}
+      grouped_changes['proxies'] = proxy_changes unless proxy_changes.empty?
+      grouped_changes['editors'] = editor_changes unless editor_changes.empty?
+      grouped_changes
+    end
+  end
+end

--- a/app/views/change_manager/scholar_notification_mailer/_editor_changes.html.erb
+++ b/app/views/change_manager/scholar_notification_mailer/_editor_changes.html.erb
@@ -1,0 +1,14 @@
+<%= User.find_by_email(@changes.first.owner).name %> has added or removed you as an editor to the following works in Scholar@UC:
+
+<ul>
+<% @changes.each do |change| %>
+	<% work_title = ActiveFedora::Base.find(change.context).title.first %>
+	<% work_url = File.join(Rails.configuration.application_root_url, 'show', change.context) %>
+	<li>
+		<%= @change_types[change.change_type]['human_readable'] %>
+		<%= link_to work_title, work_url %>
+	</li>
+<% end %>
+</ul>
+
+An editor can modify all metadata for a work and upload/delete files for a work. If you feel that this was made in error, please contact the <a href="mailto:scholar@uc.edu">Scholar@UC</a> team.

--- a/app/views/change_manager/scholar_notification_mailer/_proxy_changes.html.erb
+++ b/app/views/change_manager/scholar_notification_mailer/_proxy_changes.html.erb
@@ -1,0 +1,3 @@
+<%= User.find_by_email(@changes.first.owner).name %> has <%= @change_types[@changes.first.change_type]['human_readable'] %>
+you as a proxy in Scholar@UC. A proxy can create and upload files on behalf of another user as well as edit, or delete those
+corresponding works and files. If you feel that this was made in error, <a href="mailto:scholar@uc.edu">Scholar@UC team</a>.

--- a/app/views/change_manager/scholar_notification_mailer/notify_changes.html.erb
+++ b/app/views/change_manager/scholar_notification_mailer/notify_changes.html.erb
@@ -1,0 +1,12 @@
+<p>Dear <%= User.find_by_email(@changes.first.target).name %>:</p>
+
+<% if @changes.first.proxy_change? %>
+	<%= render 'proxy_changes' %>
+<% elsif @changes.first.editor_change? %>
+	<%= render 'editor_changes' %>
+<% end %>
+
+<p>
+Thanks,
+Scholar@UC
+</p>

--- a/config/change_manager_config.yml
+++ b/config/change_manager_config.yml
@@ -1,0 +1,1 @@
+manager_class: ChangeManager::EmailManager

--- a/config/change_types.yml
+++ b/config/change_types.yml
@@ -1,0 +1,24 @@
+added_as_proxy:
+  print: proxy
+  inverse: removed_as_proxy
+  human_readable: added
+removed_as_proxy:
+  print: proxy
+  inverse: added_as_proxy
+  human_readable: removed
+added_as_editor:
+  print: editor
+  inverse: removed_as_editor
+  human_readable: Added as an editor to
+removed_as_editor:
+  print: editor
+  inverse: added_as_editor
+  human_readable: Removed as an editor from
+embargo_set:
+  print: embargo
+  inverse: embargo_lifted
+  human_readable: An embargo has been set
+embargo_lifted:
+  print: Emboargo lifted
+  inverse: embargo
+  human_readable: An embargo has been lifted

--- a/config/initializers/change_manager_init.rb
+++ b/config/initializers/change_manager_init.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+ChangeManager::Change.send :include, ChangeManager::ComparisonConcern

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,3 +4,4 @@ max_retries: 3
   - default
   - ingest
   - event
+  - change

--- a/db/migrate/20181001000000_create_change_manager_changes.rb
+++ b/db/migrate/20181001000000_create_change_manager_changes.rb
@@ -1,0 +1,13 @@
+class CreateChangeManagerChanges < ActiveRecord::Migration[5.1]
+    def change
+      create_table :change_manager_changes do |t|
+        t.string :change_type
+        t.boolean :cancelled
+        t.datetime :notified
+        t.string :owner
+        t.string :target
+        t.string :context
+        t.timestamps
+      end
+    end
+  end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180621165939) do
+ActiveRecord::Schema.define(version: 20181001000000) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -22,6 +22,17 @@ ActiveRecord::Schema.define(version: 20180621165939) do
     t.datetime "updated_at", null: false
     t.index ["document_id"], name: "index_bookmarks_on_document_id"
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
+
+  create_table "change_manager_changes", force: :cascade do |t|
+    t.string "change_type"
+    t.boolean "cancelled"
+    t.datetime "notified"
+    t.string "owner"
+    t.string "target"
+    t.string "context"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "checksum_audit_logs", force: :cascade do |t|

--- a/spec/controllers/hyrax/depositors_controller_spec.rb
+++ b/spec/controllers/hyrax/depositors_controller_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Hyrax::DepositorsController, type: :controller do
+  routes { Rails.application.class.routes }
+  let(:user) { create(:user) }
+  let(:grantee) { create(:user) }
+
+  describe "destroy" do
+    before do
+      user.can_receive_deposits_from << grantee
+      sign_in user
+    end
+
+    it "is successful" do
+      expect { delete :destroy, params: { user_id: user.user_key, id: grantee.user_key, use_route: :hyrax } }.to change { ProxyDepositRights.count }.by(-1)
+    end
+  end
+end

--- a/spec/factories/change_manager_changes.rb
+++ b/spec/factories/change_manager_changes.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :change, class: 'ChangeManager::Change' do
+    owner "email@test.com"
+    change_type "added_as_delegate"
+    context "1"
+    target "spec@test.com"
+    cancelled false
+    notified nil
+  end
+end

--- a/spec/helpers/change_manager/change_manager_helper_spec.rb
+++ b/spec/helpers/change_manager/change_manager_helper_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe ChangeManager::ChangeManagerHelper do
+  let!(:editors) { { "0" => { 'type' => 'person', 'name' => 'new_editor@example.com', 'access' => 'edit' } } }
+  let!(:old_editor) { { 'id' => 'someid' } }
+  let!(:new_editor) { { 'type' => 'person', 'name' => 'new_editor@example.com', 'access' => 'edit' } }
+  let!(:removed_editor) { { 'id' => 'someid', 'access' => 'destroy' } }
+  let!(:curation_concern) { FactoryBot.create(:generic_work) }
+
+  describe '#queue_notifications_for_editors should' do
+    let(:change_email) { ActionMailer::Base.deliveries.last }
+    let!(:user) { FactoryBot.create(:user, email: 'new_editor@example.com') }
+    before do
+      ActionMailer::Base.deliveries = []
+    end
+
+    after do
+      ActionMailer::Base.deliveries = []
+    end
+
+    it 'queues the change in change manager and sends the appropriate email' do
+      queue_notifications_for_editors(editors)
+      change_email.to.should match([editors['0']['name']])
+      change_email.from.should match(['scholar@uc.edu'])
+    end
+  end
+
+  describe '#new_editor? should' do
+    it 'return true when the editor is new' do
+      expect(new_editor?(new_editor)).to be true
+    end
+
+    it 'return false when the editor is not new' do
+      expect(new_editor?(old_editor)).to be false
+    end
+  end
+
+  describe '#removed_editor? should' do
+    it 'return true is the editor is removed' do
+      skip 'implement removed_editor?'
+      expect(removed_editor?(removed_editor)).to be true
+    end
+
+    it 'return false if the editor is not removed' do
+      skip 'implement removed_editor?'
+      expect(removed_editor?(new_editor)).to be false
+    end
+  end
+
+  describe '#name_key? should' do
+    it 'return true if the hash object has the name key' do
+      expect(name_key?(new_editor)).to be true
+    end
+
+    it 'return false if the hash object does not have the name key' do
+      expect(name_key?(old_editor)).to be false
+    end
+  end
+
+  describe '#edit_access? should' do
+    it 'return true if the editor has edit access' do
+      expect(edit_access?(new_editor)).to be true
+    end
+
+    it 'return false if the editor does not have edit access' do
+      expect(edit_access?(removed_editor)).to be false
+    end
+  end
+end

--- a/spec/jobs/change_manager/process_change_spec.rb
+++ b/spec/jobs/change_manager/process_change_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe ChangeManager::ProcessChangeJob do
+  describe '#perform' do
+    let!(:change) { FactoryBot.build(:change) }
+    it 'calls the process change method in ChangeManager::EmailManager' do
+      expect(ChangeManager::EmailManager).to receive(:process_change).with(change.id)
+
+      described_class.perform_now(change.id)
+    end
+  end
+end

--- a/spec/models/concerns/change_manager/comparison_concern_spec.rb
+++ b/spec/models/concerns/change_manager/comparison_concern_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe ChangeManager::ComparisonConcern do
+  let!(:editor_change) { FactoryBot.create(:change, change_type: 'added_as_editor') }
+  let!(:proxy_change) { FactoryBot.create(:change, change_type: 'added_as_proxy') }
+  describe '#proxy_change? should' do
+    it 'return true when the change deals with a proxy' do
+      expect(proxy_change.proxy_change?).to be true
+    end
+
+    it 'return false when the change does not deal with a proxy' do
+      expect(editor_change.proxy_change?).to be false
+    end
+  end
+
+  describe '#editor_change? should' do
+    it 'return true when the change deals with an editor change' do
+      expect(editor_change.editor_change?).to be true
+    end
+
+    it 'return false when the change does not deal with an editor change' do
+      expect(proxy_change.editor_change?).to be false
+    end
+  end
+end


### PR DESCRIPTION
Fixes #264 

Implements the Change Manager from Scholar. Something to be made aware of is that when it is ran inline (not using sidekiq), the email items duplicate. Another known issue is that emails do not get sent out for removal for both proxies and editors.