### PR TITLE
User profile page displays ucdepartment instead of department

### DIFF
--- a/app/views/hyrax/users/_user_info.html.erb
+++ b/app/views/hyrax/users/_user_info.html.erb
@@ -56,9 +56,9 @@
     <dd><%= user.admin_area %></dd>
   <% end %>
 
-  <% if user.ucdepartment.present? %>
+  <% if user.department.present? %>
     <dt>Department</dt>
-    <dd><%= user.ucdepartment %></dd>
+    <dd><%= user.department %></dd>
   <% end %>
 
   <% if user.office %>


### PR DESCRIPTION
Fixes #525

Changes the dashboard profile view page to show the department, not the ucdepartment