### PR TITLE
Implement testing for non-repeatable fields

### DIFF
--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -66,5 +66,15 @@ RSpec.describe Article do
     expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
   end
 
+  describe "single valued fields" do
+    it "returns false for multi value" do
+      expect(described_class.multiple?("title")).to be false
+      expect(described_class.multiple?("rights_statement")).to be false
+      expect(described_class.multiple?("description")).to be false
+      expect(described_class.multiple?("date_created")).to be false
+      expect(described_class.multiple?("license")).to be false
+    end
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -64,5 +64,15 @@ RSpec.describe Document do
     expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
   end
 
+  describe "single valued fields" do
+    it "returns false for multi value" do
+      expect(described_class.multiple?("title")).to be false
+      expect(described_class.multiple?("rights_statement")).to be false
+      expect(described_class.multiple?("description")).to be false
+      expect(described_class.multiple?("date_created")).to be false
+      expect(described_class.multiple?("license")).to be false
+    end
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -67,5 +67,15 @@ RSpec.describe Etd do
     expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
   end
 
+  describe "single valued fields" do
+    it "returns false for multi value" do
+      expect(described_class.multiple?("title")).to be false
+      expect(described_class.multiple?("rights_statement")).to be false
+      expect(described_class.multiple?("description")).to be false
+      expect(described_class.multiple?("date_created")).to be false
+      expect(described_class.multiple?("license")).to be false
+    end
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -62,5 +62,15 @@ describe GenericWork do
     expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
   end
 
+  describe "single valued fields" do
+    it "returns false for multi value" do
+      expect(described_class.multiple?("title")).to be false
+      expect(described_class.multiple?("rights_statement")).to be false
+      expect(described_class.multiple?("description")).to be false
+      expect(described_class.multiple?("date_created")).to be false
+      expect(described_class.multiple?("license")).to be false
+    end
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -64,5 +64,15 @@ RSpec.describe Image do
     expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
   end
 
+  describe "single valued fields" do
+    it "returns false for multi value" do
+      expect(described_class.multiple?("title")).to be false
+      expect(described_class.multiple?("rights_statement")).to be false
+      expect(described_class.multiple?("description")).to be false
+      expect(described_class.multiple?("date_created")).to be false
+      expect(described_class.multiple?("license")).to be false
+    end
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -64,5 +64,15 @@ RSpec.describe Medium do
     expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
   end
 
+  describe "single valued fields" do
+    it "returns false for multi value" do
+      expect(described_class.multiple?("title")).to be false
+      expect(described_class.multiple?("rights_statement")).to be false
+      expect(described_class.multiple?("description")).to be false
+      expect(described_class.multiple?("date_created")).to be false
+      expect(described_class.multiple?("license")).to be false
+    end
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/student_work_spec.rb
+++ b/spec/models/student_work_spec.rb
@@ -66,5 +66,15 @@ RSpec.describe StudentWork do
     expect(described_class.properties["date_created"].predicate.to_s).to eq "http://purl.org/dc/terms/date#created"
   end
 
+  describe "single valued fields" do
+    it "returns false for multi value" do
+      expect(described_class.multiple?("title")).to be false
+      expect(described_class.multiple?("rights_statement")).to be false
+      expect(described_class.multiple?("description")).to be false
+      expect(described_class.multiple?("date_created")).to be false
+      expect(described_class.multiple?("license")).to be false
+    end
+  end
+
   it_behaves_like 'is remotely identifiable by doi'
 end


### PR DESCRIPTION
Fixes #519

Adds testing for all non-repeatable fields through model spec testing. Added testing for the following fields: title, rights_statement, description, date_created, and license.
