### PR TITLE
Datasets should not require the Required Software field

### DIFF
--- a/app/forms/hyrax/dataset_form.rb
+++ b/app/forms/hyrax/dataset_form.rb
@@ -20,7 +20,7 @@ module Hyrax
     self.terms -= %i[rights_statement keyword source contributor based_near identifier resource_type]
 
     ## Setting custom required fields
-    self.required_fields = %i[title creator college department description required_software license]
+    self.required_fields = %i[title creator college department description license]
 
     ## Adding above the fold on the form without making this required
     def primary_terms

--- a/app/forms/hyrax/forms/batch_upload_form.rb
+++ b/app/forms/hyrax/forms/batch_upload_form.rb
@@ -18,7 +18,7 @@ module Hyrax
       def required_fields
         case @payload_concern
         when "Dataset"
-          %i[title creator college department description required_software license]
+          %i[title creator college department description license]
         when "Etd"
           %i[title creator college department description advisor license]
         when "StudentWork"

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe 'Create a Dataset', :feature, js: true do
       fill_in('Language', with: language)
       fill_in('Note', with: note)
       fill_in('External Link', with: external_link)
+      expect(page).to have_css("label.control-label.string.optional", text: "Required Software")
 
       choose('dataset_visibility_open')
       expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')

--- a/spec/forms/hyrax/dataset_form_spec.rb
+++ b/spec/forms/hyrax/dataset_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::DatasetForm do
   describe "#required_fields" do
     subject { form.required_fields }
 
-    it { is_expected.to eq [:title, :creator, :college, :department, :description, :required_software, :license] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :license] }
   end
 
   describe "#primary_terms" do


### PR DESCRIPTION
Fixes #527

Removes the Required Software field from the required fields in the form, and added a spec test to check that it is optional