### PR TITLE
Sets email address for password reset.

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'scholar@uc.edu'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
Fixes #641 

Sets the password reset email address to scholar@uc.edu in the devise initializer.