### PR TITLE
Adds support for Google Analytics.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -29,6 +29,7 @@ SCHOLAR_DATABASE_USERNAME=
 SCHOLAR_DEVISE_KEY=devise_secret_key
 
 # Google Analytics
+SCHOLAR_ANALYTICS_TOGGLE=false
 SCHOLAR_ANALYTICS_ID=analytics_id
 SCHOLAR_ANALYTICS_PRIVKEY_PATH=analytics_privkey_path
 SCHOLAR_ANALYTICS_PRIVKEY_SECRET=analytics_privkey_secret

--- a/.env.test
+++ b/.env.test
@@ -29,6 +29,7 @@ SCHOLAR_DATABASE_USERNAME=
 SCHOLAR_DEVISE_KEY=devise_secret_key
 
 # Google Analytics
+SCHOLAR_ANALYTICS_TOGGLE=false
 SCHOLAR_ANALYTICS_ID=analytics_id
 SCHOLAR_ANALYTICS_PRIVKEY_PATH=analytics_privkey_path
 SCHOLAR_ANALYTICS_PRIVKEY_SECRET=analytics_privkey_secret

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,7 @@ Metrics/MethodLength:
     - 'app/indexers/hyrax/file_set_indexer.rb'
     - 'spec/support/hyrax/helpers/factory_helpers.rb'
     - 'app/services/hyrax/actor_factory.rb'
+    - 'app/services/hyrax/custom_stat_importer.rb'
 
 Metrics/ClassLength:
   Exclude:
@@ -51,6 +52,10 @@ Rails/ApplicationRecord:
 Rails/DynamicFindBy:
   Enabled: false
 
+Rails/Output:
+  Exclude:
+    - 'app/services/hyrax/custom_stat_importer.rb'
+
 Rails/SkipsModelValidations:
   Exclude:
     - 'app/models/user.rb'
@@ -59,6 +64,7 @@ Rails/SkipsModelValidations:
 Rails/TimeZone:
   Exclude:
     - 'spec/services/collection_metadata_csv_factory_spec.rb'
+    - 'config/initializers/hyrax.rb'
 
 RSpec/AnyInstance:
   Exclude:
@@ -134,6 +140,8 @@ RSpec/ExampleLength:
     - 'spec/features/create_document_doi_spec.rb'
     - 'spec/jobs/identifier_delete_job_spec.rb'
     - 'spec/services/hyrax/default_middleware_stack_spec.rb'
+    - 'spec/models/work_and_file_index_spec.rb'
+    - 'spec/models/file_view_stat_spec.rb'
 
 RSpec/ExpectActual:
   Enabled: false
@@ -187,6 +195,8 @@ RSpec/NamedSubject:
     - 'spec/actors/hyrax/actors/mint_doi_actor_spec.rb'
     - 'spec/services/hyrax/actor_factory_spec.rb'
     - 'spec/services/hyrax/default_middleware_stack_spec.rb'
+    - 'spec/models/work_and_file_index_spec.rb'
+    - 'spec/services/hyrax/custom_stat_importer_spec.rb'
 
 Style/ClassAndModuleChildren:
   Enabled: false
@@ -217,6 +227,7 @@ Metrics/AbcSize:
     - 'app/indexers/hyrax/work_indexer.rb'
     - 'app/models/ability.rb'
     - 'app/indexers/hyrax/collection_indexer.rb'
+    - 'app/services/hyrax/custom_stat_importer.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:
@@ -230,3 +241,7 @@ Lint/HandleExceptions:
 
 RSpec/SubjectStub:
   Enabled: false    
+
+Lint/RescueException:
+  Exclude:
+    - 'app/services/hyrax/custom_stat_importer.rb'

