### PR TITLE
Bug/#457 fix file name cutoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+dump.rdb
 
 # Ignore Byebug command history file.
 .byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -42,9 +42,9 @@ gem 'jbuilder', '~> 2.5'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-# gem 'clamav'
 gem 'active_attr'
 gem 'change_manager', git: "https://github.com/uclibs/change_manager.git", ref: '8d151d1123aa35658f061a63bc72435afdf0ec8a'
+# gem 'clamav'
 gem 'devise'
 gem 'devise-guests', '~> 0.6'
 gem 'devise-multi_auth', git: 'https://github.com/uclibs/devise-multi_auth', branch: 'rails-5-1'

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -42,3 +42,12 @@
  div[class*="_admin_set_id"] {
   display: none;
  }
+
+ .break-all  {
+    display: inline-block;
+    word-break: break-all;
+ }
+
+ .auto-width-overide  {
+    width: auto !important;
+ }

--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -1,13 +1,7 @@
      <div id="fileupload">
         <!-- Redirect browsers with JavaScript disabled to the origin page -->
         <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>" /></noscript>
-        <!-- The table listing the files available for upload/download -->
-        <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
-				<% if Hyrax.config.browse_everything? && !(f.object_name == 'batch_upload_item') %>
-          <%= t('hyrax.base.form_files.local_upload_browse_everything_html', contact_href: link_to(t("hyrax.upload.alert.contact_href_text"), hyrax.contact_form_index_path)) %>
-        <% else %>
-          <%= t('hyrax.base.form_files.local_upload_html') %>
-        <% end %>
+
         <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
         <div class="fileupload-buttonbar">
           <div class="row">
@@ -57,6 +51,14 @@
         <div class="dropzone">
           <%= t('hyrax.base.form_files.dropzone') %>
         </div>
+        
+        <!-- The table listing the files available for upload/download -->
+        <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
+				<% if Hyrax.config.browse_everything? && !(f.object_name == 'batch_upload_item') %>
+          <%= t('hyrax.base.form_files.local_upload_browse_everything_html', contact_href: link_to(t("hyrax.upload.alert.contact_href_text"), hyrax.contact_form_index_path)) %>
+        <% else %>
+          <%= t('hyrax.base.form_files.local_upload_html') %>
+        <% end %>
      </div>
 
 <%= render 'hyrax/uploads/js_templates' %>

--- a/app/views/hyrax/batch_uploads/_form.html.erb
+++ b/app/views/hyrax/batch_uploads/_form.html.erb
@@ -14,7 +14,7 @@
 
 <script type="text/javascript">
   Blacklight.onLoad(function() {
-    $("#fileupload").fileupload('option', 'downloadTemplateId', 'batch-template-download')
+    $("#fileupload").fileupload('option', 'downloadTemplateId', 'template-download')
   });
 </script>
 

--- a/app/views/hyrax/uploads/_js_templates.html.erb
+++ b/app/views/hyrax/uploads/_js_templates.html.erb
@@ -2,105 +2,75 @@
 <% fade_class_if_not_test = Rails.env.test? ? '' : 'fade' %>
 <script id="template-upload" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
-    <tr class="template-upload <%= fade_class_if_not_test %>">
+    <tr class="template-upload <%#= fade_class_if_not_test %>">
         <td>
-            <span class="preview"></span>
-        </td>
-        <td>
-            <p class="name">{%=file.name%}</p>
-            <strong class="error text-danger"></strong>
-        </td>
-        <td>
-            <p class="size">Processing...</p>
-            <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="progress-bar progress-bar-success" style="width:0%;"></div></div>
-        </td>
-        <td class="text-right">
-            {% if (!i && !o.options.autoUpload) { %}
-                <button class="btn btn-primary start" disabled>
-                    <i class="glyphicon glyphicon-upload"></i>
-                    <span>Start</span>
-                </button>
-            {% } %}
-            {% if (!i) { %}
-                <button class="btn btn-sm btn-warning cancel">
-                    <i class="glyphicon glyphicon-ban-circle"></i>
-                    <span>Cancel</span>
-                </button>
-            {% } %}
+            <div class="row">
+                <div class="col-sm-5">
+                    <p class="name break-all">{%=file.name%}</p>
+                    <strong class="error text-danger"></strong>
+                </div>
+                <div class="col-sm-3">
+                    <div class="progress progress-striped active auto-width-overide" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="progress-bar progress-bar-success" style="width:0%;"></div></div>
+                </div>
+                <div class="col-sm-2">
+                    <p class="size">Processing...</p>
+                </div>
+                <div class="col-sm-2 text-right">
+                    {% if (!i && !o.options.autoUpload) { %}
+                        <button class="btn btn-primary start" disabled>
+                            <i class="glyphicon glyphicon-upload"></i>
+                            <span>Start</span>
+                        </button>
+                    {% } %}
+                    {% if (!i) { %}
+                        <button class="btn btn-sm btn-warning cancel">
+                            <i class="glyphicon glyphicon-ban-circle"></i>
+                            <span>Cancel</span>
+                        </button>
+                    {% } %}
+                </div>
+            </div>
         </td>
     </tr>
 {% } %}
 </script>
 
