### PR TITLE
Fix removing citation features

### DIFF
--- a/spec/features/hyrax/work_show_spec.rb
+++ b/spec/features/hyrax/work_show_spec.rb
@@ -75,15 +75,6 @@ RSpec.describe "display a work as its owner" do
 
       # has some social media buttons
       expect(page).to have_link '', href: "https://twitter.com/intent/tweet/?#{page_title}&url=http%3A%2F%2Fwww.example.com%2Fconcern%2Fgeneric_works%2F#{work.id}"
-
-      # exports EndNote
-      expect(page).to have_link 'EndNote'
-      click_link 'EndNote'
-      expect(page).to have_content '%0 Generic Work'
-      expect(page).to have_content '%T Magnificent splendor'
-      expect(page).to have_content '%R http://localhost/files/'
-      expect(page).to have_content '%W University of Cincinnati'
-      expect(page).to have_content '%~ Scholar@UC'
     end
   end
 end


### PR DESCRIPTION
Fixes #460

Removes a check for Endnote that was left in a spec. It wasn't caught before it got merged for some reason.