### PR TITLE
Show ETD committee members on work show page

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -35,6 +35,10 @@ class SolrDocument
     self[Solrizer.solr_name('advisor')]
   end
 
+  def committee_member
+    self[Solrizer.solr_name('committee_member')]
+  end
+
   def required_software
     self[Solrizer.solr_name('required_software')]
   end

--- a/app/presenters/hyrax/etd_presenter.rb
+++ b/app/presenters/hyrax/etd_presenter.rb
@@ -4,6 +4,6 @@
 #  `rails generate hyrax:work Etd`
 module Hyrax
   class EtdPresenter < Hyrax::WorkShowPresenter
-    delegate :college, :department, :genre, :alternate_title, :time_period, :required_software, :note, :advisor, :degree, :geo_subject, :etd_publisher, :doi, to: :solr_document
+    delegate :college, :department, :genre, :alternate_title, :time_period, :required_software, :note, :advisor, :degree, :committee_member, :geo_subject, :etd_publisher, :doi, to: :solr_document
   end
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -42,7 +42,7 @@ en:
           advisor: Advisor
           alternate_title: Alternate Title
           college: College
-          committee_member: Committe Member
+          committee_member: Committee Member
           creator: Creator
           date_created: Date Created
           degree: Degree

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe Etd do
     it { is_expected.to respond_to(:identifier) }
     it { is_expected.to respond_to(:college) }
     it { is_expected.to respond_to(:department) }
+    it { is_expected.to respond_to(:committee_member) }
   end
 
   it "has correct predicates" do

--- a/spec/presenters/hyrax/etd_presenter_spec.rb
+++ b/spec/presenters/hyrax/etd_presenter_spec.rb
@@ -19,4 +19,5 @@ RSpec.describe Hyrax::EtdPresenter do
   it { is_expected.to delegate_method(:department).to(:solr_document) }
   it { is_expected.to delegate_method(:degree).to(:solr_document) }
   it { is_expected.to delegate_method(:etd_publisher).to(:solr_document) }
+  it { is_expected.to delegate_method(:committee_member).to(:solr_document) }
 end


### PR DESCRIPTION
Fixes #590 

This fixes a bug that neglected to display the Committee Member field on work show pages (ETDs only).