### PR TITLE
Fix Solr reindex_everything timeout

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -231,6 +231,15 @@ Style/SymbolArray:
 Style/GuardClause:
   Exclude:
     - 'app/indexers/hyrax/work_indexer.rb'
+    - 'lib/active_fedora/fedora.rb'
+
+Style/IfUnlessModifier:
+  Exclude:
+    - 'lib/active_fedora/fedora.rb'
+
+Style/RedundantFreeze:
+  Exclude:
+    - 'lib/active_fedora/fedora.rb'
 
 Style/BlockDelimiters:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'jbuilder', '~> 2.5'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+gem 'active-fedora', '11.5.4'
 gem 'active_attr'
 gem 'change_manager', git: "https://github.com/uclibs/change_manager.git", ref: '8d151d1123aa35658f061a63bc72435afdf0ec8a'
 # gem 'clamav'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -940,6 +940,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active-fedora (= 11.5.4)
   active_attr
   bixby (>= 1.0.0)
   browse-everything!

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -3,13 +3,16 @@ development:
   password: <%= ENV["SCHOLAR_FEDORA_PASSWORD"] %>
   url: <%= ENV["SCHOLAR_FEDORA_URL"] %>
   base_path: /dev
+  request: { timeout: 600, open_timeout: 60}
 test:
   user: fedoraAdmin
   password: <%= ENV["SCHOLAR_FEDORA_PASSWORD"] %>
   url: <%= ENV["SCHOLAR_FEDORA_URL"] %>
   base_path: /test
+  request: { timeout: 600, open_timeout: 60}
 production:
   user: fedoraAdmin
   password: <%= ENV["SCHOLAR_FEDORA_PASSWORD"] %>
   url: <%= ENV["SCHOLAR_FEDORA_URL"] %>
   base_path: /prod
+  request: { timeout: 600, open_timeout: 60}

--- a/lib/active_fedora/fedora.rb
+++ b/lib/active_fedora/fedora.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+require 'faraday'
+require 'faraday-encoding'
+
+module ActiveFedora
+  class Fedora
+    class << self
+      def register(options = {})
+        ActiveFedora::RuntimeRegistry.fedora_connection = Fedora.new(ActiveFedora.fedora_config.credentials.merge(options))
+      end
+
+      def instance
+        register unless ActiveFedora::RuntimeRegistry.fedora_connection
+
+        ActiveFedora::RuntimeRegistry.fedora_connection
+      end
+
+      def reset!
+        ActiveFedora::RuntimeRegistry.fedora_connection = nil
+      end
+    end
+
+    def initialize(config)
+      @config = config
+
+      validate_options
+    end
+
+    def host
+      @config[:url].sub(/\/$/, BLANK)
+    end
+
+    def base_path
+      @config[:base_path] || SLASH
+    end
+
+    def base_uri
+      host + base_path.sub(/\/$/, BLANK)
+    end
+
+    def user
+      @config[:user]
+    end
+
+    def password
+      @config[:password]
+    end
+
+    def ssl_options
+      @config[:ssl]
+    end
+
+    def request_options
+      @config[:request]
+    end
+
+    def connection
+      @connection ||= begin
+        build_connection
+      end
+    end
+
+    def clean_connection
+      @clean_connection ||= CleanConnection.new(connection)
+    end
+
+    def caching_connection(options = {})
+      CachingConnection.new(authorized_connection, options)
+    end
+
+    def ldp_resource_service
+      @service ||= LdpResourceService.new(connection)
+    end
+
+    SLASH = '/'.freeze
+    BLANK = ''.freeze
+
+    # Remove a leading slash from the base_path
+    def root_resource_path
+      @root_resource_path ||= base_path.sub(SLASH, BLANK)
+    end
+
+    def build_connection
+      # The InboundRelationConnection does provide more data, useful for
+      # things like ldp:IndirectContainers, but it's imposes a significant
+      # performance penalty on every request
+      #   @connection ||= InboundRelationConnection.new(caching_connection(omit_ldpr_interaction_model: true))
+      InitializingConnection.new(caching_connection(omit_ldpr_interaction_model: true), root_resource_path)
+    end
+
+    def authorized_connection
+      options = {}
+      options[:ssl] = ssl_options if ssl_options
+      options[:request] = request_options if request_options
+      Faraday.new(host, options) do |conn|
+        conn.response :encoding # use Faraday::Encoding middleware
+        conn.adapter Faraday.default_adapter # net/http
+        conn.basic_auth(user, password)
+      end
+    end
+
+    def validate_options
+      unless host.downcase.end_with?("/rest")
+        ActiveFedora::Base.logger.warn "Fedora URL (#{host}) does not end with /rest. This could be a problem. Check your fedora.yml config"
+      end
+    end
+  end
+end

--- a/spec/unit/fedora_spec.rb
+++ b/spec/unit/fedora_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe ActiveFedora::Fedora do
+  subject(:fedora) { described_class.new(config) }
+  describe "#authorized_connection" do
+    describe "with SSL options" do
+      let(:config) do
+        { url: "https://example.com",
+          user: "fedoraAdmin",
+          password: "fedoraAdmin",
+          ssl: { ca_path: '/path/to/certs' } }
+      end
+      specify do
+        expect(Faraday).to receive(:new).with("https://example.com", ssl: { ca_path: '/path/to/certs' }).and_call_original
+        fedora.authorized_connection
+      end
+    end
+    describe "with request options" do
+      let(:config) do
+        { url: "https://example.com",
+          user: "fedoraAdmin",
+          password: "fedoraAdmin",
+          request: { timeout: 600, open_timeout: 60 } }
+      end
+      specify do
+        expect(Faraday).to receive(:new).with("https://example.com", request: { timeout: 600, open_timeout: 60 }).and_call_original
+        fedora.authorized_connection
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #617 

Fixes the timeout problem when running a Solr reindex from the console.

This exact code has already been run successfully on scholar.uc.edu.