### PR TITLE
handle slashes in paths for riiif

### DIFF
--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -7,7 +7,7 @@ Riiif::Image.info_service = lambda do |id, _file|
   # but we just want the id for the FileSet it's attached to.
 
   # Capture everything before the first slash
-  fs_id = id.sub(/\A([^\/]*)\/.*/, '\1')
+  fs_id = URI.decode(id).sub(/\A([^\/]*)\/.*/, '\1')
   resp = ActiveFedora::SolrService.get("id:#{fs_id}")
   doc = resp['response']['docs'].first
   raise "Unable to find solr document with id:#{fs_id}" unless doc
@@ -19,8 +19,6 @@ Riiif::Image.file_resolver.id_to_uri = lambda do |id|
     Rails.logger.info "Riiif resolved #{id} to #{url}"
   end
 end
-
-Riiif::Image.authorization_service = Hyrax::IIIFAuthorizationService
 
 Riiif.not_found_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
 Riiif.unauthorized_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')


### PR DESCRIPTION
Fixes #492 

Migrate configuration to handle encoded slashes in paths for riiif viewer.

Changes proposed in this pull request:
* `config/initializers/riiif.rb`
