### PR TITLE
#630 Don't show metadata labels for empty fields.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -217,6 +217,10 @@ RSpec/NamedSubject:
     - 'spec/services/hyrax/custom_stat_importer_spec.rb'
     - 'spec/models/collection_spec.rb'
 
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - 'app/renderers/hyrax/renderers/attribute_renderer.rb'
+
 Style/ClassAndModuleChildren:
   Enabled: false
 
@@ -277,3 +281,4 @@ Lint/RescueException:
 Rails/OutputSafety:
   Exclude:
     - 'app/helpers/hyrax_helper.rb'
+    - 'app/renderers/hyrax/renderers/attribute_renderer.rb'

--- a/app/renderers/hyrax/renderers/attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/attribute_renderer.rb
@@ -1,0 +1,43 @@
+require "rails_autolink/helpers"
+require Hyrax::Engine.root.join('app/renderers/hyrax/renderers/attribute_renderer.rb')
+
+module Hyrax
+  module Renderers
+    class AttributeRenderer
+      # Draw the table row for the attribute
+      def render
+        markup = ''
+
+        return markup if (values.blank? || array_of_empty_strings?(values)) && !options[:include_empty]
+        markup << %(<tr><th>#{label}</th>\n<td><ul class='tabular'>)
+        attributes = microdata_object_attributes(field).merge(class: "attribute attribute-#{field}")
+        Array(values).each do |value|
+          markup << "<li#{html_attributes(attributes)}>#{attribute_value_to_html(value.to_s)}</li>"
+        end
+        markup << %(</ul></td></tr>)
+        markup.html_safe
+      end
+
+      # Draw the dl row for the attribute
+      def render_dl_row
+        markup = ''
+
+        return markup if (values.blank? || array_of_empty_strings?(values)) && !options[:include_empty]
+        markup << %(<dt>#{label}</dt>\n<dd><ul class='tabular'>)
+        attributes = microdata_object_attributes(field).merge(class: "attribute attribute-#{field}")
+        Array(values).each do |value|
+          markup << "<li#{html_attributes(attributes)}>#{attribute_value_to_html(value.to_s)}</li>"
+        end
+        markup << %(</ul></dd>)
+        markup.html_safe
+      end
+
+      private
+
+        def array_of_empty_strings?(values)
+          return true if values.is_a?(Array) && values.all?(&:empty?)
+          false
+        end
+    end
+  end
+end

--- a/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Hyrax::Renderers::AttributeRenderer do
+  let(:field) { :note }
+  let(:renderer) { described_class.new(field, [""]) }
+
+  describe '#render' do
+    let(:rendered) { Nokogiri::HTML(renderer.render) }
+    let(:expected) { Nokogiri::HTML(tr_content) }
+    let(:tr_content) { "" }
+
+    it { expect(rendered).to be_equivalent_to(expected) }
+  end
+end


### PR DESCRIPTION
Fixes #630  ;

Traditionally, blank fields are represented with `nil` in the work object.  Some blank fields were set to an array with an empty string as it's only member.  In ruby, `[""].blank?` => `false` so our traditional method of excluding them from the metadata presenter wasn't catching it.

To prevent showing empty metadata fields, I've added a function that test whether the values item it receives is just filled with empty strings.

A line has been added to the .rubocop.yml file instructing it to ignore the usage of html_safe, we're generating the HTML.  It's very possible that I'm missing something, but it doesn't look like we're doing any filtering when pulling user input from the db, should we rewrite that portion?