--- a/app/models/hyrax/statistic.rb
+++ b/app/models/hyrax/statistic.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Hyrax
+  class Statistic < ActiveRecord::Base
+    self.abstract_class = true
+
+    class_attribute :cache_column, :event_type
+
+    class << self
+      include ActionDispatch::Routing::PolymorphicRoutes
+      include Rails.application.routes.url_helpers
+
+      def statistics_for(object)
+        where(filter(object))
+      end
+
+      def build_for(object, attrs)
+        new attrs.merge(filter(object))
+      end
+
+      def convert_date(date_time)
+        date_time.to_datetime.to_i * 1000
+      end
+
+      def statistics(object, start_date, user_id = nil)
+        combined_stats object, start_date, cache_column, event_type, user_id
+      end
+
+      # Hyrax::Download is sent to Hyrax::Analytics.profile as #hyrax__download
+      # see Legato::ProfileMethods.method_name_from_klass
+      def ga_statistics(start_date, object)
+        path = if object.class.to_s == 'FileSet'
+                 hyrax_parent_file_set_path(object.parent, object)
+               else
+                 polymorphic_path object
+               end
+
+        profile = Hyrax::Analytics.profile
+        unless profile
+          Rails.logger.error("Google Analytics profile has not been established. Unable to fetch statistics.")
+          return []
+        end
+        profile.hyrax__pageview(sort: 'date', start_date: start_date).for_path(path)
+      end
+
+      private
+
+        def cached_stats(object, start_date, _method)
+          stats = statistics_for(object).order(date: :asc)
+          ga_start_date = stats.any? ? stats[stats.size - 1].date + 1.day : start_date.to_date
+          { ga_start_date: ga_start_date, cached_stats: stats.to_a }
+        end
+
+        def combined_stats(object, start_date, object_method, ga_key, user_id = nil)
+          stat_cache_info = cached_stats(object, start_date, object_method)
+          stats = stat_cache_info[:cached_stats]
+          if stat_cache_info[:ga_start_date] < Time.zone.today
+            ga_stats = ga_statistics(stat_cache_info[:ga_start_date], object)
+            ga_stats.each do |stat|
+              lstat = build_for(object, date: stat[:date], object_method => stat[ga_key], user_id: user_id)
+              lstat.save unless Date.parse(stat[:date]) == Time.zone.today
+              stats << lstat
+            end
+          end
+          stats
+        end
+    end
+
+    def to_flot
+      [self.class.convert_date(date), send(cache_column)]
+    end
+  end
+end

--- a/app/models/work_and_file_index.rb
+++ b/app/models/work_and_file_index.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+class WorkAndFileIndex < ApplicationRecord
+  def update_stats_last_gathered
+    self.stats_last_gathered = Time.zone.today
+    save
+  end
+
+  def self.reset
+    destroy_all
+    index_works_and_files
+  end
+
+  def self.update_works_and_files
+    index_new_works
+    remove_deleted_works
+    index_new_files
+    remove_deleted_files
+  end
+
+  class << self
+    def index_works_and_files
+      all_works_with_users.each do |id, email|
+        create_new_work_index_record(email, id)
+      end
+
+      all_files_with_users.each do |id, email|
+        create_new_file_index_record(email, id)
+      end
+    end
+
+    def index_new_works
+      (all_works_with_users.keys - indexed_work_ids).each do |id|
+        create_new_work_index_record(all_works_with_users[id], id)
+      end
+    end
+
+    def index_new_files
+      (all_files_with_users.keys - indexed_file_ids).each do |id|
+        create_new_file_index_record(all_files_with_users[id], id)
+      end
+    end
+
+    def remove_deleted_works
+      (indexed_work_ids - all_work_ids).each do |id|
+        work_index_entry = find_by(object_id: id)
+        work_index_entry.destroy
+      end
+    end
+
+    def remove_deleted_files
+      (indexed_file_ids - all_file_ids).each do |id|
+        file_index_entry = find_by(object_id: id)
+        file_index_entry.destroy
+      end
+    end
+
+    def indexed_work_ids
+      where(object_type: "work").select("object_id").map(&:object_id)
+    end
+
+    def indexed_file_ids
+      where(object_type: "file").select("object_id").map(&:object_id)
+    end
+
+    def all_works_with_users
+      ids_with_users = {}
+      Hyrax::WorkRelation.new.search_in_batches("*:*", fl: "id, depositor_ssim") do |group|
+        group.each { |entry| ids_with_users[entry["id"]] = entry["depositor_ssim"].first }
+      end
+      ids_with_users
+    end
+
+    def all_work_ids
+      all_works_with_users.map { |id, _user| id }
+    end
+
+    def all_files_with_users
+      ids_with_users = {}
+      ::FileSet.search_in_batches("*:*", fl: "id, depositor_ssim") do |group|
+        group.each { |entry| ids_with_users[entry["id"]] = entry["depositor_ssim"].first }
+      end
+      ids_with_users
+    end
+
+    def all_file_ids
+      all_files_with_users.map { |id, _user| id }
+    end
+
+    def create_new_work_index_record(user_email, id)
+      create(user_email: user_email, object_id: id, object_type: "work")
+    end
+
+    def create_new_file_index_record(user_email, id)
+      create(user_email: user_email, object_id: id, object_type: "file")
+    end
+  end
+end

