### PR TITLE
Disable collection export

### DIFF
--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -27,12 +27,12 @@
                 <% end %>
 <% end %>
 
-<%= link_to main_app.collection_exports_path(collection_id: presenter.id),
+<%#= link_to main_app.collection_exports_path(collection_id: presenter.id),
             method: 'post',
             class: 'btn btn-primary export-collection-button',
             title: t("hyrax.collection.actions.export_collection") do %>
-  <%= t("hyrax.collection.actions.export_collection") %>
-<% end %>
+  <%#= t("hyrax.collection.actions.export_collection") %>
+<%# end %>
 
 <% if can? :destroy, presenter.solr_document %>
     <%= link_to t('hyrax.collection.actions.delete.label'),

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -17,6 +17,6 @@
     <% end %>
   <% end %>
 
-  <%= menu.nav_link(main_app.collection_exports_path) do %>
-    <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.collection.actions.manage_exports') %></span>
-  <% end %>
+  <%#= menu.nav_link(main_app.collection_exports_path) do %>
+    <!-- <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.collection.actions.manage_exports') %></span> -->
+  <%# end %>

--- a/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
@@ -40,6 +40,6 @@ RSpec.describe 'hyrax/dashboard/_sidebar.html.erb', type: :view do
 
   it "shows Manage Exports link" do
     render
-    expect(rendered).to have_link t('hyrax.collection.actions.manage_exports')
+    expect(rendered).not_to have_link t('hyrax.collection.actions.manage_exports')
   end
 end

--- a/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'hyrax/dashboard/collections/_show_actions.html.erb', type: :view
 
     it 'renders export collection link' do
       render
-      expect(rendered).to have_link('Export Collection')
+      expect(rendered).not_to have_link('Export Collection')
     end
   end
   describe 'when user cannot edit the document' do
@@ -46,7 +46,7 @@ RSpec.describe 'hyrax/dashboard/collections/_show_actions.html.erb', type: :view
 
     it 'renders export collection link' do
       render
-      expect(rendered).to have_link('Export Collection')
+      expect(rendered).not_to have_link('Export Collection')
     end
   end
 


### PR DESCRIPTION
Fixes #581

Removes the Collection Export from the sidebar in dashboard, and the button in the my collections in dashboard 