### PR TITLE
switch from static to dynamic attributes in factories

### DIFF
--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     transient do
       user { create(:user) }
       # Set to true (or a hash) if you want to create an admin set
-      with_admin_set false
+      with_admin_set { false }
     end
 
     # It is reasonable to assume that a work has an admin set; However, we don't want to
@@ -25,23 +25,23 @@ FactoryBot.define do
       sleep 1
     end
 
-    title ["Test title"]
-    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    title { ["Test title"] }
+    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
 
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
     end
 
     factory :public_article do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     factory :private_article do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     factory :registered_article do
-      read_groups ["registered"]
+      read_groups { ["registered"] }
     end
 
     factory :article_with_one_file do
@@ -183,7 +183,7 @@ FactoryBot.define do
 
   # Doesn't set up any edit_users
   factory :article_without_access, class: Medium do
-    title ['Test title']
+    title { ['Test title'] }
     depositor { create(:user).user_key }
   end
 end

--- a/spec/factories/change_manager_changes.rb
+++ b/spec/factories/change_manager_changes.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :change, class: 'ChangeManager::Change' do
-    owner "email@test.com"
-    change_type "added_as_delegate"
-    context "1"
-    target "spec@test.com"
-    cancelled false
-    notified nil
+    owner { "email@test.com" }
+    change_type { "added_as_delegate" }
+    context { "1" } # rubocop:disable RSpec/EmptyExampleGroup
+    target { "spec@test.com" }
+    cancelled { false }
+    notified { nil }
   end
 end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -104,10 +104,10 @@ FactoryBot.define do
     transient do
       user { create(:user) }
 
-      collection_type_settings nil
-      with_permission_template false
-      with_nesting_attributes nil
-      with_solr_document false
+      collection_type_settings { nil }
+      with_permission_template { false }
+      with_nesting_attributes { nil }
+      with_solr_document { false }
     end
     sequence(:title) { |n| ["Collection Title #{n}"] }
 
@@ -132,32 +132,32 @@ FactoryBot.define do
     factory :public_collection_lw, traits: [:public_lw]
 
     factory :private_collection_lw do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     factory :institution_collection_lw do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
     end
 
     factory :named_collection_lw do
-      title ['collection title']
-      description ['collection description']
+      title { ['collection title'] }
+      description { ['collection description'] }
     end
 
     trait :public_lw do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     trait :private_lw do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     trait :institution_lw do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
     end
 
     trait :public_lw do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
   end
 
@@ -181,8 +181,8 @@ FactoryBot.define do
     #   col.save(validate: false)
     transient do
       user { create(:user) }
-      with_permission_template false
-      do_save false
+      with_permission_template { false }
+      do_save { false }
     end
 
     sequence(:title) { |n| ["Typeless Collection Title #{n}"] }

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -21,10 +21,10 @@ FactoryBot.define do
     transient do
       user { create(:user) }
       # allow defaulting to default user collection
-      collection_type_settings nil
-      with_permission_template false
-      create_access false
-      with_nesting_attributes nil
+      collection_type_settings { nil }
+      with_permission_template { false }
+      create_access { false }
+      with_nesting_attributes { nil }
     end
     sequence(:title) { |n| ["Collection Title #{n}"] }
 
@@ -67,20 +67,20 @@ FactoryBot.define do
     factory :public_collection, traits: [:public]
 
     trait :public do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     factory :private_collection do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     factory :institution_collection do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
     end
 
     factory :named_collection do
-      title ['collection title']
-      description ['collection description']
+      title { ['collection title'] }
+      description { ['collection description'] }
     end
   end
 
@@ -104,9 +104,9 @@ FactoryBot.define do
     #   col.save(validate: false)
     transient do
       user { create(:user) }
-      with_permission_template false
-      create_access false
-      do_save false
+      with_permission_template { false }
+      create_access { false }
+      do_save { false }
     end
 
     sequence(:title) { |n| ["Typeless Collection Title #{n}"] }

--- a/spec/factories/datasets.rb
+++ b/spec/factories/datasets.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     transient do
       user { create(:user) }
       # Set to true (or a hash) if you want to create an admin set
-      with_admin_set false
+      with_admin_set { false }
     end
 
     # It is reasonable to assume that a work has an admin set; However, we don't want to
