### PR TITLE
Bug/#574 Some users are confused when a a new work says no files are attached

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -59,6 +59,8 @@ en:
     base:
       form_progress:
         required_agreement: Check distribution license
+      items:
+        empty: 'This %{type} has no files associated with it. (If you just created this %{type}, it may take a few minutes for the files to display. Try refreshing the page again.) Otherwise, click edit to add more files.'
     batch_uploads:
       files:
         upload_type_instructions: 'Note: To create a single work for all the files, '

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -42,6 +42,24 @@ shared_examples 'submission form without form#fileupload' do |work_class|
   end
 end
 
+shared_examples 'show work without files' do |work_class|
+  let(:work_type) { work_class.name.underscore }
+  let(:work) { create(:public_generic_work, title: ["Magnificent splendor"], description: ["My description"], source: ["The Internet"], user: user) }
+  let(:user) { create(:user) }
+  let(:work_path) { "/concern/#{work_type}s/#{work.id}" }
+
+  before do
+    sign_in user
+    visit work_path
+  end
+
+  it 'displays clear warning', js: true do
+    page.current_window.resize_to(5000, 5000)
+    page.save_screenshot('screen.png')
+    expect(page).to have_css('div.alert.alert-warning', text: 'This Generic Work has no files associated with it. (If you just created this Generic Work, it may take a few minutes for the files to display. Try refreshing the page again.) Otherwise, click edit to add more files.')
+  end
+end
+
 describe "display a work" do
   context "as the work owner" do
     it_behaves_like "submission form with form#fileupload", GenericWork
@@ -49,5 +67,9 @@ describe "display a work" do
 
   context "as a user who is not logged in" do
     it_behaves_like 'submission form without form#fileupload', GenericWork
+  end
+
+  context "display a work without files" do
+    it_behaves_like "show work without files", GenericWork
   end
 end


### PR DESCRIPTION
Fixes #574;

Present short summary (50 characters or less)
Changed text of the message explaining files are being processed to avoid having users add multiple copies of the same files by accident.