### PR TITLE
#551 Increase Test Coverage

### DIFF
--- a/spec/services/collections_report_spec.rb
+++ b/spec/services/collections_report_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe CollectionsReport do
+  describe '#report_location' do
+    it 'is vendor/collections_report.csv' do
+      expect(described_class.report_location).to eq("#{Rails.root}/vendor/collections_report.csv")
+    end
+  end
+
+  describe '#create_report' do
+    let(:fake_collections) { [
+      FakeCollection.new('pid', 'title', 'foo@bar.org', ['foo@bar.org'], ['pid', 'pid']),
+      FakeCollection.new('pid', 'title', 'foo@bar.org', ['foo@bar.org'], ['pid']),
+      FakeCollection.new('pid', 'title', 'foo@bar.org', ['foo@bar.org'], ['']),
+      FakeCollection.new('pid', 'title', 'foo@bar.org', ['foo@bar.org'], ['pid', 'pid'])
+    ] }
+
+    before do
+      Collection.stub(:all).and_return(fake_collections)
+
+      File.delete(described_class.report_location) if File.exist?(described_class.report_location)
+    end
+
+    it 'creates a report in the report_location' do
+      described_class.create_report
+      expect(File).to exist(described_class.report_location)
+    end
+
+    it 'creates a report one line longer than the number of objects reported on' do
+      described_class.create_report
+      expect(
+        File.open(described_class.report_location).readlines.size
+      ).to eq(fake_collections.length + 1)
+    end
+
+    class FakeCollection < Struct.new(:id, :title, :depositor, :edit_users, :member_ids)
+    end
+  end
+end

--- a/spec/services/files_report_spec.rb
+++ b/spec/services/files_report_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe FilesReport do
+  describe '#report_location' do
+    it 'is vendor/files_report.csv' do
+      expect(described_class.report_location).to eq("#{Rails.root}/vendor/files_report.csv")
+    end
+  end
+
+  describe '#create_report' do
+    let(:fake_files) { [
+      FakeFile.new('id', 'title', 'label', 'file.pdf', 'foo@bar.org', 'foo@bar.org', ['foo@bar.org', 'foo@bar.org']),
+      FakeFile.new('id', 'title', 'label', 'file.pdf', 'foo@bar.org', 'foo@bar.org', ['']),
+      FakeFile.new('id', 'title', 'label', 'file.pdf', 'foo@bar.org', 'foo@bar.org', ['foo@bar.org']),
+      FakeFile.new('id', 'title', 'label', 'file.pdf', 'foo@bar.org', 'foo@bar.org', ['foo@bar.org', 'foo@bar.org'])
+    ] }
+
+    before do
+      FileSet.stub(:all).and_return(fake_files)
+
+      File.delete(described_class.report_location) if File.exist?(described_class.report_location)
+    end
+
+    it 'creates a report in the report_location' do
+      described_class.create_report
+      expect(File).to exist(described_class.report_location)
+    end
+
+    it 'creates a report one line longer than the number of objects reported on' do
+      described_class.create_report
+      expect(
+        File.open(described_class.report_location).readlines.size
+      ).to eq(fake_files.length + 1)
+    end
+
+    class FakeFile < Struct.new(:id, :title, :label, :filename, :creator, :depositor, :edit_users)
+    end
+  end
+end

--- a/spec/services/hyrax/analytics_spec.rb
+++ b/spec/services/hyrax/analytics_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'rails_helper'
+RSpec.describe Hyrax::Analytics::Config do
+  subject { described_class }
+  let!(:response) { described_class.load_from_yaml }
+  it 'defines analytics variables' do
+    expect(response.app_name).to eq("GOOGLE_OAUTH_APP_NAME")
+    expect(response.app_version).to eq("GOOGLE_OAUTH_APP_VERSION")
+    expect(response.privkey_path).to eq("analytics_privkey_path")
+    expect(response.privkey_secret).to eq("analytics_privkey_secret")
+    expect(response.client_email).to eq("analytics_client_email")
+  end
+end

