### PR TITLE
#634 Ensures that the locale will persist.

### DIFF
--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -11,7 +11,9 @@
         </button>
         <%= render '/logo' %>
         <% unless controller_name == 'homepage' %>
-          <a class="navbar-brand" href ="/"><b> | <%= image_tag 'scholar-logo.png', id: 'scholar-nav-logo', alt: 'scholar@uc' %> </b></a>
+          <%= link_to root_path, class: 'navbar-brand' do %> 
+            <b> | <%= image_tag 'scholar-logo.png', id: 'scholar-nav-logo', alt: 'scholar@uc' %> </b>
+          <% end %>
         <% end %>
       </div>
       <div class="collapse navbar-collapse" id="top-navbar-collapse">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Forgot your password?</h2>
 
-<p>Note: If you have a <strong>uc.edu</strong> email address, do <strong>not</strong> use this form to reset your password. Use the <a href="/users/auth/shibboleth">Central Login form</a> instead.</p>
+<p>Note: If you have a <strong>uc.edu</strong> email address, do <strong>not</strong> use this form to reset your password. Use the <%= link_to 'Central Login form', user_shibboleth_omniauth_authorize_path %> instead.</p>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= devise_error_messages! %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -27,5 +27,5 @@
     </div>
   <% end %>
 <% else %>
-  <p>To request an account, <a href="/contact">use the contact page</a>.</p>
+  <p>To request an account, <%= link_to 'use the contact page', contact_path %></a>.</p>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Local Account Log in</h2>
 
 <% if AUTH_CONFIG['shibboleth_enabled'] %>
-  <p>Note: If you are affiliated with UC, use the <a href="/users/auth/shibboleth">Central Login form</a> instead.</p>
+  <p>Note: If you are affiliated with UC, use the <%= link_to 'Central Login form', user_shibboleth_omniauth_authorize_path %> instead.</p>
 <% end %>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
@@ -28,7 +28,8 @@
 <% end %>
 
 <% if AUTH_CONFIG['signups_enabled'] %>
-  <a href="/users/sign_up">Sign up</a><br />
+  <%= link_to 'Sign up', new_user_registration_path %>
+<br />
 <% end %>
 
-<p><a href="/users/password/new">Reset/Forgot your password?</a></p>
+<p><%= link_to 'Reset/Forgot your password?', new_user_password_path %></a></p>

--- a/app/views/hyrax/base/_file_manager_member.erb
+++ b/app/views/hyrax/base/_file_manager_member.erb
@@ -1,0 +1,32 @@
+<li data-reorder-id='<%= node.id %>'>
+    <div class="panel panel-default">
+      <%= simple_form_for [main_app, node], remote: true, html: {'data-type': 'json'} do |f| %>
+        <div class="panel-heading">
+          <div class="order-title">
+            <%= f.input :title, as: :string, input_html: { name: "#{f.object.model_name.singular}[title][]", class: "title" }, value: node.to_s, label: false, hint: false %>
+          </div>
+          <div class="file-set-link pull-right">
+            <%= link_to contextual_path(node, @presenter + '?config=' + I18n.loacle.to_s), title: "Edit file" do %>
+              <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+            <% end %>
+          </div>
+          <% if node.respond_to?(:label) %>
+            <div class="order-filename">
+              <em title="<%= node.page_title %>">(<%= truncate(node.label, length: 29) %>)</em>
+            </div>
+          <% end %>
+        </div>
+        <div class="panel-body">
+          <div class="text-center thumbnail">
+            <%= render "file_manager_thumbnail", node: node %>
+          </div>
+          <div class="attributes">
+            <%= render "file_manager_attributes", node: node, f: f %>
+          </div>
+          <div class="spacer">
+          </div>
+        </div>
+      <% end %>
+      <%= render "file_manager_member_resource_options", node: node %>
+    </div>
+</li>

--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -1,0 +1,11 @@
+<tr class="<%= dom_class(member) %> attributes">
+  <td class="thumbnail">
+    <%= render_thumbnail_tag member %>
+  </td>
+  <td class="attribute attribute-filename ensure-wrapped"><%= link_to(member.link_name, contextual_path(member, @presenter) + '?locale=' + I18n.locale.to_s) %></td>
+  <td class="attribute attribute-date_uploaded"><%= member.try(:date_uploaded) %></td>
+  <td class="attribute attribute-permission"><%= member.permission_badge %></td>
+  <td>
+    <%= render 'actions', member: member %>
+  </td>
+</tr>

--- a/app/views/static/creators_rights.html.erb
+++ b/app/views/static/creators_rights.html.erb
@@ -3,10 +3,10 @@
 <h2>Creator&#39s Rights</h2>
 
 <p>