@@ -25,23 +25,23 @@ FactoryBot.define do
       sleep 1
     end
 
-    title ["Test title"]
-    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    title { ["Test title"] }
+    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
 
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
     end
 
     factory :public_dataset do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     factory :private_dataset do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     factory :registered_dataseet do
-      read_groups ["registered"]
+      read_groups { ["registered"] }
     end
 
     factory :dataset_with_one_file do
@@ -183,7 +183,7 @@ FactoryBot.define do
 
   # Doesn't set up any edit_users
   factory :dataset_without_access, class: Medium do
-    title ['Test title']
+    title { ['Test title'] }
     depositor { create(:user).user_key }
   end
 end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     transient do
       user { create(:user) }
       # Set to true (or a hash) if you want to create an admin set
-      with_admin_set false
+      with_admin_set { false }
     end
 
     # It is reasonable to assume that a work has an admin set; However, we don't want to
@@ -25,23 +25,23 @@ FactoryBot.define do
       sleep 1
     end
 
-    title ["Test title"]
-    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    title { ["Test title"] }
+    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
 
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
     end
 
     factory :public_document do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     factory :private_document do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     factory :registered_document do
-      read_groups ["registered"]
+      read_groups { ["registered"] }
     end
 
     factory :document_with_one_file do
@@ -183,7 +183,7 @@ FactoryBot.define do
 
   # Doesn't set up any edit_users
   factory :document_without_access, class: Medium do
-    title ['Test title']
+    title { ['Test title'] }
     depositor { create(:user).user_key }
   end
 end

