### PR TITLE
Update ruby versin in sidekiq restart script

### DIFF
--- a/script/restart_sidekiq.sh
+++ b/script/restart_sidekiq.sh
@@ -23,7 +23,7 @@ fi
 $APP_DIRECTORY/script/kill_sidekiq.sh
 
 banner "starting Sidekiq"
-export PATH=$PATH:/srv/apps/.gem/ruby/2.4.0/bin
+export PATH=$PATH:/srv/apps/.gem/ruby/2.5.0/bin
 export FITS_HOME=/opt/fits/fits
 export PATH=$PATH:/opt/fits/fits
 cd $APP_DIRECTORY


### PR DESCRIPTION
Fixes #547 

Update restart-sidekiq script to use ruby-2.5.0.

Changes proposed in this pull request:
* `script/restart-sidekiq.sh`
