### PR TITLE
Fixes alignment of featured work image.

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -58,3 +58,7 @@
      line-height: 50px !important;
      right: 10px !important;
  }
+
+.featured-work-fix {
+  display: inline-block;
+}

--- a/app/views/hyrax/homepage/_featured.html.erb
+++ b/app/views/hyrax/homepage/_featured.html.erb
@@ -1,6 +1,6 @@
 <% presenter = featured.presenter %>
 <li class="featured-item" data-id="<%= presenter.id %>">
-  <div class="center-block main row featured-thumb">
+  <div class="center-block main row featured-thumb featured-work-fix">
     <%= render_thumbnail_tag presenter, { alt: "Featured work thumbnail: #{ presenter.title.first }" } %>
   </div>
 </li>


### PR DESCRIPTION
Fixes #622  ;

Adds css to the application to center featured work image and text.  It looks like the blacklight presenter was changing the display property.  Added a specification for it to be displayed as inline-block.
