### PR TITLE
Change Etd publisher field to single value

### DIFF
--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -8,7 +8,7 @@ module Hyrax
 
     ## Adding custom descriptive metadata terms
     self.terms += %i[alternate_title genre time_period required_software note
-                     degree advisor committee_member geo_subject]
+                     degree advisor committee_member geo_subject etd_publisher]
 
     ## Adding terms needed for the special DOI form tab
     self.terms += %i[doi doi_assignment_strategy existing_identifier]
@@ -17,7 +17,7 @@ module Hyrax
     self.terms += %i[college department]
 
     ## Removing terms that we don't use
-    self.terms -= %i[rights_statement keyword source contributor based_near identifier resource_type]
+    self.terms -= %i[rights_statement keyword source contributor based_near identifier resource_type publisher]
 
     ## Setting custom required fields
     self.required_fields = %i[title creator college department description advisor license]
@@ -25,7 +25,7 @@ module Hyrax
     ## Adding above the fold on the form without making this required
     def primary_terms
       required_fields + %i[committee_member degree
-                           date_created publisher alternate_title genre subject
+                           date_created etd_publisher alternate_title genre subject
                            geo_subject time_period language
                            required_software note related_url]
     end

--- a/app/forms/hyrax/forms/batch_upload_form.rb
+++ b/app/forms/hyrax/forms/batch_upload_form.rb
@@ -40,7 +40,7 @@ module Hyrax
              time_period language required_software note related_url]
         when "Etd"
           %i[creator college department description advisor
-             license committee_member degree date_created publisher
+             license committee_member degree date_created etd_publisher
              alternate_title genre subject geo_subject time_period
              language required_software note related_url]
         when "Article"

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -56,6 +56,10 @@ class Etd < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  property :etd_publisher, predicate: ::RDF::URI.new('http://purl.org/dc/terms/publisher'), multiple: false do |index|
+    index.as :stored_searchable
+  end
+
   def self.to_s_u
     'etd'
   end
@@ -75,4 +79,8 @@ class Etd < ActiveFedora::Base
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata
+
+  def publisher
+    etd_publisher
+  end
 end

--- a/app/views/records/edit_fields/_etd_publisher.html.erb
+++ b/app/views/records/edit_fields/_etd_publisher.html.erb
@@ -1,0 +1,5 @@
+<% if params[:action] == 'new' %>
+  <%= f.input :etd_publisher, input_html: { value: "University of Cincinnati", class: 'etd_publisher' } %>
+<% else %>
+  <%= f.input :etd_publisher, input_html: { class: 'etd_publisher' } %>
+<% end %>

--- a/config/locales/etd.en.yml
+++ b/config/locales/etd.en.yml
@@ -26,7 +26,7 @@ en:
         degree:           "Degree"
         degree_date:      "Degree Year"
         genre:            "Type"
-        publisher:    "Publisher (Required for DOI registration)"
+        etd_publisher:    "Publisher (Required for DOI registration)"
         college:          "College"
         department:       "Degree Program"
     hints:
@@ -42,7 +42,7 @@ en:
         description: "Enter the abstract of the ETD. There is no character limit for this field.</p>"
         identifier: "A unique handle identifying the work. An example would be a DOI for a journal article, or an ISBN or OCLC number for a book."
         language: "Enter the language of your work.</br>Examples:</br><ul><li>English</li><li>Spanish</li><li>Arabic</li></ul>"
-        publisher: "Enter the publisher associated with the ETD, typically the University of Cincinnati."
+        etd_publisher: "Enter the publisher associated with the ETD, typically the University of Cincinnati."
         rights: "Licensing and distribution information governing access to the work. Select from the provided drop-down list."
         alternate_title: "<p>Enter an alternate title for ETD. An alternate title could include acronyms, abbreviations, or a series title.</p>"
         time_period: "Enter the period or date associated with the subject of your work.</br>Examples:</br><ul><li>19th century</li><li>Middle Ages</li><li>Jurassic Period</li></ul>"

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -45,6 +45,7 @@ en:
           language_tesim: Language
           license_tesim: License
           publisher_tesim: Publisher
+          etd_publisher: Publisher
           rights_statement_tesim: Rights Statement
           subject_tesim: Subject
           title_tesim: Title

--- a/spec/forms/hyrax/etd_form_spec.rb
+++ b/spec/forms/hyrax/etd_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Hyrax::EtdForm do
     it {
       is_expected.to eq [:title, :creator, :college, :department, :description, :advisor,
                          :license, :committee_member, :degree, :date_created,
-                         :publisher, :alternate_title, :genre, :subject, :geo_subject,
+                         :etd_publisher, :alternate_title, :genre, :subject, :geo_subject,
                          :time_period, :language, :required_software, :note, :related_url]
     }
   end


### PR DESCRIPTION
Fixes #569

Brings back the unique etd_publisher field from scholar so that it doesn't allow for multiple values