### PR TITLE
Enables the collection facets

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -53,6 +53,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("language", :facetable), limit: 5
     config.add_facet_field solr_name("publisher", :facetable), limit: 5
     config.add_facet_field solr_name("date_created", :facetable), label: "Date Created", limit: 5
+    config.add_facet_field solr_name('member_of_collection_ids', :symbol), limit: 5, label: 'Collections', helper_method: :collection_title_by_id
 
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile

--- a/spec/features/hyrax/catalog_search_spec.rb
+++ b/spec/features/hyrax/catalog_search_spec.rb
@@ -22,17 +22,18 @@ RSpec.describe 'catalog searching', type: :feature do
       create(:public_work, title: ["Jack's Research"], subject: ['jacks_subject', 'shared_subject'])
     end
 
-    let!(:collection) { create(:public_collection, collection_type_gid: collection_type.gid, keyword: ['collection_subject', 'shared_subject']) }
+    let!(:collection) { create(:public_collection, collection_type_gid: collection_type.gid, subject: ['collection_subject', 'shared_subject']) }
 
     it 'performing a search' do
       within('#search-form-header') do
-        fill_in('search-field-header', with: 'Research')
+        fill_in('search-field-header', with: 'shared_subject')
         click_button('Go')
       end
 
       expect(page).to have_content('Search Results')
       expect(page).to have_content(jills_work.title.first)
       expect(page).to have_content(jacks_work.title.first)
+      expect(page).to have_content(collection.title.first)
     end
   end
 
@@ -51,6 +52,7 @@ RSpec.describe 'catalog searching', type: :feature do
 
       expect(page).to have_content('Search Results')
       expect(page).to have_content(jills_work.title.first)
+      expect(page).not_to have_content(collection.title.first)
       expect(page).not_to have_css('.blacklight-member_of_collection_ids_ssim')
     end
 
@@ -73,6 +75,8 @@ RSpec.describe 'catalog searching', type: :feature do
 
         expect(page).to have_content('Search Results')
         expect(page).to have_content(jills_work.title.first)
+        find('.blacklight-member_of_collection_ids_ssim').click
+        expect(page).to have_content(collection.title.first)
       end
     end
   end


### PR DESCRIPTION
Fixes #477 

Add the collection facet back to the catalog controller.
Adds the test back.