--- a/app/services/hyrax/custom_stat_importer.rb
+++ b/app/services/hyrax/custom_stat_importer.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+require 'legato'
+require 'hyrax/pageview'
+require 'hyrax/download'
+
+module Hyrax
+  class CustomStatImporter
+    attr_reader :start_date, :object
+    def initialize(object, options)
+      if options[:verbose]
+        stdout_logger = Logger.new(STDOUT)
+        stdout_logger.level = Logger::INFO
+        Rails.logger.extend(ActiveSupport::Logger.broadcast(stdout_logger))
+      end
+      @logging = options[:logging]
+      @delay_secs = options[:delay_secs].to_f
+      @number_of_retries = options[:number_of_retries].to_i
+      @object = object
+      @start_date = if object.stats_last_gathered.nil?
+                      Hyrax.config.analytic_start_date
+                    else
+                      object.stats_last_gathered
+                    end
+    end
+
+    def import
+      user = ::User.find_by_email(object.user_email)
+
+      case object.object_type
+      when "work"
+        begin
+          work = Hyrax::WorkRelation.new.find(object.object_id)
+
+          rescue_and_retry("Retried WorkViewStat on #{user} for work #{work.id} too many times.") do
+            WorkViewStat.statistics(work, start_date, user.id)
+          end
+
+          delay
+        rescue Exception => ex
+          puts ex.message.to_s
+          return
+        end
+      when "file"
+        begin
+          file = ::FileSet.find(object.object_id)
+
+          rescue_and_retry("Retried FileViewStat on #{user} for file #{file.id} too many times.") do
+            FileViewStat.statistics(file, start_date, user.id)
+          end
+          delay
+
+          rescue_and_retry("Retried FileDownloadStat on #{user} for file #{file.id} too many times.") do
+            FileDownloadStat.statistics(file, start_date, user.id)
+          end
+          delay
+        rescue Exception => ex
+          puts ex.message.to_s
+          return
+        end
+      end
+
+      object.update_stats_last_gathered
+    end
+
+    private
+
+      def delay
+        sleep @delay_secs
+      end
+
+      def rescue_and_retry(fail_message)
+        retry_count = 0
+        begin
+          return yield
+        rescue StandardError => e
+          retry_count += 1
+          if retry_count < @number_of_retries
+            delay
+            retry
+          else
+            log_message fail_message
+            log_message "Last exception #{e}"
+          end
+        end
+      end
+
+      def log_message(message)
+        Rails.logger.info "#{self.class}: #{message}" if @logging
+      end
+  end
+end

--- a/app/services/hyrax/user_stat_adder.rb
+++ b/app/services/hyrax/user_stat_adder.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+module Hyrax
+  class UserStatAdder
+    def self.reset_user_stats
+      delete_all_user_stats
+      add_up_all_the_user_stats
+    end
+
+    class << self
+      def delete_all_user_stats
+        UserStat.destroy_all
+      end
+
+      def add_up_all_the_user_stats
+        ::User.find_each do |user|
+          stats = {}
+          stats[:work_views] = total_work_views(user)
+          stats[:file_views] = total_file_views(user)
+          stats[:file_downloads] = total_file_downloads(user)
+
+          create_user_stat(stats, user)
+        end
+      end
+
+      def total_work_views(user)
+        stats_array = WorkViewStat.where(user_id: user.id).collect(&:work_views)
+        total = stats_array.inject(:+)
+
+        return 0 if total.nil?
+        total
+      end
+
+      def total_file_views(user)
+        stats_array = FileViewStat.where(user_id: user.id).collect(&:views)
+        total = stats_array.inject(:+)
+
+        return 0 if total.nil?
+        total
+      end
+
+      def total_file_downloads(user)
+        stats_array = FileDownloadStat.where(user_id: user.id).collect(&:downloads)
+        total = stats_array.inject(:+)
+
+        return 0 if total.nil?
+        total
+      end
+
+      def create_user_stat(stats, user)
+        date = Time.zone.today
+        user_stat = UserStat.new(user_id: user.id, date: date)
+
+        user_stat.file_views = stats.fetch(:file_views, 0)
+        user_stat.file_downloads = stats.fetch(:file_downloads, 0)
+        user_stat.work_views = stats.fetch(:work_views, 0)
+
+        user_stat.save!
+      end
+    end
+  end
+end

--- a/app/views/hyrax/users/_vitals.html.erb
+++ b/app/views/hyrax/users/_vitals.html.erb
@@ -8,6 +8,7 @@
   <span class="glyphicon glyphicon-upload" aria-hidden="true"></span> <%= link_to_field('depositor', user.to_s, t("hyrax.dashboard.stats.works"), generic_type: "Work") %>
 
   <ul class="views-downloads-dashboard list-unstyled">
