### PR TITLE
Update license view in collections

### DIFF
--- a/app/views/hyrax/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/collections/_show_descriptions.html.erb
@@ -1,0 +1,8 @@
+<dl>
+  <% present_terms(@presenter, @presenter.terms_with_values) do |r, term| %>
+    <div>
+      <dt><%= r.label(term) == "Rights" ? "License" : r.label(term) %></dt>
+      <dd><%= r.value(term) %></dd>
+    </div>
+  <% end %>
+</dl>

--- a/app/views/hyrax/dashboard/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_descriptions.html.erb
@@ -1,0 +1,7 @@
+<h2 class="sr-only">Descriptions</h2>
+<dl class="dl-horizontal metadata-collections">
+  <% present_terms(@presenter, @presenter.terms_with_values) do |r, term| %>
+    <dt><%= r.label(term) == "Rights" ? "License" : r.label(term) %></dt>
+    <dd><%= r.value(term) %></dd>    
+  <% end %>
+</dl>

--- a/app/views/records/show_fields/_license.html.erb
+++ b/app/views/records/show_fields/_license.html.erb
@@ -1,0 +1,6 @@
+<% record.license.each do |license| %>
+<span itemprop="rights" itemscope itemtype="http://schema.org/Person">
+  <%= link_to Hyrax.config.license_service_class.new.label(license), license %>
+</span>
+<br />
+<% end %>

--- a/spec/features/hyrax/collection_spec.rb
+++ b/spec/features/hyrax/collection_spec.rb
@@ -120,4 +120,18 @@ RSpec.describe 'collection', type: :feature, js: true, clean_repo: true do
       expect(page).to have_css(".pagination")
     end
   end
+
+  describe 'check collection License hyperlink' do
+    let(:collection) do
+      create(:public_collection, user: user, license: 'http://creativecommons.org/publicdomain/zero/1.0/', description: ['collection description'], collection_type_settings: :nestable)
+    end
+
+    before do
+      visit "/collections/#{collection.id}"
+    end
+
+    it 'Verify correct link for license' do
+      expect(page).to have_link("CC0 1.0 Universal", href: "http://creativecommons.org/publicdomain/zero/1.0/")
+    end
+  end
 end

--- a/spec/views/hyrax/collections/_show_descriptions.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_descriptions.html.erb_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/collections/_show_descriptions.html.erb', type: :view do
+  context 'displaying a custom collection' do
+    let(:collection_size) { 123_456_678 }
+    let(:collection) do
+      {
+        id: '999',
+        "has_model_ssim" => ["Collection"],
+        "title_tesim" => ["Title 1"],
+        'date_created_tesim' => '2000-01-01',
+        "license_tesim" => ["http://creativecommons.org/publicdomain/zero/1.0/"]
+      }
+    end
+    let(:ability) { double }
+    let(:solr_document) { SolrDocument.new(collection) }
+    let(:presenter) { Hyrax::CollectionPresenter.new(solr_document, ability) }
+
+    before do
+      allow(presenter).to receive(:total_items).and_return(2)
+      allow(presenter).to receive(:size).and_return("118 MB")
+      assign(:presenter, presenter)
+    end
+
+    it "displays the License label and License name hyperlinked" do
+      render
+      expect(rendered).to have_content 'License'
+      expect(rendered).to have_link("CC0 1.0 Universal", href: "http://creativecommons.org/publicdomain/zero/1.0/")
+    end
+  end
+end

--- a/spec/views/hyrax/dashboard/collections/_show_descriptions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_descriptions.html.erb_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/dashboard/collections/_show_descriptions.html.erb', type: :view do
+  context 'displaying a custom collection' do
+    let(:collection_size) { 123_456_678 }
+    let(:collection) do
+      {
+        id: '999',
+        "has_model_ssim" => ["Collection"],
+        "title_tesim" => ["Title 1"],
+        'date_created_tesim' => '2000-01-01',
+        "license_tesim" => ["http://creativecommons.org/publicdomain/zero/1.0/"]
+      }
+    end
+    let(:ability) { double }
+    let(:solr_document) { SolrDocument.new(collection) }
+    let(:presenter) { Hyrax::CollectionPresenter.new(solr_document, ability) }
+
+    before do
+      allow(presenter).to receive(:total_items).and_return(2)
+      allow(presenter).to receive(:size).and_return("118 MB")
+      assign(:presenter, presenter)
+    end
+
+    it "displays the License label and License name hyperlinked" do
+      render
+      expect(rendered).to have_content 'License'
+      expect(rendered).to have_link("CC0 1.0 Universal", href: "http://creativecommons.org/publicdomain/zero/1.0/")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #454 

Adds the license partial to have a link with the name of the license