### PR TITLE
Bug/#597 default collection visibility

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require Hyrax::Engine.root.join('app/controllers/hyrax/dashboard/collections_controller.rb')
+module Hyrax
+  module Dashboard
+    ## Shows a list of all collections to the admins
+    class CollectionsController < Hyrax::My::CollectionsController
+      def create
+        # Manual load and authorize necessary because Cancan will pass in all
+        # form attributes. When `permissions_attributes` are present the
+        # collection is saved without a value for `has_model.`
+        @collection = ::Collection.new
+        authorize! :create, @collection
+        # Coming from the UI, a collection type gid should always be present.  Coming from the API, if a collection type gid is not specified,
+        # use the default collection type (provides backward compatibility with versions < Hyrax 2.1.0)
+        @collection.collection_type_gid = params[:collection_type_gid].presence || default_collection_type.gid
+        @collection.attributes = collection_params.except(:members, :parent_id, :collection_type_gid)
+        @collection.apply_depositor_metadata(current_user.user_key)
+        add_members_to_collection unless batch.empty?
+        @collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        if @collection.save
+          after_create
+        else
+          after_create_error
+        end
+      end
+    end
+  end
+end

--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -12,7 +12,6 @@ module Hyrax
         attrs = super
         attrs[:title] = Array(attrs[:title]) if attrs[:title]
         attrs[:description] = Array(attrs[:description]) if attrs[:description]
-        attrs[:visibility] = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
         attrs
       end
 

--- a/app/views/hyrax/my/_collection_action_menu.html.erb
+++ b/app/views/hyrax/my/_collection_action_menu.html.erb
@@ -32,14 +32,14 @@
         <% end %>
       </li>
     <% end %>
-    <li role="menuitem" tabindex="-1">
-      <%= link_to main_app.collection_exports_path(collection_id: id),
+    <!-- <li role="menuitem" tabindex="-1"> -->
+      <%#= link_to main_app.collection_exports_path(collection_id: id),
                   method: 'post',
                   class: 'itemicon itemexport export-collection-button',
                   title: t("hyrax.dashboard.my.action.export_collection") do %>
-        <%= t("hyrax.dashboard.my.action.export_collection") %>
-      <% end %>
-    </li>
+        <%#= t("hyrax.dashboard.my.action.export_collection") %>
+      <%# end %>
+      <!-- </li> -->
     <li role="menuitem" tabindex="-1">
       <%= link_to "#",
                   class: 'itemicon itemtrash delete-collection-button',

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
+  routes { Hyrax::Engine.routes }
+  let(:user)  { create(:user) }
+  let(:other) { build(:user) }
+  let(:collection_type_gid) { create(:user_collection_type).gid }
+
+  let(:asset1)         { create(:work, title: ["First of the Assets"], user: user) }
+  let(:asset2)         { create(:work, title: ["Second of the Assets"], user: user) }
+  let(:unowned_asset)  { create(:work, user: other) }
+
+  let(:collection_attrs) do
+    { collection: { title: "title",
+                    creator: ["creator"],
+                    description: "desc",
+                    license: "http://rightsstatements.org/vocab/InC/1.0/",
+                    permissions_attributes: [{ type: 'person', name: 'archivist1', access: 'edit' }] },
+      collection_type_gid: collection_type_gid }
+  end
+
+  describe '#create' do
+    before { sign_in user }
+
+    # rubocop:disable RSpec/ExampleLength
+    it "creates a Collection" do
+      expect do
+        post :create, params: collection_attrs
+      end.to change { Collection.count }.by(1)
+      expect(assigns[:collection].visibility).to eq 'open'
+      expect(assigns[:collection].edit_users).to contain_exactly "archivist1", user.email
+      expect(flash[:notice]).to eq "Collection was successfully created."
+    end
+
+    context "when create fails" do
+      let(:collection) { Collection.new }
+
+      before do
+        allow(controller).to receive(:authorize!)
+        allow(Collection).to receive(:new).and_return(collection)
+        allow(collection).to receive(:save).and_return(false)
+      end
+
+      it "renders the form again" do
+        post :create, params: { collection: collection_attrs }
+        expect(response).to be_successful
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+end

--- a/spec/features/collection_export_spec.rb
+++ b/spec/features/collection_export_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe "collection export", type: :feature do
 
     context "collections that the user created" do
       it "do all the things we expect", :clean_repo do
+        skip
         sign_in user
         visit "dashboard/my/collections"
         # can export a collection from the dashboard collection index

--- a/spec/views/hyrax/my/_collection_action_menu.html.erb_spec.rb
+++ b/spec/views/hyrax/my/_collection_action_menu.html.erb_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'hyrax/my/_collection_action_menu.html.erb' do
     it "shows view, edit, export, and delete" do
       expect(rendered).to have_link 'View collection', href: hyrax.dashboard_collection_path(id)
       expect(rendered).to have_link 'Edit collection', href: hyrax.edit_dashboard_collection_path(id)
-      expect(rendered).to have_link 'Export collection', href: main_app.collection_exports_path(collection_id: id)
+      expect(rendered).not_to have_link 'Export collection', href: main_app.collection_exports_path(collection_id: id)
       expect(rendered).to have_link 'Delete collection'
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe 'hyrax/my/_collection_action_menu.html.erb' do
     it "shows view, delete, and export; hide edit" do
       expect(rendered).to have_link 'View collection', href: hyrax.dashboard_collection_path(id)
       expect(rendered).not_to have_link 'Edit collection', href: hyrax.edit_dashboard_collection_path(id)
-      expect(rendered).to have_link 'Export collection', href: main_app.collection_exports_path(collection_id: id)
+      expect(rendered).not_to have_link 'Export collection', href: main_app.collection_exports_path(collection_id: id)
       expect(rendered).to have_link 'Delete collection'
     end
   end


### PR DESCRIPTION
Fixes #597 

Two fixes in two different commits for this PR:

1. Hides a "Collection Export" link that was missed in a previous PR. 

1. Refactors the way we default new collections to Open Access visibility.  The previous method prevented visibility from ever being changed.