+      <li><span class="badge badge-optional"><%= user.total_work_views %></span> <%= t("hyrax.dashboard.stats.work_views").pluralize(user.total_work_views) %></li>
       <li><span class="badge badge-optional"><%= user.total_file_views %></span> <%= t("hyrax.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>
       <li><span class="badge badge-optional"><%= user.total_file_downloads %></span> <%= t("hyrax.dashboard.stats.file_downloads").pluralize(user.total_file_downloads) %></li>
   </ul>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -49,7 +49,7 @@ Hyrax.config do |config|
   # Enable displaying usage statistics in the UI
   # Defaults to false
   # Requires a Google Analytics id and OAuth2 keyfile.  See README for more info
-  # config.analytics = false
+  config.analytics = ENV["SCHOLAR_ANALYTICS_TOGGLE"]
 
   # Google Analytics tracking ID to gather usage statistics
   config.google_analytics_id = ENV["SCHOLAR_ANALYTICS_ID"]
@@ -57,7 +57,7 @@ Hyrax.config do |config|
   # Date you wish to start collecting Google Analytic statistics for
   # Leaving it blank will set the start date to when ever the file was uploaded by
   # NOTE: if you have always sent analytics to GA for downloads and page views leave this commented out
-  # config.analytic_start_date = DateTime.new(2014, 9, 10)
+  config.analytic_start_date = DateTime.new(2017, 10, 31)
 
   # Enables a link to the citations page for a work
   # Default is false

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -124,6 +124,9 @@ en:
         export_collection: "Export Collection"
         manage_exports: "Manage Exports"
     dashboard:
+      stats:
+        file_views:             "File View"
+        work_views:             "Work View"
       my:
         action:
           export_collection: "Export collection"

--- a/db/migrate/20180328132422_work_and_file_index.rb
+++ b/db/migrate/20180328132422_work_and_file_index.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class WorkAndFileIndex < ActiveRecord::Migration[5.0]
+  def change
+    create_table :work_and_file_indices do |t|
+      t.string :object_id
+      t.string :object_type
+      t.string :user_email
+      t.datetime :stats_last_gathered
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -622,6 +622,15 @@ ActiveRecord::Schema.define(version: 20181128154405) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "work_and_file_indices", force: :cascade do |t|
+    t.string "object_id"
+    t.string "object_type"
+    t.string "user_email"
+    t.datetime "stats_last_gathered"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "work_view_stats", force: :cascade do |t|
     t.datetime "date"
     t.integer "work_views"

--- a/lib/tasks/custom_stats_tasks.rake
+++ b/lib/tasks/custom_stats_tasks.rake
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+namespace :custom_stats do
+  desc "reset work/file index"
+  task reset_index: :environment do
+    WorkAndFileIndex.reset
+  end
+
+  desc "update work/file index"
+  task update_index: :environment do
+    WorkAndFileIndex.update_works_and_files
+  end
+
+  desc "start user stats update"
+  task collect: :environment do
+    limit = ENV["LIMIT"].to_i
+    delay = ENV["DELAY"].to_i
+    retries = ENV["RETRIES"].to_i
+
+    WorkAndFileIndex.order(stats_last_gathered: :asc).limit(limit).each do |object|
+      importer = Hyrax::CustomStatImporter.new(object, delay_secs: delay, retries: retries, verbose: true, logging: true)
+      importer.import
+    end
+
+    Hyrax::UserStatAdder.reset_user_stats
+  end
+end

--- a/script/custom_stats.sh
+++ b/script/custom_stats.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Update work and file index, and update stats
+# Runs as a cron job daily 
+
+cd /srv/apps/curate_uc
+RAILS_ENV=production bundle exec rake custom_stats:update_index
+RAILS_ENV=production bundle exec rake custom_stats:collect LIMIT="1000" DELAY="2" RETRIES="8"

--- a/spec/models/file_view_stat_spec.rb
+++ b/spec/models/file_view_stat_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe FileViewStat, type: :model do
+  let(:file_id) { file.id }
+  let(:user_id) { 123 }
+  let(:date) { Time.current }
+  let(:file_stat) { described_class.create(views: "25", date: date, file_id: file_id, user_id: user_id) }
+  let(:file) { mock_model(FileSet, id: 99) }
+
+  it "has attributes" do
+    expect(file_stat).to respond_to(:views)
+    expect(file_stat).to respond_to(:date)
+    expect(file_stat).to respond_to(:file_id)
+    expect(file_stat.file_id).to eq("99")
+    expect(file_stat.date).to eq(date)
+    expect(file_stat.views).to eq(25)
+    expect(file_stat.user_id).to eq(user_id)
+  end
+
+  describe "#statistics" do
+    let(:dates) do
+      ldates = []
+      4.downto(0) { |idx| ldates << (Time.zone.now.beginning_of_day - idx.day) }
+      ldates
+    end
+    let(:date_strs) do
+      dates.map { |date| date.strftime("%Y%m%d") }
+    end
+
+    let(:view_output) do
+      [[statistic_date(dates[0]), 4], [statistic_date(dates[1]), 8], [statistic_date(dates[2]), 6], [statistic_date(dates[3]), 10]]
+    end
+
+    # This is what the data looks like that's returned from Google Analytics (GA) via the Legato gem
+    # Due to the nature of querying GA, testing this data in an automated fashion is problematc.
+    # Sample data structures were created by sending real events to GA from a test instance of
+    # Scholarsphere.  The data below are essentially a "cut and paste" from the output of query
+    # results from the Legato gem.
+    let(:sample_pageview_statistics) do
+      [
+        SpecStatistic.new(date: date_strs[0], pageviews: 4),
+        SpecStatistic.new(date: date_strs[1], pageviews: 8),
+        SpecStatistic.new(date: date_strs[2], pageviews: 6),
+        SpecStatistic.new(date: date_strs[3], pageviews: 10)
+      ]
+    end
+
+    describe "cache empty" do
+      let(:stats) do
+        expect(described_class).to receive(:ga_statistics).and_return(sample_pageview_statistics)
+        described_class.statistics(file, Time.zone.today - 4.days, user_id)
+      end
+
+      it "includes cached ga data" do
+        expect(stats.map(&:to_flot)).to include(*view_output)
+      end
+
+      it "caches data" do
+        expect(stats.map(&:to_flot)).to include(*view_output)
+        expect(stats.first.user_id).to eq user_id
+
+        # at this point all data should be cached
+        allow(described_class).to receive(:ga_statistics).with(Time.zone.today, file).and_raise("We should not call Google Analytics All data should be cached!")
+
+        stats2 = described_class.statistics(file, Time.zone.today - 5.days)
+        expect(stats2.map(&:to_flot)).to include(*view_output)
+      end
+    end
+
+    describe "cache loaded" do
+      let!(:file_view_stat) { described_class.create(date: (Time.zone.today - 5.days).to_datetime, file_id: file_id, views: "25") }
+
+      let(:stats) do
+        expect(described_class).to receive(:ga_statistics).and_return(sample_pageview_statistics)
+        described_class.statistics(file, Time.zone.today - 5.days)
+      end
+
+      it "includes cached data" do
+        expect(stats.map(&:to_flot)).to include([file_view_stat.date.to_i * 1000, file_view_stat.views], *view_output)
+      end
+    end
+  end
+end

--- a/spec/models/work_and_file_index_spec.rb
+++ b/spec/models/work_and_file_index_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe WorkAndFileIndex, type: :model do
+  it 'has attributes' do
+    expect(subject).to respond_to(:object_id)
+    expect(subject).to respond_to(:object_type)
+    expect(subject).to respond_to(:user_email)
+    expect(subject).to respond_to(:stats_last_gathered)
+  end
+
+  describe '#update_stats_last_gathered' do
+    it 'updates #stats_last_gathered to today' do
+      expect(subject.stats_last_gathered).to be_nil
+      subject.update_stats_last_gathered
+      expect(subject.stats_last_gathered.today?).to be(true)
+    end
+  end
+
+  describe '#reset' do
+    let!(:work1) { create(:work) }
+    let!(:work2) { create(:work) }
+    let!(:work3) { create(:generic_work_with_one_file) }
+    let!(:work4) { create(:generic_work_with_one_file) }
+    let(:file1) { work3.file_sets.first }
+    let(:file2) { work4.file_sets.first }
+
+    let!(:old_records) do
+      (1..3).map { WorkAndFileIndex.create }
+    end
+
+    it 'removes all of the old records' do
+      WorkAndFileIndex.reset
+      old_records.each do |record|
+        expect { record.reload }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    it 'adds a new record for each object, with the correct attributes' do
+      # this is longer than it needs to be to speed up the test
+
+      WorkAndFileIndex.reset
+      # works
+      expect(WorkAndFileIndex.find_by(object_id: work1.id).class).to be(WorkAndFileIndex)
+      expect(WorkAndFileIndex.find_by(object_id: work2.id).class).to be(WorkAndFileIndex)
+      expect(WorkAndFileIndex.find_by(object_id: work3.id).class).to be(WorkAndFileIndex)
+      expect(WorkAndFileIndex.find_by(object_id: work4.id).class).to be(WorkAndFileIndex)
+
+      # files
+      expect(WorkAndFileIndex.find_by(object_id: file1.id).class).to be(WorkAndFileIndex)
+      expect(WorkAndFileIndex.find_by(object_id: file2.id).class).to be(WorkAndFileIndex)
+
+      # work attributes
+      work = WorkAndFileIndex.find_by(object_id: work1.id)
+      expect(work.object_id).to eq(work1.id)
+      expect(work.user_email).to eq(work1.depositor)
+      expect(work.stats_last_gathered).to eq(nil)
+      expect(work.object_type).to eq("work")
+
+      # file attributes
+      file = WorkAndFileIndex.find_by(object_id: file1.id)
+      expect(file.object_id).to eq(file1.id)
+      expect(file.user_email).to eq(file1.depositor)
+      expect(file.stats_last_gathered).to eq(nil)
+      expect(file.object_type).to eq("file")
+    end
+  end
+
+  describe '#update_works_and_files' do
+    let!(:work1) { create(:generic_work_with_one_file) }
+    let(:file1) { work1.file_sets.first }
+
+    before { WorkAndFileIndex.reset }
+
+    context 'when objects are deleted' do
+      it 'removes records for works that have been deleted' do
+        work1.destroy
+
+        WorkAndFileIndex.update_works_and_files
+        expect(WorkAndFileIndex.find_by(object_id: work1.id)).to be_nil
+      end
+
+      it 'removes records for files that have been deleted' do
+        file1.destroy
+
+        WorkAndFileIndex.update_works_and_files
+        expect(WorkAndFileIndex.find_by(object_id: file1.id)).to be_nil
+      end
+    end
+
+    context 'when objects are added' do
+      let!(:work2) { create(:generic_work_with_one_file) }
+      let(:file2) { work2.file_sets.first }
+
+      it 'adds records for works that have been added' do
+        WorkAndFileIndex.update_works_and_files
+        expect(WorkAndFileIndex.find_by(object_id: work2.id).class).to be(WorkAndFileIndex)
+      end
+
+      it 'adds records for files that have been added' do
+        WorkAndFileIndex.update_works_and_files
+        expect(WorkAndFileIndex.find_by(object_id: file2.id).class).to be(WorkAndFileIndex)
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/custom_stat_importer_spec.rb
+++ b/spec/services/hyrax/custom_stat_importer_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Hyrax::CustomStatImporter do
+  before do
+    allow(Hyrax.config).to receive(:analytic_start_date) { dates[0] }
+
+    allow(FileViewStat).to receive(:ga_statistics) do |_date, file|
+      case file
+      when bilbo_file_1
+        bilbo_file_1_pageview_stats
+      end
+    end
+
+    allow(FileDownloadStat).to receive(:ga_statistics) do |_date, file|
+      case file
+      when bilbo_file_1
+        bilbo_file_1_download_stats
+      end
+    end
+
+    allow(WorkViewStat).to receive(:ga_statistics) do |_date, work|
+      case work
+      when bilbo_work_1
+        bilbo_work_1_pageview_stats
+      end
+    end
+  end
+
+  let(:bilbo) { create(:user, email: 'bilbo@example.com') }
+
+  let!(:bilbo_file_1) do
+    create(:file_set, id: 'xyzbilbo1', user: bilbo)
+  end
+
+  let!(:bilbo_work_1) do
+    create(:work, id: 'xyzbilbowork1', user: bilbo)
+  end
+
+  let(:dates) do
+    ldates = []
+    4.downto(0) { |idx| ldates << (Time.zone.today - idx.day) }
+    ldates
+  end
+
+  let(:date_strs) do
+    ldate_strs = []
+    dates.each { |date| ldate_strs << date.strftime("%Y%m%d") }
+    ldate_strs
+  end
+
+  # This is what the data looks like that's returned from Google Analytics via the Legato gem.
+  let(:bilbo_file_1_pageview_stats) do
+    [
+      SpecStatistic.new(date: date_strs[0], pageviews: 1),
+      SpecStatistic.new(date: date_strs[1], pageviews: 2),
+      SpecStatistic.new(date: date_strs[2], pageviews: 3),
+      SpecStatistic.new(date: date_strs[3], pageviews: 4),
+      SpecStatistic.new(date: date_strs[4], pageviews: 5)
+    ]
+  end
+
+  let(:bilbo_work_1_pageview_stats) do
+    [
+      SpecStatistic.new(date: date_strs[0], pageviews: 1),
+      SpecStatistic.new(date: date_strs[1], pageviews: 2),
+      SpecStatistic.new(date: date_strs[2], pageviews: 3),
+      SpecStatistic.new(date: date_strs[3], pageviews: 4),
+      SpecStatistic.new(date: date_strs[4], pageviews: 5)
+    ]
+  end
+
+  let(:bilbo_file_1_download_stats) do
+    [
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[0], totalEvents: "2"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[1], totalEvents: "3"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[2], totalEvents: "5"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[3], totalEvents: "3"),
+      SpecStatistic.new(eventCategory: "Files", eventAction: "Downloaded", eventLabel: "bilbo1", date: date_strs[4], totalEvents: "7")
+    ]
+  end
+
+  let(:work_index_object) do
+    WorkAndFileIndex.create(
+      object_id: bilbo_work_1.id,
+      object_type: "work",
+      user_email: bilbo.email
+    )
+  end
+
+  let(:file_index_object) do
+    WorkAndFileIndex.create(
+      object_id: bilbo_file_1.id,
+      object_type: "file",
+      user_email: bilbo.email
+    )
+  end
+
+  subject { described_class.new(work_index_object, delay_secs: 0, retries: 4) }
+
+  context "works" do
+    it "adds all data" do
+      expect { subject.import }.to change { WorkViewStat.count }.by(4)
+    end
+
+    it "doesn't add duplicate data" do
+      described_class.new(work_index_object, delay_secs: 0, retries: 4).import
+      expect { subject.import }.not_to(change { WorkViewStat.count })
+    end
+  end
+
+  context "files" do
+    subject { described_class.new(file_index_object, delay_secs: 0, retries: 4) }
+
+    it "adds all file view data" do
+      expect { subject.import }.to change { FileViewStat.count }.by(4)
+    end
+
+    it "adds all file download data" do
+      expect { subject.import }.to change { FileDownloadStat.count }.by(4)
+    end
+
+    it "doesn't add duplicate data" do
+      described_class.new(file_index_object, delay_secs: 0, retries: 4).import
+      expect { subject.import }.not_to(change { FileDownloadStat.count })
+    end
+  end
+
+  it "sets index object date" do
+    expect(work_index_object.stats_last_gathered).to be_nil
+    subject.import
+    expect(work_index_object.reload.stats_last_gathered).to be_between(Time.zone.today - 1.day, Time.zone.today + 1.day)
+  end
+
+  context "without a stats_last_gathered date" do
+    it "initializes the appropriate date" do
+      expect(subject.start_date).to eq(dates[0])
+    end
+  end
+
+  context "with a stats_last_gathered date" do
+    let(:work_index_object) do
+      WorkAndFileIndex.create(
+        object_id: bilbo_work_1.id,
+        object_type: "work",
+        user_email: bilbo.email,
+        stats_last_gathered: dates[2]
+      )
+    end
+
+    it "initializes the appropriate date" do
+      expect(subject.start_date.strftime("%Y%m%d")).to eq(date_strs[2])
+    end
+  end
+end

