### PR TITLE
Removed search label, and resized to match production scholar

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -151,6 +151,9 @@ RSpec/VerifiedDoubles:
     - 'spec/controllers/hyrax/contact_form_controller_spec.rb'
     - 'spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb'
     - 'spec/helpers/hyrax_helper_spec.rb'
+    - 'spec/views/catalog/_search_form.html.erb_spec.rb'
+    - 'spec/views/hyrax/my/collections/index.html.erb_spec.rb'
+    - 'spec/views/hyrax/my/_search_form.html.erb_spec.rb'
 
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -11,7 +11,7 @@
         <li <%= 'class=active' if current_page?(hyrax.help_path) %>>
           <%= link_to t(:'hyrax.controls.help'), hyrax.help_path, aria: current_page?(hyrax.help_path) ? {current: 'page'} : nil %></li>
       </ul>
-      <div class="searchbar-right navbar-right col-sm-7">
+      <div class="searchbar-right navbar-right col-sm-7 col-md-6">
         <%= render partial: 'catalog/search_form' %>
       </div>
     </div>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -7,10 +7,6 @@
       <%= link_to 'Browse', main_app.search_catalog_path, class: 'btn btn-primary nav-btn navbar-left' %>
     </div>
 
-    <label class="control-label col-sm-3" for="search-field-header">
-        <%= t("hyrax.search.form.q.label", application_name: application_name) %>
-    </label>
-
     <div class="input-group">
       <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 

--- a/app/views/hyrax/my/_search_form.html.erb
+++ b/app/views/hyrax/my/_search_form.html.erb
@@ -1,0 +1,16 @@
+<%= form_tag search_action_url, method: :get, class: "search-query-form form-horizontal search-form", role: "search" do %>
+
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+  <div class="form-group">
+
+    <div class="input-group">
+      <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
+
+      <div class="input-group-btn">
+        <button type="submit" class="btn btn-primary" id="search-submit-header">
+          <%= t('hyrax.search.button.html') %>
+        </button>
+      </div>
+    </div><!-- /.input-group -->
+  </div><!-- /.form-group -->
+<% end %>

--- a/spec/views/catalog/_search_form.html.erb_spec.rb
+++ b/spec/views/catalog/_search_form.html.erb_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'catalog/_search_form.html.erb', type: :view do
+  before do
+    allow(view).to receive(:search_form_action).and_return("/catalog")
+    allow(view).to receive(:search_state).and_return(search_state)
+    allow(view).to receive(:current_search_parameters).and_return(nil)
+    allow(view).to receive(:current_user).and_return(nil)
+
+    render
+  end
+  let(:search_state) { double('SearchState', params_for_search: {}) }
+  let(:page) { Capybara::Node::Simple.new(rendered) }
+
+  it "has a hidden search_field input" do
+    expect(page).to have_selector("[name='search_field'][value='all_fields']", visible: false)
+  end
+
+  it "does not have a search label" do
+    expect(rendered).not_to have_css('label.control-label')
+  end
+end

--- a/spec/views/hyrax/my/_search_form.html.erb_spec.rb
+++ b/spec/views/hyrax/my/_search_form.html.erb_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/my/_search_form.html.erb', type: :view do
+  let(:search_state) { double('SearchState', params_for_search: {}) }
+  before do
+    view.extend Hyrax::BatchEditsHelper
+    allow(view).to receive(:search_state).and_return(search_state)
+    allow(view).to receive(:on_the_dashboard?).and_return(true)
+    allow(view).to receive(:search_action_url).and_return('')
+    render
+  end
+
+  it "does not have a search label" do
+    expect(rendered).not_to have_css('label.control-label')
+  end
+end


### PR DESCRIPTION
Fixes #468

Removes the unnecessary search Scholar@UC label that was added in Hyrax (between 2.1.0 and 2.3.3). Also resizes to match production Scholar.