### PR TITLE
Port over Scholar 3 proxy removal feature.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,6 +123,7 @@ RSpec/ExampleLength:
     - 'spec/controllers/hyrax/batch_uploads_controller_spec.rb'
     - 'spec/features/create_collection_spec.rb'
     - 'spec/features/catalog_facet_spec.rb'
+    - 'spec/jobs/proxy_edit_removal_job_spec.rb'
 
 RSpec/ExpectActual:
   Enabled: false

--- a/app/controllers/hyrax/depositors_controller.rb
+++ b/app/controllers/hyrax/depositors_controller.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 require Hyrax::Engine.root.join('app/controllers/hyrax/depositors_controller.rb')
 module Hyrax
   class DepositorsController < ApplicationController
@@ -7,6 +6,8 @@ module Hyrax
       grantor = authorize_and_return_grantor
       grantee = ::User.from_url_component(params[:id])
       send_removed_proxy_email(grantor, grantee) if grantor.can_receive_deposits_from.delete(grantee)
+      grantor.can_receive_deposits_from.delete(::User.from_url_component(params[:id]))
+      ProxyEditRemovalJob.perform_now(grantor, ::User.from_url_component(params[:id]))
       head :ok
     end
 

--- a/app/jobs/proxy_edit_removal_job.rb
+++ b/app/jobs/proxy_edit_removal_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class ProxyEditRemovalJob < ActiveJob::Base
+  queue_as :proxy_removal
+
+  def perform(grantor, proxy)
+    type = Hyrax.config.curation_concerns
+    #    type = Hyrax.config.registered_curation_concern_types
+    type.each do |klass|
+      klass.find_each('edit_access_person_ssim' => [proxy.email]) do |work|
+        next unless (work.on_behalf_of == grantor.email) && (work.proxy_depositor == proxy.email)
+        work.remove_proxy_from_work(work, proxy)
+      end
+    end
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@
 #  `rails generate hyrax:work Article`
 class Article < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
+  include RemoveProxyEditors::RemoveUser
 
   self.indexer = ArticleIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/concerns/remove_proxy_editors.rb
+++ b/app/models/concerns/remove_proxy_editors.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module RemoveProxyEditors
+  module RemoveUser
+    def remove_proxy_from_work(work, proxy)
+      work.file_sets.each do |file|
+        file.edit_users -= [proxy.email]
+        file.save!
+        file.to_solr
+      end
+      work.edit_users -= [proxy.email]
+      work.save!
+      work.to_solr
+    end
+  end
+end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -4,6 +4,7 @@
 #  `rails generate hyrax:work Dataset`
 class Dataset < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
+  include RemoveProxyEditors::RemoveUser
 
   self.indexer = DatasetIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -4,6 +4,7 @@
 #  `rails generate hyrax:work Document`
 class Document < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
+  include RemoveProxyEditors::RemoveUser
 
   self.indexer = DocumentIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -4,6 +4,7 @@
 #  `rails generate hyrax:work Etd`
 class Etd < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
+  include RemoveProxyEditors::RemoveUser
 
   self.indexer = EtdIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -4,6 +4,7 @@
 #  `rails generate hyrax:work GenericWork`
 class GenericWork < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
+  include RemoveProxyEditors::RemoveUser
 
   self.indexer = GenericWorkIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -4,6 +4,7 @@
 #  `rails generate hyrax:work Image`
 class Image < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
+  include RemoveProxyEditors::RemoveUser
 
   self.indexer = ImageIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -4,6 +4,7 @@
 #  `rails generate hyrax:work Medium`
 class Medium < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
+  include RemoveProxyEditors::RemoveUser
 
   self.indexer = MediumIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/student_work.rb
+++ b/app/models/student_work.rb
@@ -4,6 +4,7 @@
 #  `rails generate hyrax:work StudentWork`
 class StudentWork < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
+  include RemoveProxyEditors::RemoveUser
 
   self.indexer = StudentWorkIndexer
   # Change this to restrict which works can be added as a child.

--- a/spec/features/hyrax/proxy_spec.rb
+++ b/spec/features/hyrax/proxy_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 RSpec.describe 'proxy', type: :feature do
   let(:user) { create(:user) }
-  let(:second_user) { create(:user) }
+  let(:second_user) { create(:user, display_name: 'Second User') }
 
-  describe 'add proxy in profile', :js do
+  describe 'add proxy in dashboard', :js do
     it "creates a proxy" do
       sign_in user
       visit "/dashboard"