-  Contributing to <a href="/"><%=t('hyrax.product_name') %></a> may raise questions about what rights you may hold as the creator of a work.
+  Contributing to <%= link_to t('hyrax.product_name'), root_path %> may raise questions about what rights you may hold as the creator of a work.
 
   First and foremost, you are the creator of your work and you are in control of its copyright.  This is your
-  right; in no way does contributing to <a href="/"><%=t('hyrax.product_name') %></a> limit your ability to
+  right; in no way does contributing to <%= link_to t('hyrax.product_name'), root_path %></a> limit your ability to
   claim or enforce copyright on your work.  However, you may have entered into publishing agreements that
   restrict you from sharing your work, especially if you agreed to relinquish or transfer your copyright as part of an author agreement.
 </p>
@@ -25,7 +25,7 @@
   This resource is a database of academic publishers and their standard terms. If you signed a standard
   publishing agreement with one of these companies, this resource will help you determine what rights you have
   under that agreement.  For example, it may help you determine whether it is okay to archive, or submit to
-  <a href="/"><%=t('hyrax.product_name') %></a> a pre-print, post-print, publisher’s version, or other version.
+  <%= link_to t('hyrax.product_name'), root_path %></a> a pre-print, post-print, publisher’s version, or other version.
 </p>
 
 <p>
@@ -75,7 +75,7 @@
       By retaining copyright for articles you submit to commercial or society publishers, you are taking back
     control of your own scholarly output. When you own the copyright of your own work, you have the freedom to
     disseminate your work as you please whether this means posting a copy of your article on your own website,
-    distributing copies to students and colleagues or posting it to a repository [such as <a href="/"><%=t('hyrax.product_name') %></a>].
+    distributing copies to students and colleagues or posting it to a repository [such as <%= link_to t('hyrax.product_name'), root_path %></a>].
     Widespread dissemination of your work, in turn, means that your work can be read by more people and thus has greater potential impact.
   </p>
 

--- a/app/views/static/login.html.erb
+++ b/app/views/static/login.html.erb
@@ -8,5 +8,5 @@
 <div id="local-login">
   &nbsp;<br />
   <h3>Other Users</h3>
-  <p>If you're not affiliated with UC, but have been given an account for <%= t('hyrax.product_name') %>, you can <strong><%= link_to 'log in using a local account', new_user_session_path %></strong>.  To request an account, <a href="/contact">use the contact page</a>.</p>
+  <p>If you're not affiliated with UC, but have been given an account for <%= t('hyrax.product_name') %>, you can <strong><%= link_to 'log in using a local account', new_user_session_path %></strong>.  To request an account, <%= link_to 'use the contact page', contact_path %>.</p>
 </div>

--- a/app/views/welcome_page/_student_welcome_text.erb
+++ b/app/views/welcome_page/_student_welcome_text.erb
@@ -2,7 +2,7 @@
 <p>Welcome to <%= t('hyrax.product_name') %>! On this page, you will learn how students can use <%= t('hyrax.product_name') %>.</p>
 
 <h3 id="what-is-Scholar">What is <%= t('hyrax.product_name') %>?</h3>
-<p><%= t('hyrax.product_name') %> is a digital repository that enables the University of Cincinnati community to share research and scholarly work with a worldwide audience and preserve it for the future. It provides free access to material written, produced, and researched by the UC community. Read more about the mission of <%= t('hyrax.product_name') %> on the <a href="/about">About page</a>. Get the latest updates on development of <%= t('hyrax.product_name') %> on our <a href="http://libapps.libraries.uc.edu/scholarblog/">Scholarblog</a>.</p>
+<p><%= t('hyrax.product_name') %> is a digital repository that enables the University of Cincinnati community to share research and scholarly work with a worldwide audience and preserve it for the future. It provides free access to material written, produced, and researched by the UC community. Read more about the mission of <%= t('hyrax.product_name') %> on the <%= link_to 'About page', about_path %></a>. Get the latest updates on development of <%= t('hyrax.product_name') %> on our <a href="http://libapps.libraries.uc.edu/scholarblog/">Scholarblog</a>.</p>
 
 <h3 id="how-can-students-use-Scholar">How can students use <%= t('hyrax.product_name') %>?</h3>
 <p>Although only faculty and staff can submit content to <%= t('hyrax.product_name') %> at this time, students can log in and view material in the repository for research or classroom work. <%= t('hyrax.product_name') %> is constantly growing and includes information like published articles, photographs, manuscripts, datasets, posters and much more.</p>
@@ -15,8 +15,8 @@
 
   <li><p><b>Citing materials in <%= t('hyrax.product_name') %>: </b>Citing material in <%= t('hyrax.product_name') %> is similar to citing resources found in other database and online. See the <a href= "http://guides.libraries.uc.edu/citing">campus guide on citing your sources.</a></p></li>
 