--- a/spec/services/hyrax/user_stat_adder_spec.rb
+++ b/spec/services/hyrax/user_stat_adder_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Hyrax::UserStatAdder do
+  it "resets the cache" do
+    us = UserStat.create
+    described_class.reset_user_stats
+    expect { us.reload }.to raise_error ActiveRecord::RecordNotFound
+  end
+
+  context "with data" do
+    let(:user) { create(:user) }
+    let(:another_user) { create(:user) }
+
+    let(:work1) { create(:generic_work, user: user) }
+    let(:work2) { create(:generic_work, user: user) }
+    let(:work3) { create(:generic_work, user: another_user) }
+    let(:file1) { create(:file_set, user: user) }
+    let(:file2) { create(:file_set, user: user) }
+    let(:file3) { create(:file_set, user: another_user) }
+
+    before do
+      FileViewStat.create(views: 2, file_id: file1.id, user_id: user.id)
+      FileViewStat.create(views: 3, file_id: file1.id, user_id: user.id)
+
+      FileDownloadStat.create(downloads: 11, file_id: file1.id, user_id: user.id)
+      FileDownloadStat.create(downloads: 13, file_id: file1.id, user_id: user.id)
+
+      FileViewStat.create(views: 5, file_id: file2.id, user_id: user.id)
+      FileViewStat.create(views: 3, file_id: file2.id, user_id: user.id)
+
+      FileDownloadStat.create(downloads: 18, file_id: file2.id, user_id: user.id)
+      FileDownloadStat.create(downloads: 11, file_id: file2.id, user_id: user.id)
+
+      FileViewStat.create(views: 19, file_id: file3.id, user_id: another_user.id)
+      FileViewStat.create(views: 31, file_id: file3.id, user_id: another_user.id)
+
+      FileDownloadStat.create(downloads: 21, file_id: file3.id, user_id: another_user.id)
+      FileDownloadStat.create(downloads: 13, file_id: file3.id, user_id: another_user.id)
+
+      WorkViewStat.create(work_views: 23, work_id: work1.id, user_id: user.id)
+      WorkViewStat.create(work_views: 29, work_id: work1.id, user_id: user.id)
+      WorkViewStat.create(work_views: 31, work_id: work1.id, user_id: user.id)
+
+      WorkViewStat.create(work_views: 10, work_id: work2.id, user_id: user.id)
+      WorkViewStat.create(work_views: 1, work_id: work2.id, user_id: user.id)
+      WorkViewStat.create(work_views: 0, work_id: work2.id, user_id: user.id)
+
+      WorkViewStat.create(work_views: 105, work_id: work3.id, user_id: another_user.id)
+      WorkViewStat.create(work_views: 9, work_id: work3.id, user_id: another_user.id)
+      WorkViewStat.create(work_views: 30, work_id: work3.id, user_id: another_user.id)
+
+      WorkAndFileIndex.reset
+    end
+
+    it "totals the work view stats for a user" do
+      described_class.reset_user_stats
+      expect(UserStat.find_by_user_id(user.id).work_views).to eq(94)
+      expect(UserStat.find_by_user_id(another_user.id).work_views).to eq(144)
+    end
+
+    it "totals the file download stats for a user" do
+      described_class.reset_user_stats
+      expect(UserStat.find_by_user_id(user.id).file_downloads).to eq(53)
+      expect(UserStat.find_by_user_id(another_user.id).file_downloads).to eq(34)
+    end
+
+    it "totals the file view stats for a user" do
+      described_class.reset_user_stats
+      expect(UserStat.find_by_user_id(user.id).file_views).to eq(13)
+      expect(UserStat.find_by_user_id(another_user.id).file_views).to eq(50)
+    end
+  end
+end