--- a/spec/factories/embargos.rb
+++ b/spec/factories/embargos.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :embargo, aliases: [:public_embargo], class: Hydra::AccessControls::Embargo do
-    visibility_during_embargo Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-    visibility_after_embargo Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-    embargo_release_date '2017-07-04 00:00:00'
+    visibility_during_embargo { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+    visibility_after_embargo { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    embargo_release_date { '2017-07-04 00:00:00' }
   end
 end

--- a/spec/factories/etds.rb
+++ b/spec/factories/etds.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     transient do
       user { create(:user) }
       # Set to true (or a hash) if you want to create an admin set
-      with_admin_set false
+      with_admin_set { false }
     end
 
     # It is reasonable to assume that a work has an admin set; However, we don't want to
@@ -25,23 +25,23 @@ FactoryBot.define do
       sleep 1
     end
 
-    title ["Test title"]
-    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    title { ["Test title"] }
+    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
 
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
     end
 
     factory :public_etd do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     factory :private_etd do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     factory :registered_etd do
-      read_groups ["registered"]
+      read_groups { ["registered"] }
     end
 
     factory :etd_with_one_file do
@@ -183,7 +183,7 @@ FactoryBot.define do
 
   # Doesn't set up any edit_users
   factory :etd_without_access, class: Medium do
-    title ['Test title']
+    title { ['Test title'] }
     depositor { create(:user).user_key }
   end
 end

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :file_set do
     transient do
       user { create(:user) }
-      content nil
+      content { nil }
     end
     after(:build) do |fs, evaluator|
       fs.apply_depositor_metadata evaluator.user.user_key
@@ -15,11 +15,11 @@ FactoryBot.define do
     end
 
     trait :public do
-      read_groups ["public"]
+      read_groups { ["public"] }
     end
 
     trait :registered do
-      read_groups ["registered"]
+      read_groups { ["registered"] }
     end
 
     trait :with_public_embargo do

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     transient do
       user { create(:user) }
       # Set to true (or a hash) if you want to create an admin set
-      with_admin_set false
+      with_admin_set { false }
     end
 
     # It is reasonable to assume that a work has an admin set; However, we don't want to
@@ -25,8 +25,8 @@ FactoryBot.define do
       sleep 1
     end
 
-    title ["Test title"]
-    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    title { ["Test title"] }
+    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
 
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
@@ -35,7 +35,7 @@ FactoryBot.define do
     factory :public_generic_work, aliases: [:public_work], traits: [:public]
 
     trait :public do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     factory :private_work do
@@ -44,7 +44,7 @@ FactoryBot.define do
     end
 
     factory :registered_generic_work do
-      read_groups ["registered"]
+      read_groups { ["registered"] }
     end
 
     factory :generic_work_with_one_file do
@@ -184,8 +184,8 @@ FactoryBot.define do
     end
 
     factory :embargoed_generic_work do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-      visibility_after_embargo Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+      visibility_after_embargo { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     trait :with_public_embargo do
@@ -198,7 +198,7 @@ FactoryBot.define do
   # Doesn't set up any edit_users
 
   factory :work_without_access, class: GenericWork do
-    title ['Test title']
+    title { ['Test title'] }
     depositor { create(:user).user_key }
   end
 end

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     transient do
       user { create(:user) }
       # Set to true (or a hash) if you want to create an admin set
-      with_admin_set false
+      with_admin_set { false }
     end
 
     # It is reasonable to assume that a work has an admin set; However, we don't want to
@@ -25,23 +25,23 @@ FactoryBot.define do
       sleep 1
     end
 
-    title ["Test title"]
-    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    title { ["Test title"] }
+    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
 
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
     end
 
     factory :public_image do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     factory :private_image do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     factory :registered_image do
-      read_groups ["registered"]
+      read_groups { ["registered"] }
     end
 
     factory :image_with_one_file do
@@ -183,7 +183,7 @@ FactoryBot.define do
 
   # Doesn't set up any edit_users
   factory :image_without_access, class: Medium do
-    title ['Test title']
+    title { ['Test title'] }
     depositor { create(:user).user_key }
   end
 end

--- a/spec/factories/media.rb
+++ b/spec/factories/media.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     transient do
       user { create(:user) }
       # Set to true (or a hash) if you want to create an admin set
-      with_admin_set false
+      with_admin_set { false }
     end
 
     # It is reasonable to assume that a work has an admin set; However, we don't want to
@@ -25,23 +25,23 @@ FactoryBot.define do
       sleep 1
     end
 
-    title ["Test title"]
-    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    title { ["Test title"] }
+    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
 
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
     end
 
     factory :public_medium do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     factory :private_medium do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     factory :registered_medium do
-      read_groups ["registered"]
+      read_groups { ["registered"] }
     end
 
     factory :medium_with_one_file do
@@ -183,7 +183,7 @@ FactoryBot.define do
 
   # Doesn't set up any edit_users
   factory :medium_without_access, class: Medium do
-    title ['Test title']
+    title { ['Test title'] }
     depositor { create(:user).user_key }
   end
 end

--- a/spec/factories/operations.rb
+++ b/spec/factories/operations.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :operation, class: Hyrax::Operation do
-    operation_type "Test operation"
+    operation_type { "Test operation" }
 
     trait :failing do
-      status Hyrax::Operation::FAILURE
+      status { Hyrax::Operation::FAILURE }
     end
 
     trait :pending do
-      status Hyrax::Operation::PENDING
+      status { Hyrax::Operation::PENDING }
     end
 
     trait :successful do
-      status Hyrax::Operation::SUCCESS
+      status { Hyrax::Operation::SUCCESS }
     end
 
     factory :batch_create_operation, class: Hyrax::BatchCreateOperation do
-      operation_type "Batch Create"
+      operation_type { "Batch Create" }
     end
   end
 end

--- a/spec/factories/permission_template_accesses.rb
+++ b/spec/factories/permission_template_accesses.rb
@@ -4,15 +4,15 @@ FactoryBot.define do
   factory :permission_template_access, class: Hyrax::PermissionTemplateAccess do
     permission_template
     trait :manage do
-      access 'manage'
+      access { 'manage' }
     end
 
     trait :deposit do
-      access 'deposit'
+      access { 'deposit' }
     end
 
     trait :view do
-      access 'view'
+      access { 'view' }
     end
   end
 end

--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -54,16 +54,16 @@ FactoryBot.define do
     end
 
     transient do
-      with_admin_set false
-      with_collection false
-      with_workflows false
-      with_active_workflow false
-      manage_users nil
-      manage_groups nil
-      deposit_users nil
-      deposit_groups nil
-      view_users nil
-      view_groups nil
+      with_admin_set { false }
+      with_collection { false }
+      with_workflows { false }
+      with_active_workflow { false }
+      manage_users { nil }
+      manage_groups { nil }
+      deposit_users { nil }
+      deposit_groups { nil }
+      view_users { nil }
+      view_groups { nil }
     end
   end
 

--- a/spec/factories/sipity_entities.rb
+++ b/spec/factories/sipity_entities.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :sipity_entity, class: Sipity::Entity do
-    proxy_for_global_id 'gid://internal/Mock/1'
+    proxy_for_global_id { 'gid://internal/Mock/1' }
     workflow { workflow_state.workflow }
     workflow_state
   end

--- a/spec/factories/student_works.rb
+++ b/spec/factories/student_works.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     transient do
       user { create(:user) }
       # Set to true (or a hash) if you want to create an admin set
-      with_admin_set false
+      with_admin_set { false }
     end
 
     # It is reasonable to assume that a work has an admin set; However, we don't want to
@@ -25,23 +25,23 @@ FactoryBot.define do
       sleep 1
     end
 
-    title ["Test title"]
-    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    title { ["Test title"] }
+    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
 
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
     end
 
     factory :public_student_work do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     factory :private_student_work do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     factory :registered_student_work do
-      read_groups ["registered"]
+      read_groups { ["registered"] }
     end
 
     factory :student_work_with_one_file do
@@ -183,7 +183,7 @@ FactoryBot.define do
 
   # Doesn't set up any edit_users
   factory :student_work_without_access, class: Medium do
-    title ['Test title']
+    title { ['Test title'] }
     depositor { create(:user).user_key }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,22 +3,22 @@
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
-    password 'password'
-    first_name 'Sample'
-    last_name 'User'
-    title 'job title'
-    ucdepartment 'Department'
-    uc_affiliation 'UC affiliation'
-    alternate_email 'Alternate email'
-    telephone 'Campus phone number'
-    alternate_phone_number 'Alternate phone number'
-    website 'Personal webpage'
-    blog 'Blog'
+    password { 'password' }
+    first_name { 'Sample' }
+    last_name { 'User' }
+    title { 'job title' }
+    ucdepartment { 'Department' }
+    uc_affiliation { 'UC affiliation' }
+    alternate_email { 'Alternate email' }
+    telephone { 'Campus phone number' }
+    alternate_phone_number { 'Alternate phone number' }
+    website { 'Personal webpage' }
+    blog { 'Blog' }
 
     transient do
       # Allow for custom groups when a user is instantiated.
       # @example create(:user, groups: 'avacado')
-      groups []
+      groups { [] }
     end
 
     # TODO: Register the groups for the given user key such that we can remove the following from other specs:
@@ -34,7 +34,7 @@ FactoryBot.define do
     end
 
     factory :admin do
-      groups ['admin']
+      groups { ['admin'] }
     end
 
     factory :user_with_mail do
@@ -59,21 +59,21 @@ FactoryBot.define do
 
   factory :shibboleth_user, class: 'User' do
     transient do
-      count 1
-      person_pid nil
+      count { 1 }
+      person_pid { nil }
     end
-    email 'sixplus2@test.com'
-    password '12345678'
-    first_name 'Fake'
-    last_name 'User'
-    password_confirmation '12345678'
+    email { 'sixplus2@test.com' }
+    password { '12345678' }
+    first_name { 'Fake' }
+    last_name { 'User' }
+    password_confirmation { '12345678' }
     sign_in_count { count.to_s }
-    provider 'shibboleth'
-    uid 'sixplus2@test.com'
+    provider { 'shibboleth' }
+    uid { 'sixplus2@test.com' }
   end
 
   trait :guest do
-    guest true
+    guest { true }
   end
 end
 

--- a/spec/factories/workflow_actions.rb
+++ b/spec/factories/workflow_actions.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :workflow_action, class: Sipity::WorkflowAction do
     workflow
-    name 'submit'
+    name { 'submit' }
   end
 end

--- a/spec/factories/workflow_states.rb
+++ b/spec/factories/workflow_states.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :workflow_state, class: Sipity::WorkflowState do
     workflow
-    name 'initial'
+    name { 'initial' }
   end
 end


### PR DESCRIPTION
Fixes #648 

Switch from static to dynamic attributes in factories to settle deprecation warning.
