### PR TITLE
Remove joined date from user profile page

### DIFF
--- a/app/views/hyrax/users/_vitals.html.erb
+++ b/app/views/hyrax/users/_vitals.html.erb
@@ -1,0 +1,14 @@
+<div class="list-group-item">
+  <span class="badge"><%= number_of_collections(user) %></span>
+  <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span> <%= link_to_field('depositor', user.to_s, t("hyrax.dashboard.stats.collections"), generic_type: "Collection") %>
+</div>
+
+<div class="list-group-item">
+  <span class="badge"><%= number_of_works(user) %></span>
+  <span class="glyphicon glyphicon-upload" aria-hidden="true"></span> <%= link_to_field('depositor', user.to_s, t("hyrax.dashboard.stats.works"), generic_type: "Work") %>
+
+  <ul class="views-downloads-dashboard list-unstyled">
+      <li><span class="badge badge-optional"><%= user.total_file_views %></span> <%= t("hyrax.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>
+      <li><span class="badge badge-optional"><%= user.total_file_downloads %></span> <%= t("hyrax.dashboard.stats.file_downloads").pluralize(user.total_file_downloads) %></li>
+  </ul>
+</div>

--- a/spec/features/hyrax/users_spec.rb
+++ b/spec/features/hyrax/users_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "User Spec", type: :feature do
 
       it 'page should be editable' do
         visit profile_path
+        expect(page).not_to have_content("Joined on")
         expect(page).to have_content(user.email)
 
         within '.highlighted-works' do


### PR DESCRIPTION
Fixes #526

Removes the joined date from the user profile page, and adds a test to check