### PR TITLE
Wipe content before running locales feature spec

### DIFF
--- a/spec/features/locales_spec.rb
+++ b/spec/features/locales_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe 'locales' do
+describe 'locales', :clean_repo do
   before do
     Rails.application.config.application_root_url = 'http://localhost:3000'
   end


### PR DESCRIPTION
spec/features/locales_spec.rb was failing on some runs of the test suite because of content that gets created before this spec runs.  

So I'm adding `:clean_repo` at the start of the test like many of our other specs have.