### PR TITLE
Fix Selenium errors on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,4 @@ services:
 before_script:
   - jdk_switcher use oraclejdk8
   - bundle exec rubocop
+  - sudo mount -o remount,size=32G /run/shm

--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ end
 group :test do
   gem 'capybara', '~> 2.4', '< 2.18.0'
   gem 'capybara-maleficent', '~> 0.2'
-  gem "chromedriver-helper"
+  gem "chromedriver-helper", '< 2.0'
   gem 'coveralls', '~> 0.8.22', require: false
   gem 'database_cleaner'
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,7 @@ GEM
       mime-types (>= 1.16)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
+    chromedriver-helper (1.2.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
     clipboard-rails (1.7.1)
@@ -925,7 +925,7 @@ DEPENDENCIES
   capybara (~> 2.4, < 2.18.0)
   capybara-maleficent (~> 0.2)
   change_manager!
-  chromedriver-helper
+  chromedriver-helper (< 2.0)
   coffee-rails (~> 4.2)
   coveralls (~> 0.8.22)
   database_cleaner


### PR DESCRIPTION
Fixes #537 

Adds `sudo mount -o remount,size=32G /run/shm` to .travis.yml.  Seems to fix the `Selenium::WebDriver::Error::NoSuchDriverError` errors.

Also downgrades `chromedriver-helper` to < 2.0 because they've pinned it like that in Hyrax to resolve errors.

Refs https://github.com/freeCodeCamp/testable-projects-fcc/pull/324