### PR TITLE
Fix managed works title wrapping

### DIFF
--- a/app/views/hyrax/dashboard/works/_default_group.html.erb
+++ b/app/views/hyrax/dashboard/works/_default_group.html.erb
@@ -2,6 +2,7 @@
   <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
   <thead>
     <tr>
+      <th class="check-all"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
       <th scope="col"><%= t("hyrax.dashboard.my.heading.title") %></th>
       <th class="date"><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
       <th class="sorts-dash"><%= t("blacklight.search.fields.facet.suppressed_bsi") %></th>


### PR DESCRIPTION
Fixes #570

Realized that the table headers were off, and re-implemented the deleted code from hyrax. It added the checkbox that had the dropdown that allows you to select everything or nothing