### PR TITLE
Fixes owner file permission problem with proxy deposit.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,7 @@ Metrics/MethodLength:
     - 'spec/support/hyrax/helpers/factory_helpers.rb'
     - 'app/services/hyrax/actor_factory.rb'
     - 'app/services/hyrax/custom_stat_importer.rb'
+    - 'app/jobs/attach_files_to_work_job.rb'
 
 Metrics/ClassLength:
   Exclude:
@@ -156,6 +157,7 @@ RSpec/ExampleLength:
     - 'spec/services/hyrax/default_middleware_stack_spec.rb'
     - 'spec/models/work_and_file_index_spec.rb'
     - 'spec/models/file_view_stat_spec.rb'
+    - 'spec/jobs/attach_files_to_work_job_spec.rb'
 
 RSpec/ExpectActual:
   Enabled: false
@@ -199,6 +201,7 @@ RSpec/VerifiedDoubles:
     - 'spec/lib/scholar_spec.rb'
     - 'spec/jobs/identifier_delete_job_spec.rb'
     - 'spec/services/hyrax/default_middleware_stack_spec.rb'
+    - 'spec/jobs/attach_files_to_work_job_spec.rb'
     
 RSpec/NamedSubject:
   Exclude:

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+# Converts UploadedFiles into FileSets and attaches them to works.
+class AttachFilesToWorkJob < Hyrax::ApplicationJob
+  queue_as Hyrax.config.ingest_queue_name
+
+  # @param [ActiveFedora::Base] work - the work object
+  # @param [Array<Hyrax::UploadedFile>] uploaded_files - an array of files to attach
+  def perform(work, uploaded_files, **work_attributes)
+    validate_files!(uploaded_files)
+    depositor = proxy_or_depositor(work)
+    user = User.find_by_user_key(depositor)
+    work_permissions = work.permissions.map(&:to_hash)
+
+    # Temporary fix for edit access to files for owners on proxy deposit.
+    # See Hyrax issue #3416
+    work_permissions << { name: depositor, type: "person", access: "edit" } if work.on_behalf_of
+
+    metadata = visibility_attributes(work_attributes)
+    uploaded_files.each do |uploaded_file|
+      next if uploaded_file.file_set_uri.present?
+
+      actor = Hyrax::Actors::FileSetActor.new(FileSet.create, user)
+      uploaded_file.update(file_set_uri: actor.file_set.uri)
+      actor.file_set.permissions_attributes = work_permissions
+      actor.create_metadata(metadata)
+      actor.create_content(uploaded_file)
+      actor.attach_to_work(work)
+    end
+  end
+
+  private
+
+    # The attributes used for visibility - sent as initial params to created FileSets.
+    def visibility_attributes(attributes)
+      attributes.slice(:visibility, :visibility_during_lease,
+                       :visibility_after_lease, :lease_expiration_date,
+                       :embargo_release_date, :visibility_during_embargo,
+                       :visibility_after_embargo)
+    end
+
+    def validate_files!(uploaded_files)
+      uploaded_files.each do |uploaded_file|
+        next if uploaded_file.is_a? Hyrax::UploadedFile
+        raise ArgumentError, "Hyrax::UploadedFile required, but #{uploaded_file.class} received: #{uploaded_file.inspect}"
+      end
+    end
+
+    ##
+    # A work with files attached by a proxy user will set the depositor as the intended user
+    # that the proxy was depositing on behalf of. See tickets #2764, #2902.
+    def proxy_or_depositor(work)
+      work.on_behalf_of.blank? ? work.depositor : work.on_behalf_of
+    end
+end

--- a/spec/factories/uploaded_files.rb
+++ b/spec/factories/uploaded_files.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :uploaded_file, class: Hyrax::UploadedFile do
+    user
+  end
+end

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -1,0 +1,85 @@
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AttachFilesToWorkJob do
+  let(:file1) { File.open(fixture_path + '/world.png') }
+  let(:file2) { File.open(fixture_path + '/image.jp2') }
+  let(:uploaded_file1) { build(:uploaded_file, file: file1) }
+  let(:uploaded_file2) { build(:uploaded_file, file: file2) }
+  let(:generic_work) { create(:public_generic_work) }
+  let(:user) { create(:user) }
+
+  shared_examples 'a file attacher' do
+    it 'attaches files, copies visibility and permissions and updates the uploaded files' do
+      expect(CharacterizeJob).to receive(:perform_later).twice
+      described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])
+      generic_work.reload
+      expect(generic_work.file_sets.count).to eq 2
+      expect(generic_work.file_sets.map(&:visibility)).to all(eq 'open')
+      expect(uploaded_file1.reload.file_set_uri).not_to be_nil
+    end
+  end
+
+  context "with uploaded files on the filesystem" do
+    before do
+      generic_work.permissions.build(name: 'userz@bbb.ddd', type: 'person', access: 'edit')
+      generic_work.save
+    end
+    it_behaves_like 'a file attacher' do
+      it 'records the depositor(s) in edit_users' do
+        expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([generic_work.depositor, 'userz@bbb.ddd']))
+      end
+
+      describe 'with existing files' do
+        let(:file_set)       { create(:file_set) }
+        let(:uploaded_file1) { build(:uploaded_file, file: file1, file_set_uri: 'http://example.com/file_set') }
+
+        it 'skips files that already have a FileSet' do
+          expect(CharacterizeJob).to receive(:perform_later)
+          expect { described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2]) }
+            .to change { generic_work.file_sets.count }.to eq 1
+        end
+      end
+    end
+  end
+
+  context "with uploaded files at remote URLs" do
+    let(:url1) { 'https://example.com/my/img.png' }
+    let(:url2) { URI('https://example.com/other/img.png') }
+    let(:fog_file1) { double(CarrierWave::Storage::Abstract, url: url1) }
+    let(:fog_file2) { double(CarrierWave::Storage::Abstract, url: url2) }
+
+    before do
+      allow(uploaded_file1.file).to receive(:file).and_return(fog_file1)
+      allow(uploaded_file2.file).to receive(:file).and_return(fog_file2)
+    end
+
+    it_behaves_like 'a file attacher'
+  end
+
+  context "deposited on behalf of another user" do
+    before do
+      generic_work.on_behalf_of = user.user_key
+      generic_work.save
+    end
+    it_behaves_like 'a file attacher' do
+      it 'records the depositor(s) in edit_users' do
+        expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([user.user_key, generic_work.depositor]))
+      end
+    end
+  end
+
+  context "deposited as 'Yourself' selected in on behalf of list" do
+    before do
+      generic_work.on_behalf_of = ''
+      generic_work.save
+    end
+    it_behaves_like 'a file attacher' do
+      it 'records the depositor(s) in edit_users' do
+        expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([generic_work.depositor]))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #488 and https://github.com/samvera/hyrax/issues/3416

Present short summary (50 characters or less)

Added a condition to the attach_files_to_work_job that adds the owner to the work_permissions map that gets used to set the file permissions.  This should be reviewed manually with config.active_job.queue_adapter = :sidekiq set in your environment.

We should also add a line in our manual test script to verify this also.