### PR TITLE
Ignore manifest csv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 !/log/.keep
 !/tmp/.keep
 dump.rdb
+vendor/*.csv
 
 # Ignore Byebug command history file.
 .byebug_history


### PR DESCRIPTION
Fixes #556 

Adds `vendor/*.csv` to the .gitignore file