### PR TITLE
#449 Correct Proxy Delete Path

### DIFF
--- a/spec/controllers/hyrax/depositors_controller_spec.rb
+++ b/spec/controllers/hyrax/depositors_controller_spec.rb
@@ -6,6 +6,20 @@ describe Hyrax::DepositorsController, type: :controller do
   let(:user) { create(:user) }
   let(:grantee) { create(:user) }
 
+  describe "create" do
+    let(:request_to_grant_proxy) { post :create, params: { user_id: user.user_key, grantee_id: grantee.user_key, format: 'json', use_route: :hyrax } }
+    let(:expected_delete_path) { "/users/" + user.user_key.gsub("\.", '-dot-') + "/depositors/" + grantee.user_key.gsub("\.", '-dot-') + "?locale=en" }
+
+    before do
+      sign_in user
+    end
+
+    it "is successful" do
+      expect { request_to_grant_proxy }.to change { ProxyDepositRights.count }.by(1)
+      expect(JSON.parse(response.body)["delete_path"]).to eq expected_delete_path
+    end
+  end
+
   describe "destroy" do
     before do
       user.can_receive_deposits_from << grantee


### PR DESCRIPTION
Fixes #449  ;

Previously, the JSON returned to the proxy management page returned a path to the delete function that contained dots.  Rails wants emails in paths to use -dot- instead of a `.`.  Now it replies in the correct format.
