### PR TITLE
add etd_genre test to ETD feature spec

### DIFF
--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'Create a Etd', :feature, js: true do
       expect(page).to have_select('etd_license', selected: license)
       expect(page).to have_field('Publisher (Required for DOI registration)', with: publisher)
       expect(page).to have_field('etd_alternate_title', with: alternate_title)
-      # expect(page).to have_select('etd_genre', selected: type) # This is broken see https://github.com/uclibs/ucrate/issues/514
+      expect(page).to have_select('etd_genre', selected: type)
       expect(page).to have_field('Subject', with: subject_term)
       expect(page).to have_field('Geographic Subject', with: geographic_subject)
       expect(page).to have_field('Time Period', with: time_period)


### PR DESCRIPTION
Fixes #521 

Include check for :etd_genre persistence in create ETD feature spec

Changes proposed in this pull request:
* add :etd_genre check to `spec/features/create_etd_feature_spec.rb`
