### PR TITLE
Remove rights from all forms

### DIFF
--- a/app/forms/hyrax/article_form.rb
+++ b/app/forms/hyrax/article_form.rb
@@ -16,14 +16,14 @@ module Hyrax
     self.terms += %i[college department]
 
     ## Removing terms that we don't use
-    self.terms -= %i[keyword source contributor based_near identifier resource_type]
+    self.terms -= %i[rights_statement keyword source contributor based_near identifier resource_type]
 
     ## Setting custom required fields
     self.required_fields = %i[title creator college department description license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + %i[rights_statement publisher date_created alternate_title journal_title issn subject
+      required_fields + %i[publisher date_created alternate_title journal_title issn subject
                            geo_subject time_period language required_software note related_url]
     end
 

--- a/app/forms/hyrax/dataset_form.rb
+++ b/app/forms/hyrax/dataset_form.rb
@@ -17,14 +17,14 @@ module Hyrax
     self.terms += %i[college department]
 
     ## Removing terms that we don't use
-    self.terms -= %i[keyword source contributor based_near identifier resource_type]
+    self.terms -= %i[rights_statement keyword source contributor based_near identifier resource_type]
 
     ## Setting custom required fields
     self.required_fields = %i[title creator college department description required_software license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      %i[title creator college department description required_software license rights_statement
+      %i[title creator college department description required_software license
          publisher date_created alternate_title subject geo_subject time_period language
          note related_url]
     end

--- a/app/forms/hyrax/document_form.rb
+++ b/app/forms/hyrax/document_form.rb
@@ -16,14 +16,14 @@ module Hyrax
     self.terms += %i[college department]
 
     ## Removing terms that we don't use
-    self.terms -= %i[keyword source contributor based_near identifier resource_type]
+    self.terms -= %i[rights_statement keyword source contributor based_near identifier resource_type]
 
     ## Setting custom required fields
     self.required_fields = %i[title creator college department description license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + %i[rights_statement publisher date_created alternate_title genre subject geo_subject time_period
+      required_fields + %i[publisher date_created alternate_title genre subject geo_subject time_period
                            language required_software note related_url]
     end
 

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -17,14 +17,14 @@ module Hyrax
     self.terms += %i[college department]
 
     ## Removing terms that we don't use
-    self.terms -= %i[keyword source contributor based_near identifier resource_type]
+    self.terms -= %i[rights_statement keyword source contributor based_near identifier resource_type]
 
     ## Setting custom required fields
     self.required_fields = %i[title creator college department description advisor license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + %i[rights_statement committee_member degree
+      required_fields + %i[committee_member degree
                            date_created publisher alternate_title genre subject
                            geo_subject time_period language
                            required_software note related_url]

--- a/app/forms/hyrax/forms/batch_upload_form.rb
+++ b/app/forms/hyrax/forms/batch_upload_form.rb
@@ -5,7 +5,7 @@ require Hyrax::Engine.root.join('app/forms/hyrax/forms/batch_upload_form.rb')
 module Hyrax
   module Forms
     class BatchUploadForm < Hyrax::Forms::WorkForm
-      self.terms = %i[creator description license rights_statement publisher
+      self.terms = %i[creator description license publisher
                       date_created subject language identifier based_near related_url representative_id
                       thumbnail_id files visibility_during_embargo embargo_release_date
                       visibility_after_embargo visibility_during_lease
@@ -31,36 +31,36 @@ module Hyrax
       def primary_terms
         case @payload_concern
         when "Dataset"
-          %i[creator college department description required_software license rights_statement
+          %i[creator college department description required_software license
              publisher date_created alternate_title subject geo_subject
              time_period language note related_url]
         when "StudentWork"
-          %i[creator college department description advisor license rights_statement
+          %i[creator college department description advisor license
              degree publisher date_created alternate_title genre subject geo_subject
              time_period language required_software note related_url]
         when "Etd"
           %i[creator college department description advisor
-             license rights_statement committee_member degree date_created publisher
+             license committee_member degree date_created publisher
              alternate_title genre subject geo_subject time_period
              language required_software note related_url]
         when "Article"
-          %i[creator college department description license rights_statement publisher
+          %i[creator college department description license publisher
              date_created alternate_title journal_title issn subject
              geo_subject time_period language required_software note related_url]
         when "Document"
-          %i[creator college department description license rights_statement publisher
+          %i[creator college department description license publisher
              date_created alternate_title genre subject geo_subject
              time_period language required_software note related_url]
         when "Image"
-          %i[creator college department description license rights_statement publisher
+          %i[creator college department description license publisher
              date_created alternate_title genre subject geo_subject
              time_period language required_software note related_url]
         when "Medium"
-          %i[creator college department description license rights_statement publisher
+          %i[creator college department description license publisher
              date_created alternate_title subject geo_subject
              time_period language required_software note related_url]
         else
-          %i[creator college department description license rights_statement publisher
+          %i[creator college department description license publisher
              date_created alternate_title subject geo_subject
              time_period language required_software note related_url]
         end

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -17,14 +17,14 @@ module Hyrax
     self.terms += %i[college department]
 
     ## Removing terms that we don't use
-    self.terms -= %i[keyword source contributor description based_near identifier resource_type]
+    self.terms -= %i[rights_statement keyword source contributor description based_near identifier resource_type]
 
     ## Setting custom required fields
     self.required_fields = %i[title creator college department description license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + %i[rights_statement publisher date_created alternate_title subject geo_subject time_period
+      required_fields + %i[publisher date_created alternate_title subject geo_subject time_period
                            language required_software note related_url]
     end
 

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -17,14 +17,14 @@ module Hyrax
     self.terms += %i[college department]
 
     ## Removing terms that we don't use
-    self.terms -= %i[keyword source contributor identifier based_near resource_type]
+    self.terms -= %i[rights_statement keyword source contributor identifier based_near resource_type]
 
     ## Setting custom required fields
     self.required_fields = %i[title creator college department description license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + %i[rights_statement publisher date_created alternate_title genre subject geo_subject time_period
+      required_fields + %i[publisher date_created alternate_title genre subject geo_subject time_period
                            language required_software note related_url]
     end
 

--- a/app/forms/hyrax/medium_form.rb
+++ b/app/forms/hyrax/medium_form.rb
@@ -18,14 +18,14 @@ module Hyrax
     self.terms += %i[college department]
 
     ## Removing terms that we don't use
-    self.terms -= %i[keyword source contributor identifier based_near resource_type]
+    self.terms -= %i[rights_statement keyword source contributor identifier based_near resource_type]
 
     ## Setting custom required fields
     self.required_fields = %i[title creator college department description license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + %i[rights_statement publisher date_created alternate_title subject geo_subject time_period
+      required_fields + %i[publisher date_created alternate_title subject geo_subject time_period
                            language required_software note related_url]
     end
 

--- a/app/forms/hyrax/student_work_form.rb
+++ b/app/forms/hyrax/student_work_form.rb
@@ -18,14 +18,14 @@ module Hyrax
     self.terms += %i[college department]
 
     ## Removing terms that we don't use
-    self.terms -= %i[keyword source contributor identifier based_near resource_type]
+    self.terms -= %i[rights_statement keyword source contributor identifier based_near resource_type]
 
     ## Setting custom required fields
     self.required_fields = %i[title creator college department description advisor license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + %i[rights_statement degree publisher date_created alternate_title genre subject geo_subject time_period
+      required_fields + %i[degree publisher date_created alternate_title genre subject geo_subject time_period
                            language required_software note related_url]
     end
 

--- a/spec/features/create_article_spec.rb
+++ b/spec/features/create_article_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe 'Create a Article', js: true do
       college_element = find_by_id("article_college")
       college_element.select("Business")
 
-      select 'In Copyright', from: "article_rights_statement"
       expect(page).to have_content("License Wizard")
+      expect(page).not_to have_content('Rights statement')
       select 'Attribution-ShareAlike 4.0 International', from: 'article_license'
 
       fill_in('Author', with: 'Doe, Jane')

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe 'Create a Dataset', js: true do
       title_element = find_by_id("dataset_title")
       title_element.set("My Test Work  ") # Add whitespace to test it getting removed
 
-      select 'In Copyright', from: "dataset_rights_statement"
       expect(page).to have_content("License Wizard")
+      expect(page).not_to have_content('Rights statement')
       select 'Attribution-ShareAlike 4.0 International', from: "dataset_license"
 
       college_element = find_by_id("dataset_college")

--- a/spec/features/create_document_spec.rb
+++ b/spec/features/create_document_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe 'Create a Document', js: true do
       college_element = find_by_id("document_college")
       college_element.select("Business")
 
-      select 'In Copyright', from: "document_rights_statement"
       expect(page).to have_content("License Wizard")
+      expect(page).not_to have_content('Rights statement')
       select 'Attribution-ShareAlike 4.0 International', from: 'document_license'
 
       fill_in('Creator', with: 'Doe, Jane')

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe 'Create a Etd', js: true do
       college_element = find_by_id("etd_college")
       college_element.select("Business")
 
-      select 'In Copyright', from: "etd_rights_statement"
       expect(page).to have_content("License Wizard")
+      expect(page).not_to have_content('Rights statement')
       select 'Attribution-ShareAlike 4.0 International', from: 'etd_license'
 
       fill_in('Creator', with: 'Doe, Jane')

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe 'Create a Image', js: true do
       fill_in('Program or Department', with: 'University Department')
       fill_in('Description', with: 'This is a description')
 
-      select 'In Copyright', from: "image_rights_statement"
       expect(page).to have_content("License Wizard")
+      expect(page).not_to have_content('Rights statement')
       select 'Attribution-ShareAlike 4.0 International', from: "image_license"
 
       choose('image_visibility_open')

--- a/spec/features/create_medium_spec.rb
+++ b/spec/features/create_medium_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe 'Create a Medium', js: true do
       college_element = find_by_id("medium_college")
       college_element.select("Business")
 
-      select 'In Copyright', from: "medium_rights_statement"
       expect(page).to have_content("License Wizard")
+      expect(page).not_to have_content('Rights statement')
       select 'Attribution-ShareAlike 4.0 International', from: 'medium_license'
 
       fill_in('Creator', with: 'Doe, Jane')

--- a/spec/features/create_student_work_spec.rb
+++ b/spec/features/create_student_work_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe 'Create a StudentWork', js: true do
       title_element = find_by_id("student_work_title")
       title_element.set("My Test Work  ") # Add whitespace to test it getting removed
 
-      select 'In Copyright', from: "student_work_rights_statement"
       expect(page).to have_content("License Wizard")
+      expect(page).not_to have_content('Rights statement')
       select 'Attribution-ShareAlike 4.0 International', from: 'student_work_license'
 
       college_element = find_by_id("student_work_college")

--- a/spec/features/hyrax/create_work_spec.rb
+++ b/spec/features/hyrax/create_work_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
       college_element = find_by_id("generic_work_college")
       college_element.select("Business")
 
-      select 'In Copyright', from: "generic_work_rights_statement"
       expect(page).to have_content("License Wizard")
       select 'Attribution-ShareAlike 4.0 International', from: 'generic_work_license'
 
@@ -111,7 +110,6 @@ RSpec.describe 'Creating a new Work', :js, :workflow do
       title_element = find_by_id("generic_work_title")
       title_element.set("My Test Work  ") # Add whitespace to test it getting removed
 
-      select 'In Copyright', from: "generic_work_rights_statement"
       select 'Attribution-ShareAlike 4.0 International', from: 'generic_work_license'
 
       expect(page).to have_field("Creator", with: user.name_for_works)

--- a/spec/features/hyrax/dashboard/collection_spec.rb
+++ b/spec/features/hyrax/dashboard/collection_spec.rb
@@ -712,7 +712,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         title_element = find_by_id("generic_work_title")
         title_element.set("New Work for Collection")
 
-        select 'In Copyright', from: "generic_work_rights_statement"
         select 'Attribution-ShareAlike 4.0 International', from: 'generic_work_license'
 
         fill_in('Creator', with: 'Doe, Jane')

--- a/spec/features/hyrax/embargo_spec.rb
+++ b/spec/features/hyrax/embargo_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe 'embargo' do
       college_element = find_by_id("generic_work_college")
       college_element.select("Business")
 
-      select 'In Copyright', from: "generic_work_rights_statement"
       select 'Attribution-ShareAlike 4.0 International', from: 'generic_work_license'
 
       fill_in('Creator', with: 'Doe, Jane')

--- a/spec/forms/hyrax/article_form_spec.rb
+++ b/spec/forms/hyrax/article_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Hyrax::ArticleForm do
     subject { form.primary_terms }
 
     it {
-      is_expected.to eq [:title, :creator, :college, :department, :description, :license, :rights_statement, :publisher, :date_created,
+      is_expected.to eq [:title, :creator, :college, :department, :description, :license, :publisher, :date_created,
                          :alternate_title, :journal_title, :issn, :subject, :geo_subject, :time_period,
                          :language, :required_software, :note, :related_url]
     }
@@ -68,7 +68,6 @@ RSpec.describe Hyrax::ArticleForm do
       expect(attrib['title']).to eq ['foo']
       expect(attrib['description']).to be_nil
       expect(attrib['visibility']).to eq 'open'
-      expect(attrib['rights_statement']).to eq 'http://creativecommons.org/licenses/by/4.0/us/'
       expect(attrib['member_of_collection_ids']).to eq ['123456', 'abcdef']
     end
 

--- a/spec/forms/hyrax/batch_upload_form_spec.rb
+++ b/spec/forms/hyrax/batch_upload_form_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Hyrax::Forms::BatchUploadForm do
 
   describe "#terms" do
     let(:terms) do
-      %i[creator description license rights_statement publisher date_created subject
+      %i[creator description license publisher date_created subject
          language identifier based_near related_url representative_id
          thumbnail_id files visibility_during_embargo embargo_release_date
          visibility_after_embargo visibility_during_lease

--- a/spec/forms/hyrax/dataset_form_spec.rb
+++ b/spec/forms/hyrax/dataset_form_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Hyrax::DatasetForm do
 
     it {
       is_expected.to eq [:title, :creator, :college, :department, :description,
-                         :required_software, :license, :rights_statement, :publisher, :date_created,
+                         :required_software, :license, :publisher, :date_created,
                          :alternate_title, :subject, :geo_subject, :time_period,
                          :language, :note, :related_url]
     }
@@ -69,7 +69,6 @@ RSpec.describe Hyrax::DatasetForm do
       expect(attrib['title']).to eq ['foo']
       expect(attrib['description']).to be_nil
       expect(attrib['visibility']).to eq 'open'
-      expect(attrib['rights_statement']).to eq 'http://creativecommons.org/licenses/by/4.0/us/'
       expect(attrib['member_of_collection_ids']).to eq ['123456', 'abcdef']
     end
 

--- a/spec/forms/hyrax/document_form_spec.rb
+++ b/spec/forms/hyrax/document_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Hyrax::DocumentForm do
     subject { form.primary_terms }
 
     it {
-      is_expected.to eq [:title, :creator, :college, :department, :description, :license, :rights_statement,
+      is_expected.to eq [:title, :creator, :college, :department, :description, :license,
                          :publisher, :date_created, :alternate_title, :genre, :subject, :geo_subject,
                          :time_period, :language, :required_software, :note, :related_url]
     }
@@ -68,7 +68,6 @@ RSpec.describe Hyrax::DocumentForm do
       expect(attrib['title']).to eq ['foo']
       expect(attrib['description']).to be_nil
       expect(attrib['visibility']).to eq 'open'
-      expect(attrib['rights_statement']).to eq 'http://creativecommons.org/licenses/by/4.0/us/'
       expect(attrib['member_of_collection_ids']).to eq ['123456', 'abcdef']
     end
 

--- a/spec/forms/hyrax/etd_form_spec.rb
+++ b/spec/forms/hyrax/etd_form_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Hyrax::EtdForm do
 
     it {
       is_expected.to eq [:title, :creator, :college, :department, :description, :advisor,
-                         :license, :rights_statement, :committee_member, :degree, :date_created,
+                         :license, :committee_member, :degree, :date_created,
                          :publisher, :alternate_title, :genre, :subject, :geo_subject,
                          :time_period, :language, :required_software, :note, :related_url]
     }
@@ -69,7 +69,6 @@ RSpec.describe Hyrax::EtdForm do
       expect(attrib['title']).to eq ['foo']
       expect(attrib['description']).to be_nil
       expect(attrib['visibility']).to eq 'open'
-      expect(attrib['rights_statement']).to eq 'http://creativecommons.org/licenses/by/4.0/us/'
       expect(attrib['member_of_collection_ids']).to eq ['123456', 'abcdef']
     end
 

--- a/spec/forms/hyrax/generic_work_form_spec.rb
+++ b/spec/forms/hyrax/generic_work_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Hyrax::GenericWorkForm do
     subject { form.primary_terms }
 
     it {
-      is_expected.to eq [:title, :creator, :college, :department, :description, :license, :rights_statement,
+      is_expected.to eq [:title, :creator, :college, :department, :description, :license,
                          :publisher, :date_created, :alternate_title, :subject, :geo_subject,
                          :time_period, :language, :required_software, :note, :related_url]
     }
@@ -68,7 +68,6 @@ RSpec.describe Hyrax::GenericWorkForm do
       expect(attrib['title']).to eq ['foo']
       expect(attrib['description']).to be_nil
       expect(attrib['visibility']).to eq 'open'
-      expect(attrib['rights_statement']).to eq 'http://creativecommons.org/licenses/by/4.0/us/'
       expect(attrib['member_of_collection_ids']).to eq ['123456', 'abcdef']
     end
 

--- a/spec/forms/hyrax/image_form_spec.rb
+++ b/spec/forms/hyrax/image_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Hyrax::ImageForm do
     subject { form.primary_terms }
 
     it {
-      is_expected.to eq [:title, :creator, :college, :department, :description, :license, :rights_statement,
+      is_expected.to eq [:title, :creator, :college, :department, :description, :license,
                          :publisher, :date_created, :alternate_title, :genre, :subject, :geo_subject, :time_period,
                          :language, :required_software, :note, :related_url]
     }
@@ -68,7 +68,6 @@ RSpec.describe Hyrax::ImageForm do
       expect(attrib['title']).to eq ['foo']
       expect(attrib['description']).to be_nil
       expect(attrib['visibility']).to eq 'open'
-      expect(attrib['rights_statement']).to eq 'http://creativecommons.org/licenses/by/4.0/us/'
       expect(attrib['member_of_collection_ids']).to eq ['123456', 'abcdef']
     end
 

--- a/spec/forms/hyrax/medium_form_spec.rb
+++ b/spec/forms/hyrax/medium_form_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Hyrax::MediumForm do
 
     it {
       is_expected.to eq [:title, :creator, :college, :department, :description,
-                         :license, :rights_statement, :publisher, :date_created, :alternate_title, :subject, :geo_subject,
+                         :license, :publisher, :date_created, :alternate_title, :subject, :geo_subject,
                          :time_period, :language, :required_software, :note, :related_url]
     }
   end
@@ -68,7 +68,6 @@ RSpec.describe Hyrax::MediumForm do
       expect(attrib['title']).to eq ['foo']
       expect(attrib['description']).to be_nil
       expect(attrib['visibility']).to eq 'open'
-      expect(attrib['rights_statement']).to eq 'http://creativecommons.org/licenses/by/4.0/us/'
       expect(attrib['member_of_collection_ids']).to eq ['123456', 'abcdef']
     end
 

--- a/spec/forms/hyrax/student_work_form_spec.rb
+++ b/spec/forms/hyrax/student_work_form_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Hyrax::StudentWorkForm do
 
     it {
       is_expected.to eq [:title, :creator, :college, :department, :description,
-                         :advisor, :license, :rights_statement, :degree, :publisher,
+                         :advisor, :license, :degree, :publisher,
                          :date_created, :alternate_title, :genre, :subject, :geo_subject,
                          :time_period, :language, :required_software, :note, :related_url]
     }
@@ -69,7 +69,6 @@ RSpec.describe Hyrax::StudentWorkForm do
       expect(attrib['title']).to eq ['foo']
       expect(attrib['description']).to be_nil
       expect(attrib['visibility']).to eq 'open'
-      expect(attrib['rights_statement']).to eq 'http://creativecommons.org/licenses/by/4.0/us/'
       expect(attrib['member_of_collection_ids']).to eq ['123456', 'abcdef']
     end
 

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
     expect(page).to have_content('The more descriptive information you provide')
   end
 
+  it "does not display rights" do
+    expect(page).not_to have_content('Rights statement')
+  end
+
   context 'with secondary terms' do
     let(:additional_fields) { true }
 


### PR DESCRIPTION
Fixes #470

Removes all rights_statement from the required terms for all forms, and removes it from the self.terms. Also modifies all of the current specs that check for rights and doens't include that anymore.