-  <li><p><b>Terms of Use: </b>For more information, see the <%= t('hyrax.product_name') %> <a href="/terms">Terms of Use.</a></p></li>
+  <li><p><b>Terms of Use: </b>For more information, see the <%= t('hyrax.product_name') %> <%= link_to 'Terms of Use.', terms_path %></p></li>
 </ul>
 
 <h4 id="need-further-assistance">Need Further Assistance?</h4>
-<p><a href="/contact">Contact the <%= t('hyrax.product_name') %> Team</a>.</p>
+<p><%= link_to 'Contact the ' + t('hyrax.product_name'), contact_path %> Team</a>.</p>

--- a/app/views/welcome_page/_welcome_text.html.erb
+++ b/app/views/welcome_page/_welcome_text.html.erb
@@ -2,10 +2,10 @@
 <p>Welcome to <%= t('hyrax.product_name') %>! On this page, you will learn how to use <%= t('hyrax.product_name') %>.</p>
 
 <h3 id="what-is-Scholar">What is <%= t('hyrax.product_name') %>?</h3>
-<p><%= t('hyrax.product_name') %> is a digital repository that enables the University of Cincinnati community to share research and scholarly work with a worldwide audience and preserve it for the future. Read more about the mission of <%= t('hyrax.product_name') %> on the <a href="/about">About page</a>. Get the latest updates on development of <%= t('hyrax.product_name') %> on our <a href="http://libapps.libraries.uc.edu/scholarblog/">Scholarblog</a>. All users, including non-registered users, of <%= t('hyrax.product_name') %> are bound by the <a href="/terms">Terms of Use</a>.</p>
+<p><%= t('hyrax.product_name') %> is a digital repository that enables the University of Cincinnati community to share research and scholarly work with a worldwide audience and preserve it for the future. Read more about the mission of <%= t('hyrax.product_name') %> on the <%= link_to 'About page', about_path %>. Get the latest updates on development of <%= t('hyrax.product_name') %> on our <a href="http://libapps.libraries.uc.edu/scholarblog/">Scholarblog</a>. All users, including non-registered users, of <%= t('hyrax.product_name') %> are bound by the <%= link_to 'Terms of Use', terms_path %>.</p>
 
 <h3 id="what-types-of-content-should-i-submit-to-Scholar">What types of content should I submit to <%= t('hyrax.product_name') %>?</h3>
-<p><%= t('hyrax.product_name') %> stores and preserves the scholarly output and creative works of UC faculty, staff, and students. Examples of appropriate content include, but are not limited to: <a href="https://en.wikipedia.org/wiki/Grey_literature">grey literature</a>, <a href="https://en.wikipedia.org/wiki/Preprint">pre-</a>, <a href="https://en.wikipedia.org/wiki/Postprint">post-</a>, and published versions of academic papers, manuscripts, senior design projects, posters, datasets, presentations, and other creative works. Content may be text, image, video, audio, or mixed-media in nature. Learn more about types of content you can share on the <a href="/coll_policy">Collection Policy</a>.</p>
+<p><%= t('hyrax.product_name') %> stores and preserves the scholarly output and creative works of UC faculty, staff, and students. Examples of appropriate content include, but are not limited to: <a href="https://en.wikipedia.org/wiki/Grey_literature">grey literature</a>, <a href="https://en.wikipedia.org/wiki/Preprint">pre-</a>, <a href="https://en.wikipedia.org/wiki/Postprint">post-</a>, and published versions of academic papers, manuscripts, senior design projects, posters, datasets, presentations, and other creative works. Content may be text, image, video, audio, or mixed-media in nature. Learn more about types of content you can share on the <%= link_to 'Collection Policy', coll_policy_path %>.</p>
 <p>Students should work with a faculty member to share scholarly output and creative works, such a capstone projects.</p>
 
 <h3 id="how-do-i-get-started">How do I get started?</h3>
@@ -15,10 +15,10 @@
 <p>Under the Help button on the main <%= t('hyrax.product_name') %> menu, you will find the following help topics:</p>
 
 <ul>
-  <li><a href="/faq">FAQs</a> – Answers to a variety of commonly asked questions</li>
-  <li><a href="/format_advice">File Format Advice</a> – Help with finding the right file format for the content you submit to <%= t('hyrax.product_name') %></li>
-  <li><a href="/creators_rights">Creator’s Rights</a> – Information on Copyright and Intellectual Property</li>
+  <li><%= link_to 'FAQs', faq_path %> – Answers to a variety of commonly asked questions</li>
+  <li><%= link_to 'File Format Advice', format_advice_path %> – Help with finding the right file format for the content you submit to <%= t('hyrax.product_name') %></li>
+  <li><%= link_to 'Creator’s Rights', creators_rights_path %> – Information on Copyright and Intellectual Property</li>
 </ul>
 
 <h4 id="need-further-assistance">Need Further Assistance?</h4>