-<!-- The template to display files available for download -->
-<script id="batch-template-download" type="text/x-tmpl">
+<script id="template-download" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
     <tr class="template-download add-batch-work-file-wrapper <%= fade_class_if_not_test %>">
         <td>
-          <div class="row padding-bottom">
-            <div class="col-sm-6 name">
-                <span>{%=file.name%}</span>
-                <input type="hidden" name="uploaded_files[]" value="{%=file.id%}">
-            </div>
-            <div class="col-sm-6">
-              {% if (file.error) { %}
-                  <div><span class="label label-danger">Error</span> {%=file.error%}</div>
-              {% } %}
-              <span class="size">{%=o.formatFileSize(file.size)%}</span>
-              <button class="btn btn-sm btn-danger delete pull-right" data-type="{%=file.deleteType%}" data-url="{%=file.deleteUrl%}"{% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
-                  <i class="glyphicon glyphicon-trash"></i>
-                  <span>Delete</span>
-              </button>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-sm-12 form-horizontal">
-              <div class="form-group">
-                <label for="title_{%=file.id%}" class="col-sm-5 control-label">Display label</label>
-                <div class="col-sm-7 padding-bottom">
-                  <input type="text" class="form-control" name="title[{%=file.id%}]" id="title_{%=file.id%}" value="{%=file.name%}">
+            <div class="row padding-bottom">
+                <div class="col-sm-5">
+                    <p class="name">
+                        {% if (file.url) { %}
+                            <a href="{%=file.url%}" class="break-all" title="{%=file.name%}" download="{%=file.name%}" {%=file.thumbnailUrl?'data-gallery':''%}>{%=file.name%}</a>
+                        {% } else { %}
+                            <span class="break-all">{%=file.name%}</span>
+                        {% } %}
+                        <input type="hidden" name="uploaded_files[]" value="{%=file.id%}">
+                    </p>
                 </div>
-              </div>
+                <div class="col-sm-3">
+                    {% if (file.error) { %}
+                        <div><span class="label label-danger">Error</span> {%=file.error%}</div>
+                    {% } %}
+                </div>
+                <div class="col-sm-2">
+                    <span class="size">{%=o.formatFileSize(file.size)%}</span>
+                </div>
+                <div class="col-sm-2 text-right">
+                    <button class="btn btn-sm btn-danger delete" data-type="{%=file.deleteType%}" data-url="{%=file.deleteUrl%}"{% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
+                        <i class="glyphicon glyphicon-trash"></i>
+                        Delete
+                    </button>
+                </div>
             </div>
-          </div>
-        </td>
-    </tr>
-{% } %}
-</script>
-
-<!-- Simpler display of files available for download. Originally from hyrax/base/_form_files -->
-<!-- TODO: further consolidate with template-download above -->
-<script id="template-download" type="text/x-tmpl">
-{% for (var i=0, file; file=o.files[i]; i++) { %}
-    <tr class="template-download <%= fade_class_if_not_test %>">
-        <td>
-            <span class="preview">
-                {% if (file.thumbnailUrl) { %}
-                    <a href="{%=file.url%}" title="{%=file.name%}" download="{%=file.name%}" data-gallery><img src="{%=file.thumbnailUrl%}"></a>
-                {% } %}
-            </span>
-        </td>
-        <td>
-            <p class="name">
-                {% if (file.url) { %}
-                    <a href="{%=file.url%}" title="{%=file.name%}" download="{%=file.name%}" {%=file.thumbnailUrl?'data-gallery':''%}>{%=file.name%}</a>
-                {% } else { %}
-                    <span>{%=file.name%}</span>
-                {% } %}
-                <input type="hidden" name="uploaded_files[]" value="{%=file.id%}">
-            </p>
-            {% if (file.error) { %}
-                <div><span class="label label-danger">Error</span> {%=file.error%}</div>
-            {% } %}
-        </td>
-        <td>
-            <span class="size">{%=o.formatFileSize(file.size)%}</span>
-        </td>
-        <td class="text-right">
-            <button class="btn btn-sm btn-danger delete" data-type="{%=file.deleteType%}" data-url="{%=file.deleteUrl%}"{% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
-                <i class="glyphicon glyphicon-trash"></i>
-                Delete
-            </button>
+            <div class="row">
+                <label for="title_{%=file.id%}" class="col-sm-2 control-label">Display label</label>
+                <div class="col-sm-10 padding-bottom">
+                    <input type="text" class="form-control" name="title[{%=file.id%}]" id="title_{%=file.id%}" value="{%=file.name%}">
+                </div>
+            </div>
         </td>
     </tr>
 {% } %}


### PR DESCRIPTION
Fixes #457

Restructured the rows for the file uploader in both Batch Create and the Files tab in a individual work. Merged them both into the same script. Added new CSS rules that properly cut off a very long file name (depending on the screen size), and resizing the progress bar correctly.