### PR TITLE
Override description and date_created predicates

### DIFF
--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+module Hyrax
+  # An optional model mixin to define some simple properties. This must be mixed
+  # after all other properties are defined because no other properties will
+  # be defined once  accepts_nested_attributes_for is called
+  module BasicMetadata
+    extend ActiveSupport::Concern
+
+    included do
+      property :label, predicate: ActiveFedora::RDF::Fcrepo::Model.downloadFilename, multiple: false
+
+      property :relative_path, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#relativePath'), multiple: false
+
+      property :import_url, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#importUrl'), multiple: false
+      property :resource_type, predicate: ::RDF::Vocab::DC.type
+      property :creator, predicate: ::RDF::Vocab::DC11.creator
+      property :contributor, predicate: ::RDF::Vocab::DC11.contributor
+
+      # override the predicate for description to match past versions of Scholar
+      property :description, predicate: ::RDF::URI.new('http://purl.org/dc/terms/description')
+
+      property :keyword, predicate: ::RDF::Vocab::DC11.relation
+      # Used for a license
+      property :license, predicate: ::RDF::Vocab::DC.rights
+
+      # This is for the rights statement
+      property :rights_statement, predicate: ::RDF::Vocab::EDM.rights
+      property :publisher, predicate: ::RDF::Vocab::DC11.publisher
+
+      # override the predicate for date_created to match past versions of Scholar
+      property :date_created, predicate: ::RDF::URI.new('http://purl.org/dc/terms/date#created')
+
+      property :subject, predicate: ::RDF::Vocab::DC11.subject
+      property :language, predicate: ::RDF::Vocab::DC11.language
+      property :identifier, predicate: ::RDF::Vocab::DC.identifier
+      property :based_near, predicate: ::RDF::Vocab::FOAF.based_near, class_name: Hyrax::ControlledVocabularies::Location
+      property :related_url, predicate: ::RDF::RDFS.seeAlso
+      property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation
+      property :source, predicate: ::RDF::Vocab::DC.source
+
+      id_blank = proc { |attributes| attributes[:id].blank? }
+
+      class_attribute :controlled_properties
+      self.controlled_properties = [:based_near]
+      accepts_nested_attributes_for :based_near, reject_if: id_blank, allow_destroy: true
+    end
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -61,5 +61,10 @@ RSpec.describe Article do
     it { is_expected.to respond_to(:department) }
   end
 
+  it "has correct predicates" do
+    expect(described_class.properties["description"].predicate.to_s).to eq "http://purl.org/dc/terms/description"
+    expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -59,5 +59,10 @@ RSpec.describe Dataset do
     it { is_expected.to respond_to(:department) }
   end
 
+  it "has correct predicates" do
+    expect(described_class.properties["description"].predicate.to_s).to eq "http://purl.org/dc/terms/description"
+    expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -59,5 +59,10 @@ RSpec.describe Document do
     it { is_expected.to respond_to(:department) }
   end
 
+  it "has correct predicates" do
+    expect(described_class.properties["description"].predicate.to_s).to eq "http://purl.org/dc/terms/description"
+    expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -62,5 +62,10 @@ RSpec.describe Etd do
     it { is_expected.to respond_to(:department) }
   end
 
+  it "has correct predicates" do
+    expect(described_class.properties["description"].predicate.to_s).to eq "http://purl.org/dc/terms/description"
+    expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -57,5 +57,10 @@ describe GenericWork do
     it { is_expected.to respond_to(:department) }
   end
 
+  it "has correct predicates" do
+    expect(described_class.properties["description"].predicate.to_s).to eq "http://purl.org/dc/terms/description"
+    expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -59,5 +59,10 @@ RSpec.describe Image do
     it { is_expected.to respond_to(:department) }
   end
 
+  it "has correct predicates" do
+    expect(described_class.properties["description"].predicate.to_s).to eq "http://purl.org/dc/terms/description"
+    expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -59,5 +59,10 @@ RSpec.describe Medium do
     it { is_expected.to respond_to(:department) }
   end
 
+  it "has correct predicates" do
+    expect(described_class.properties["description"].predicate.to_s).to eq "http://purl.org/dc/terms/description"
+    expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/student_work_spec.rb
+++ b/spec/models/student_work_spec.rb
@@ -61,5 +61,10 @@ RSpec.describe StudentWork do
     it { is_expected.to respond_to(:department) }
   end
 
+  it "has correct predicates" do
+    expect(described_class.properties["description"].predicate.to_s).to eq "http://purl.org/dc/terms/description"
+    expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end


### PR DESCRIPTION
Fixes #554 

This fixes our problem where the application was not seeing existing content in the `description` and `data_created` fields because the prefix in Fedora was different.

Once a property has been declared for a field in Hyrax, we can't re-declare it in our app.  So I had to override the entire app/models/concerns/hyrax/basic_metadata.rb file in Hyrax and change the property lines for `description` and `data_created` to match the prefixes used in Scholar 3.x.

I pushed this change to scholar-qa and was then able to see the existing content in those fields.   Example: https://scholar-qa.uc.edu/concern/documents/6d56zw601

So I've verified it's working.

Just in case we ever lose this override, I added tests to each of the work type models to verify `description` and `data_created` have the predicates we expect.

Before this change: 
* `Article.properties["description"].predicate.to_s` returns "http://purl.org/dc/elements/1.1/description"
* `Article.properties["date_created"].predicate.to_s` returns "http://purl.org/dc/terms/created"

After this change: 
* `Article.properties["description"].predicate.to_s` returns "http://purl.org/dc/terms/description" (matches Scholar 3.x)
* `Article.properties["date_created"].predicate.to_s` returns "http://purl.org/dc/terms/date#created" (matches Scholar 3.x)