### PR TITLE
Removes the On behalf of on edit views.

### DIFF
--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -21,7 +21,8 @@
     <div class="set-access-controls list-group-item">
       <%= render 'form_visibility_component', f: f %>
     </div>
-    <% if Flipflop.proxy_deposit? && current_user.can_make_deposits_for.any? %>
+
+    <% if Flipflop.proxy_deposit? && current_user.can_make_deposits_for.any? && params[:action] != "edit" %>
         <div class="list-group-item">
           <%= f.input :on_behalf_of, collection: current_user.can_make_deposits_for.map(&:user_key), 
             prompt: "Yourself", onChange: 'setProxySelectionAsCreator(); setProxySelectionDeptAsDept(); setProxySelectionCollegeAsCollege()' %>


### PR DESCRIPTION
Fixes #510 

This PR hides the On behalf of when on the EDIT view.  This PR also reorganized the spec test around the form_progess to separate the Capybara part from the render part.