### PR TITLE
Configures file attachment requirement for batch create.

### DIFF
--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -8,7 +8,7 @@
         <legend class="legend-save-work"><%= t('.requirements') %></legend>
         <ul class="requirements">
           <li class="incomplete" id="required-metadata"><%= t('.required_descriptions') %></li>
-          <% if Hyrax.config.work_requires_files? %>
+          <% if Hyrax.config.work_requires_files? || params[:controller] == "hyrax/batch_uploads" %>
             <li class="incomplete" id="required-files"><%= t('.required_files') %></li>
           <% end %>
           <% if Flipflop.show_deposit_agreement? && Flipflop.active_deposit_agreement_acceptance? %>

--- a/spec/features/hyrax/batch_create_spec.rb
+++ b/spec/features/hyrax/batch_create_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Batch creation of works', type: :feature do
       expect(page).to have_content("Files")
     end
     expect(page).to have_content("Each file will be uploaded to a separate new work resulting in one work per uploaded file.")
+    expect(page).to have_content("Add files")
   end
 
   it 'defaults to public visibility' do


### PR DESCRIPTION
Fixes #638 

The use case required that the batch create require a file to be attached while the work submission page without the file requirement.  To do this, I added a param check to see if we were coming from batch create.