### PR TITLE
#671 - Update Shibboleth attributes on every login.

### DIFF
--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -34,6 +34,7 @@ class CallbacksController < Devise::OmniauthCallbacksController
     end
 
     def sign_in_shibboleth_user
+      update_user_shibboleth_perishable_attributes
       sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
       cookies[:login_type] = {
         value: "shibboleth",
@@ -87,6 +88,13 @@ class CallbacksController < Devise::OmniauthCallbacksController
       @user.telephone          = @omni.extra.raw_info.telephoneNumber
       @user.first_name         = @omni.extra.raw_info.givenName
       @user.last_name          = @omni.extra.raw_info.sn
+      @user.uc_affiliation     = @omni.extra.raw_info.uceduPrimaryAffiliation
+      @user.ucdepartment       = @omni.extra.raw_info.ou
+      @user.save
+    end
+
+    def update_user_shibboleth_perishable_attributes
+      retrieve_shibboleth_attributes
       @user.uc_affiliation     = @omni.extra.raw_info.uceduPrimaryAffiliation
       @user.ucdepartment       = @omni.extra.raw_info.ou
       @user.save

--- a/spec/controllers/callbacks_controller_spec.rb
+++ b/spec/controllers/callbacks_controller_spec.rb
@@ -150,5 +150,30 @@ describe CallbacksController do
 
       it_behaves_like 'Shibboleth login'
     end
+
+    context 'with a registered user who has previously logged in and has updated shibboleth data' do
+      before do
+        omniauth_hash = { provider: 'shibboleth',
+                          uid: uid,
+                          extra: {
+                            raw_info: {
+                              uceduPrimaryAffiliation: 'Second Affiliation',
+                              ou: 'Second Department'
+                            }
+                          } }
+        OmniAuth.config.add_mock(provider, omniauth_hash)
+        request.env["omniauth.auth"] = OmniAuth.config.mock_auth[provider]
+      end
+
+      let!(:user) { FactoryBot.create(:shibboleth_user, count: 0, uc_affiliation: "First Affiliation", ucdepartment: "First Department") }
+      let!(:email) { user.email }
+
+      it 'has the correct metadata' do
+        get provider
+        user = User.find(1)
+        expect(user["uc_affiliation"]).to eq "Second Affiliation"
+        expect(user["ucdepartment"]).to eq "Second Department"
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #671  ;

Added a method to our callbacks controller that updates a users affiliation and department on each Shibboleth login.

Changes proposed in this pull request:
* Update Shibboleth attributes.