--- a/spec/support/spec_statistic.rb
+++ b/spec/support/spec_statistic.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# This is a replacement for the OpenStruct usage. The idea is to expose
+# an object with a common interface.
+class SpecStatistic
+  def initialize(**kargs)
+    @attributes = kargs.symbolize_keys
+  end
+
+  def [](key)
+    @attributes[key.to_sym]
+  end
+
+  def method_missing(method_name, *arguments, &block)
+    if @attributes.key?(method_name.to_sym)
+      @attributes[method_name]
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    @attributes.key?(method_name.to_sym) || super
+  end
+end

--- a/spec/support/statistics_helper.rb
+++ b/spec/support/statistics_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module StatisticHelper
+  def statistic_date(date)
+    date.to_datetime.to_i * 1000
+  end
+
+  RSpec.configure do |config|
+    config.include StatisticHelper
+  end
+end

--- a/spec/views/hyrax/user/_vitals.html.erb_spec.rb
+++ b/spec/views/hyrax/user/_vitals.html.erb_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'hyrax/users/_vitals.html.erb', type: :view do
+  let(:user) { stub_model(User, user_key: 'cam156') }
+  let(:current_user) { stub_model(User, user_key: 'mjg') }
+
+  before do
+    allow(view).to receive(:signed_in?).and_return(true)
+    allow(view).to receive(:current_user).and_return(current_user)
+    allow(view).to receive(:user).and_return(current_user)
+    assign(:user, user)
+    render
+  end
+
+  it 'displays user work and file analytics' do
+    expect(rendered).to have_content 'File Views'
+    expect(rendered).to have_content 'Work Views'
+    expect(rendered).to have_content 'Downloads'
+  end
+end


### PR DESCRIPTION
Fixes #413

Present short summary (50 characters or less)

This PR sets the variables needed for connecting to Google Analytics to provide view and download stats for each work and file_set. It also has the machinery for updating the totals in the dashboard.

The updating machinery includes rake task, database migrations, and copy scripts.

Refer to the notes on Legato for using in non-production environments :
https://github.com/samvera/hyrax/wiki/Analytics-workaround-for-non-production-environments

Refer to config_vault for authentication file and google API connection information:
https://git.uc.edu/UCLIBS/config_vault