### PR TITLE
Add noid initializer

### DIFF
--- a/config/initializers/noid_rails.rb
+++ b/config/initializers/noid_rails.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+::Noid::Rails.config.identifier_in_use = lambda do |id|
+  ActiveFedora::Base.exists?(id) || ActiveFedora::Base.gone?(id)
+end


### PR DESCRIPTION
Fixes #515 
Add noid initializer to prevent LDP::Conflict error.

Changes proposed in this pull request:
* Add `config/initializers/noid_rails.rb`
