### PR TITLE
fix etd :type/:genre field persistence

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -35,7 +35,7 @@ class Etd < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
-  property :genre, predicate: ::RDF::URI.new('http://purl.org/dc/terms/type#genre') do |index|
+  property :genre, predicate: ::RDF::URI.new('http://purl.org/dc/terms/type#genre'), multiple: false do |index|
     index.as :stored_searchable, :facetable
   end
 

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Etd do
     it { is_expected.to respond_to(:subject) }
     it { is_expected.to respond_to(:geo_subject) }
     it { is_expected.to respond_to(:required_software) }
+    it { is_expected.to respond_to(:genre) }
     it { is_expected.to respond_to(:note) }
     it { is_expected.to respond_to(:language) }
     it { is_expected.to respond_to(:identifier) }


### PR DESCRIPTION
Fixes #514 

Genre was not persisting on ETDs because of incomplete config for the attribute on the model.

Changes proposed in this pull request:
* Specify not_multi for :genre on the etd model
* Add :genre attribute to model spec
