### PR TITLE
Turns off solr-suggest.

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -386,6 +386,8 @@
       -->
   </searchComponent>
 
+  <!-- TURN OFF SUGGEST - it causes performance issues -->
+  <!--
   <searchComponent name="suggest" class="solr.SuggestComponent">
     <lst name="suggester">
       <str name="name">mySuggester</str>
@@ -406,6 +408,7 @@
       <str>suggest</str>
     </arr>
   </requestHandler>
+  -->
 
 </config>
 

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -286,6 +286,8 @@
       -->
   </searchComponent>
 
+  <!-- TURN OFF SUGGEST - it causes performance issues -->
+  <!--
   <searchComponent name="suggest" class="solr.SuggestComponent">
     <lst name="suggester">
       <str name="name">mySuggester</str>
@@ -306,6 +308,7 @@
       <str>suggest</str>
     </arr>
   </requestHandler>
+  -->
 
   <requestHandler name="/update/extract" class="org.apache.solr.handler.extraction.ExtractingRequestHandler">
     <lst name="defaults">


### PR DESCRIPTION
Fixes #520 

Present short summary (50 characters or less)

Comments out suggestion search component in both of the solr config files.