@@ -25,6 +25,96 @@ RSpec.describe 'proxy', type: :feature do
 
       expect(page).to have_css('td.depositor-name', text: second_user.name)
       expect(page).to have_link('Delete Proxy')
+    end
+  end
+
+  describe 'as proxy', js: true, clean_repo: true do
+    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
+    let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+
+    before do
+      # Create a single action that can be taken
+      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+
+      # Grant the user access to deposit into the admin set.
+      Hyrax::PermissionTemplateAccess.create!(
+        permission_template_id: permission_template.id,
+        agent_type: 'second_user',
+        agent_id: second_user.user_key,
+        access: 'deposit'
+      )
+
+      sign_in user
+      visit '/dashboard'
+      within 'div#proxy_management' do
+        click_link "Manage Proxies"
+      end
+      sleep(5)
+      find('a.select2-choice').click
+      find(".select2-input").set(second_user.user_key)
+      expect(page).to have_css("div.select2-result-label")
+      find("div.select2-result-label").click
+      sleep(5)
+      logout
+    end
+
+    it "is able to create, edit, and delete work on behalf of" do
+      sign_in second_user
+      visit '/dashboard'
+      within('.sidebar') do
+        click_link "Works"
+      end
+      click_link "Add new work"
+      expect(page).to have_link('Add New', href: '/concern/generic_works/new?locale=en')
+      click_link('Add New', href: '/concern/generic_works/new?locale=en')
+      sleep(5)
+      title_element = find_by_id("generic_work_title")
+      title_element.set("My proxy submitted work")
+      fill_in('Creator', with: 'Grantor')
+      fill_in('Description', with: 'A proxy deposited work')
+      select 'All rights reserved', from: "generic_work_license"
+      select(user.user_key, from: 'On behalf of')
+      check('agreement')
+      click_on('Save')
+
+      # Edit
+      expect(page).to have_link 'Edit'
+      click_link 'Edit'
+      expect(current_path).to include('edit')
+      fill_in('Creator', with: 'Edited grantor')
+      fill_in('Description', with: 'An edited proxy deposited work')
+      check('agreement')
+      page.find('#savewidget').click
+      page.find('#with_files_submit').click
+      sleep(10)
+      expect(current_path).to include('/concern/generic_works/')
+      expect(page).to have_content('Edited grantor')
+
+      # Delete
+      expect(page).to have_link 'Delete'
+      click_link 'Delete'
+      page.driver.browser.switch_to.alert.accept
+      expect(page).to have_content 'Deleted'
+    end
+
+    it "removes a proxy" do
+      sign_in user
+      visit '/dashboard'
+      within 'div#proxy_management' do
+        click_link "Manage Proxies"
+      end
+      sleep(5)
+      click_link 'Delete Proxy'
+      expect(page).not_to have_content(second_user.display_name)
+      logout
+      sign_in second_user
+      visit '/dashboard'
+      within('.sidebar') do
+        click_link "Works"
+      end
+      #      click_link 'Managed Works'
+      expect(page).not_to have_content "My proxy submitted work"
     end
   end
 end

--- a/spec/jobs/proxy_edit_removal_job_spec.rb
+++ b/spec/jobs/proxy_edit_removal_job_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe ProxyEditRemovalJob do
+  let!(:current_user) { create(:user) }
+  let!(:proxy) { create(:user) }
+
+  let!(:work) { FactoryBot.build(:generic_work, user: proxy, depositor: current_user.email, edit_users: [current_user, proxy], proxy_depositor: proxy.email, on_behalf_of: current_user.email) }
+  let!(:file_set) { FactoryBot.build(:file_set, user: proxy, depositor: current_user.email, edit_users: [current_user, proxy], title: ['ABC123xyz']) }
+
+  before do
+    work.ordered_members << file_set
+    work.save!
+  end
+
+  it "removes proxy user as an editor" do
+    expect(file_set.edit_users).to include proxy.email
+    described_class.perform_now(current_user, proxy)
+    work.reload
+    file_set.reload
+    expect(work.edit_users).not_to include proxy.email
+    expect(file_set.edit_users).not_to include proxy.email
+  end
+end


### PR DESCRIPTION
Present short summary (50 characters or less)

This PR contains the feature test for the proxy CRUD and the code for the proxy removal job that removes edit access to works after removal of proxy.

Note:  You may need redis and sidekiq running to test this code.