### PR TITLE
Define timezone to fix embargo spec failures

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,6 @@ module ScholarUc
     config.eager_load_paths << Rails.root.join('lib')
     # REMOVE_ME: Temporarily remove strong params
     # config.action_controller.permit_all_parameters = true
+    config.time_zone = "Eastern Time (US & Canada)"
   end
 end


### PR DESCRIPTION
Fixes #655

This fix defines the current timezone as Eastern Time (US & Canada), so that the embargo specs don't fail after 7:00 PM (Due to UTC conversion). When testing locally, I only had 2 specs fail
`rspec ./spec/features/hyrax/embargo_spec.rb:79`
`rspec ./spec/features/hyrax/embargo_spec.rb:15`

I don't know if the other specs are fixed by this, or there needs to be other fixes implemented