### PR TITLE
Update embargo_manager.rake

### DIFF
--- a/lib/tasks/embargo_notify.rake
+++ b/lib/tasks/embargo_notify.rake
@@ -8,6 +8,7 @@ task embargo_notify: :environment do
   ONE_DAY = 1
   ZERO_DAYS = 0
   results_cap = 1_000_000
+  Time.zone = 'EST'
 
   solr_results = ActiveFedora::SolrService.query('embargo_release_date_dtsi:[* TO *]', rows: results_cap)
   solr_results.each do |work|


### PR DESCRIPTION
Fixes #555

Adds `Time.zone = 'EST'` to the lib/tasks/embargo_notify.rake file 