--- a/spec/services/users_report_spec.rb
+++ b/spec/services/users_report_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe UsersReport do
+  describe '#report_location' do
+    it 'is vendor/users_report.csv' do
+      expect(described_class.report_location).to eq("#{Rails.root}/vendor/users_report.csv")
+    end
+  end
+
+  describe '#create_report' do
+    let(:fake_users) { [
+      FakeUser.new('id1', 'foo@bar.com', 'Foo Bar', 'Foo', 'Bar'),
+      FakeUser.new('id1', 'foo@bar.com', 'Foo Bar', 'Foo', 'Bar'),
+      FakeUser.new('id1', 'foo@bar.com', 'Foo Bar', 'Foo', 'Bar'),
+      FakeUser.new('id1', 'foo@bar.com', 'Foo Bar', 'Foo', 'Bar')
+    ] }
+
+    before do
+      User.stub(:all).and_return(fake_users)
+
+      File.delete(described_class.report_location) if File.exist?(described_class.report_location)
+    end
+
+    it 'creates a report in the report_location' do
+      described_class.create_report
+      expect(File).to exist(described_class.report_location)
+    end
+
+    it 'creates a report one line longer than the number of objects reported on' do
+      described_class.create_report
+      expect(
+        File.open(described_class.report_location).readlines.size
+      ).to eq(fake_users.length + 1)
+    end
+
+    class FakeUser < Struct.new(:id, :email, :name, :first_name, :last_name)
+    end
+  end
+end

--- a/spec/services/works_report_spec.rb
+++ b/spec/services/works_report_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe WorksReport do
+  describe '#report_location' do
+    it 'is vendor/work_report.csv' do
+      expect(described_class.report_location).to eq("#{Rails.root}/vendor/works_report.csv")
+    end
+  end
+
+  describe '#create_report' do
+    let(:fake_articles) {
+      [
+        FakeWork.new('1234', 'Title', 'foo@bar.org', 'foo@bar.org', ['pid', 'pid'], ['foo@bar.org']),
+        FakeWork.new('1234', 'Title', 'foo@bar.org', 'foo@bar.org', ['pid'], ['foo@bar.org'])
+      ]
+    }
+    let(:fake_generic_works) { [] }
+    let(:fake_images) {
+      [
+        FakeWork.new('1234', 'Title', 'foo@bar.org', 'foo@bar.org', ['pid', 'pid'], ['foo@bar.org']),
+        FakeWork.new('1234', 'Title', 'foo@bar.org', 'foo@bar.org', [''], ['foo@bar.org'])
+      ]
+    }
+    let(:fake_datasets) {
+      [
+        FakeWork.new('1234', 'Title', 'foo@bar.org', 'foo@bar.org', ['pid', 'pid'], ['foo@bar.org', 'foo@bar.org'])
+      ]
+    }
+    let(:fake_documents) { [] }
+
+    before do
+      Article.stub(:all).and_return(fake_articles)
+      GenericWork.stub(:all).and_return(fake_generic_works)
+      Image.stub(:all).and_return(fake_images)
+      Dataset.stub(:all).and_return(fake_datasets)
+      Document.stub(:all).and_return(fake_documents)
+
+      File.delete(described_class.report_location) if File.exist?(described_class.report_location)
+    end
+
+    it 'creates a report in the report_location' do
+      described_class.create_report
+      expect(File).to exist(described_class.report_location)
+    end
+
+    it 'creates a report one line longer than the number of objects reported on' do
+      described_class.create_report
+      expect(
+        File.open(described_class.report_location).readlines.size
+      ).to eq(
+        (fake_articles + fake_generic_works + fake_images + fake_datasets + fake_documents).length + 1
+      )
+    end
+
+    class FakeWork < Struct.new(:id, :title, :owner, :depositor, :editor_ids, :edit_users)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #551 ;

There were a couple of tests that needed to be ported over from scholar, and a new test needed to be added to test the analytics configuration.

This pull request brings us up to 96.69% coverage.  The next least covered file has 15 un-hit lines, almost all of which are lines adding to our logging files or catching errors and then logging.  Adding tests for those logging statements would bring us above 97%, however prevailing wisdom seems to be against testing logging statements.