### PR TITLE
#653 Field labels are incorrect on some work show pages

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -6,9 +6,9 @@
 <%= presenter.attribute_to_html(:time_period, html_dl: true) %>
 <%= presenter.submitter_profile.html_safe%>
 <%= presenter.attribute_to_html(:college, render_as: :faceted, html_dl: true) %>
-<%= presenter.attribute_to_html(:department, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:department, render_as: :faceted, html_dl: true, work_type: dom_class(presenter)) %>
 <%= presenter.attribute_to_html(:degree, html_dl: true) %>
-<%= presenter.attribute_to_html(:date_created, render_as: :faceted, label: "Date Created", html_dl: true) %>
+<%= presenter.attribute_to_html(:date_created, render_as: :faceted, label: "Date Created", html_dl: true, work_type: dom_class(presenter)) %>
 <%= presenter.attribute_to_html(:advisor, html_dl: true) %>
 <%= presenter.attribute_to_html(:committee_member, html_dl: true) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -13,6 +13,10 @@ en:
     search:
       collections: Collections
       fields:
+        etd:
+          show:
+            department: "Degree Program"
+            date_created: "Degree Date"
         facet:
           based_near_label_sim: Location
           college_sim: College

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -124,6 +124,10 @@ RSpec.describe 'Create a Etd', :feature, js: true do
       expect(page).to have_content "Your files are being processed by Scholar@UC in the background."
       expect(page).to have_content("Permanent link to this page")
 
+      # Page should show etd fields correctly
+      expect(page).to have_content("Degree Program")
+      expect(page).to have_content("Degree Date")
+
       # Edit the work to verify form values persist
       click_on('Edit')
 


### PR DESCRIPTION
Fixes #653  ; 

ETD show page was showing field names for department and date created rather than Degree Program and Degree Date.  This was due to missing a translation / the priority hyrax pulls translations.  Since Degree Program and Degree Dates are just different labels on Department and Date Created when the name of the solr field got pulled, it pulled the standard name.
