### PR TITLE
Bug/#611 Uses eager_load_paths over autoload

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ module ScholarUc
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     config.exceptions_app = routes
-    config.autoload_paths << Rails.root.join('lib')
+    config.eager_load_paths << Rails.root.join('lib')
     # REMOVE_ME: Temporarily remove strong params
     # config.action_controller.permit_all_parameters = true
   end


### PR DESCRIPTION
Fixes #611;

Load lib directory into memory immediately on server start.

We've found the source of the problem, and made a change locally on QA.  We think the problem came from a difference in autoloading and eager loading classes and methods.  autoload only pulls in things in the app folder into memory and pulls from things in lib and others as needed, which is fine locally.  Eager loading pulls everything into memory, which is important because we lose thread safety in prod.  This change was done in #1723 for scholar.