-<p><a href="/contact">Contact the <%= t('hyrax.product_name') %> Team</a>.</p>
+<p><%= link_to 'Contact the ' + t('hyrax.product_name') + 'Team', contact_path %>.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,3 +44,7 @@ en:
     create_confirmation: "Collection export was successfully created."
     destroy_confirmation: "Collection export was successfully deleted."
   whats_new: "What's New"
+  devise:
+    sessions:
+      user:
+        signed_in: "Signed in successfully."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -44,3 +44,7 @@ es:
     create_confirmation: "La exportación de la colección fue creada con éxito."
     destroy_confirmation: "La exportación de la colección se ha eliminado correctamente."
   whats_new: Qué hay de nuevo
+  devise:
+    sessions:
+      user:
+        signed_in: "Inicia sesión con éxito."

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -44,3 +44,7 @@ zh:
     create_confirmation: "已成功创建集合导出。"
     destroy_confirmation: "集合导出已成功删除。"
   whats_new: 什么是新的
+  devise:
+    sessions:
+      user:
+        signed_in: "成功签约。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   get 'login' => 'static#login'
   get 'about' => 'static#about'
   get 'help' => 'static#help'
+  get 'contact' => 'hyrax/contact_form#new'
   get 'coll_policy' => 'static#coll_policy'
   get 'format_advice' => 'static#format_advice'
   get 'faq' => 'static#faq'

--- a/spec/features/locales_spec.rb
+++ b/spec/features/locales_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'locales' do
+  before do
+    Rails.application.config.application_root_url = 'http://localhost:3000'
+  end
+
+  describe 'work show page' do
+    let(:work_type) { "generic_work" }
+    let!(:user) { create(:user) }
+    let!(:work) { create(:generic_work_with_one_file, title: ["Magnificent splendor"], description: ["My description"], source: ["The Internet"], based_near: ["USA"], user: user) }
+    let(:work_path) { "/concern/#{work_type}s/#{work.id}" }
+    let(:file_path) { "/concern/parent/#{work.id}/file_sets/#{work.file_sets.first.id}?locale=en" }
+
+    before do
+      sign_in user
+      visit work_path
+    end
+
+    it "has a fileset link with the correct locale" do
+      expect(page).to have_link(work.file_sets.first.title.first, href: file_path)
+    end
+  end
+
+  describe 'masthead' do
+    before do
+      visit search_catalog_path
+    end
+
+    it "has a link with the correct locale" do
+      expect(page).to have_link('|', href: '/?locale=en')
+    end
+  end
+end

--- a/spec/features/uc_shibboleth_spec.rb
+++ b/spec/features/uc_shibboleth_spec.rb
@@ -68,7 +68,7 @@ describe 'UC account workflow', type: :feature do
     it 'shows a request link of signups are disabled' do
       AUTH_CONFIG['signups_enabled'] = false
       visit new_user_registration_path
-      expect(page).to have_link('use the contact page', href: '/contact')
+      expect(page).to have_link('use the contact page', contact_path)
     end
   end
 
@@ -76,19 +76,19 @@ describe 'UC account workflow', type: :feature do
     it 'shows a shibboleth login link if shibboleth is enabled' do
       AUTH_CONFIG['shibboleth_enabled'] = true
       visit new_user_session_path
-      expect(page).to have_link('Central Login form', href: '/users/auth/shibboleth')
+      expect(page).to have_link('Central Login form', user_shibboleth_omniauth_authorize_path)
     end
 
     it 'does not show a shibboleth login link if shibboleth is disabled' do
       AUTH_CONFIG['shibboleth_enabled'] = false
       visit new_user_session_path
-      expect(page).not_to have_link('Central Login form', href: '/users/auth/shibboleth')
+      expect(page).not_to have_link('Central Login form', user_shibboleth_omniauth_authorize_path)
     end
 
     it 'shows a signup link if signups are enabled' do
       AUTH_CONFIG['signups_enabled'] = true
       visit new_user_session_path
-      page.should have_link('Sign up', href: new_user_registration_path)
+      page.should have_link('Sign up', new_user_registration_path)
     end
 
     it 'does not show signup link if signups are disabled' do


### PR DESCRIPTION
Fixes #634  ;

There are several places in the application where anchor tags are used rather than rails link_to helpers.  Helpers ensure that language selection persists.  This PR transitions relative links in the application to rails tags.

I found a missing translation in the course of working on this issue, I've added them to this PR as well.