### PR TITLE
Implement changes to static page line lengths

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,35 +1,39 @@
-<h2>Local Account Log in</h2>
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2">
+    <h2>Local Account Log in</h2>
 
-<% if AUTH_CONFIG['shibboleth_enabled'] %>
-  <p>Note: If you are affiliated with UC, use the <%= link_to 'Central Login form', user_shibboleth_omniauth_authorize_path %> instead.</p>
-<% end %>
+    <% if AUTH_CONFIG['shibboleth_enabled'] %>
+      <p>Note: If you are affiliated with UC, use the <%= link_to 'Central Login form', user_shibboleth_omniauth_authorize_path %> instead.</p>
+    <% end %>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true %>
+      </div>
+
+      <div class="field">
+        <%= f.label :password %><br />
+        <%= f.password_field :password, autocomplete: "off" %>
+      </div>
+
+      <% if devise_mapping.rememberable? -%>
+        <div class="field">
+          <%= f.check_box :remember_me %>
+          <%= f.label :remember_me %>
+        </div>
+      <% end -%>
+
+      <div class="actions">
+        <p><%= f.submit "Log in" %></p>
+      </div>
+    <% end %>
+
+    <% if AUTH_CONFIG['signups_enabled'] %>
+      <%= link_to 'Sign up', new_user_registration_path %>
+    <br />
+    <% end %>
+
+    <p><%= link_to 'Reset/Forgot your password?', new_user_password_path %></a></p>
   </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
-
-  <% if devise_mapping.rememberable? -%>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end -%>
-
-  <div class="actions">
-    <p><%= f.submit "Log in" %></p>
-  </div>
-<% end %>
-
-<% if AUTH_CONFIG['signups_enabled'] %>
-  <%= link_to 'Sign up', new_user_registration_path %>
-<br />
-<% end %>
-
-<p><%= link_to 'Reset/Forgot your password?', new_user_password_path %></a></p>
+</div>

--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -1,9 +1,12 @@
 <% content_for :page_title, "About // #{application_name}" %>
+<div class="row">
+    <div class="col-lg-8 col-lg-offset-2">
+        <h2>What is <%=t('hyrax.product_name') %>?</h2>
 
-<h2>What is <%=t('hyrax.product_name') %>?</h2>
+        <%= render :partial => 'about_text' %>
 
-<%= render :partial => 'about_text' %>
+        <p><%= link_to("Terms of Use", hyrax.terms_path) %></p>
 
-<p><%= link_to("Terms of Use", hyrax.terms_path) %></p>
-
-<p><%= link_to("Collection Policy", coll_policy_path) %></p>
+        <p><%= link_to("Collection Policy", coll_policy_path) %></p>
+    </div>
+</div>

--- a/app/views/static/advisor_guidelines.html.erb
+++ b/app/views/static/advisor_guidelines.html.erb
@@ -1,25 +1,28 @@
 <% content_for :page_title, "Advisor Guidelines // #{application_name}" %>
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2">
+    <h2>Student Self Submissions to <%=t('hyrax.product_name') %></h2>
+    <h2>Guidelines for Faculty Advisors</h2>
 
-<h2>Student Self Submissions to <%=t('hyrax.product_name') %></h2>
-<h2>Guidelines for Faculty Advisors</h2>
+    <p>
+      Works that are deposited in <%=t('hyrax.product_name') %> should be related to scholarship and research and be consistent with the <%=t('hyrax.product_name') %> <%= link_to "Mission and Collection Policy", coll_policy_path %>. Students should work with a faculty advisor to share scholarly output and creative works, such a capstone projects. <b>All official theses and dissertations must be submitted directly to the Graduate School and not <%=t('hyrax.product_name') %></b>. If you are a faculty advisor for a student submitting a work to <%=t('hyrax.product_name') %>, these guidelines are for you.
 
-<p>
-  Works that are deposited in <%=t('hyrax.product_name') %> should be related to scholarship and research and be consistent with the <%=t('hyrax.product_name') %> <%= link_to "Mission and Collection Policy", coll_policy_path %>. Students should work with a faculty advisor to share scholarly output and creative works, such a capstone projects. <b>All official theses and dissertations must be submitted directly to the Graduate School and not <%=t('hyrax.product_name') %></b>. If you are a faculty advisor for a student submitting a work to <%=t('hyrax.product_name') %>, these guidelines are for you.
+      Student and faculty advisors log-on to <%=t('hyrax.product_name') %> using their central log-on credentials (6+2). If logging on the first time, you will see a Welcome page.
+    </p>
 
-  Student and faculty advisors log-on to <%=t('hyrax.product_name') %> using their central log-on credentials (6+2). If logging on the first time, you will see a Welcome page.
-</p>
-
-<ol>
-  <li>Students are required to choose a faculty advisor or sponsor for their work. (See <b><%= link_to "Instructions for Student Self Submissions", student_instructions_path %></b>.) Advisors should be made a content editor on the work. Additionally, students should notify their advisor that the work has been submitted.</li></br>
-  <li>Please provide instructions to students that cover topics such as the name of the degree program, so that the submissions will be consistent. Please see the <b><%= link_to "Instructions for Student Self Submissions", student_instructions_path %></b> to review the required fields and provide advice and instructions to student submitters about the input form.</li></br>
-  <li>It is useful for the access rights (Open Access, Open Access with Embargo, University of Cincinnati only) and license (Creative Commons or All Rights Reserved) to be discussed and agreed upon by the student and their advisor.
-    <ul></br>
-      <li>You may want to request that students set the access rights to private so that you can review it before it is made public. In that case, change the status to public once the review is complete. This is not mandatory, but may be a recommended workflow for any student work required for course completion.</li>
-      <li>Students should use the license wizard to select a license for their work. This license is a legal statement about how others may use their work.</li>
-      <li>Students will have to agree to a <%= link_to t('hyrax.deposit_agreement'), '/distribution_license_request' %> which grants University of Cincinnati the right to preserve, backup, and add metadata to their work. It also attests that the student has the necessary legal authority to submit the work and make it available. Students will retain full copyright of their work.</li>
-      <li>As a content editor, you can make changes to the work and to the attached content, including replacing a file with a different version or removing the work – but in this case the student submitter should be informed. Once you have reviewed the submission, make any necessary changes to the access rights, such as changing from private to open access.</li>
-    </ul></br>
-  </li>
-  <li>You can add a Digital Object Identifier (DOI) to the work if the student author has not already done so, but inform the student when you do. A DOI is intended to reference stable content and is a permanent URL that you may share and use in publications.</li></br>
-  <li>For some works, once a review is complete, you may wish to remove a student submitter's editing rights, so that they cannot make changes to the work or delete the work. (This may be the case with capstone projects or other degree requirements.) For other works, it may be fine to leave the student as the editor of the work. Contact <%= link_to t('hyrax.product_name'), hyrax.contact_path %> if a change to editing rights is required as a last step in project workflow. Once the student graduates or is no longer associated with UC, they will lose access to the work record. If the work's access rights have been set to open access, they will still be able to view the work. If the faculty advisor has been made a content editor, they can still edit the work. If both the student and advisor are no longer associated with UC and edits are necessary, please contact <%= link_to t('hyrax.product_name'), hyrax.contact_path %>.</li>
-</ol>
+    <ol>
+      <li>Students are required to choose a faculty advisor or sponsor for their work. (See <b><%= link_to "Instructions for Student Self Submissions", student_instructions_path %></b>.) Advisors should be made a content editor on the work. Additionally, students should notify their advisor that the work has been submitted.</li></br>
+      <li>Please provide instructions to students that cover topics such as the name of the degree program, so that the submissions will be consistent. Please see the <b><%= link_to "Instructions for Student Self Submissions", student_instructions_path %></b> to review the required fields and provide advice and instructions to student submitters about the input form.</li></br>
+      <li>It is useful for the access rights (Open Access, Open Access with Embargo, University of Cincinnati only) and license (Creative Commons or All Rights Reserved) to be discussed and agreed upon by the student and their advisor.
+        <ul></br>
+          <li>You may want to request that students set the access rights to private so that you can review it before it is made public. In that case, change the status to public once the review is complete. This is not mandatory, but may be a recommended workflow for any student work required for course completion.</li>
+          <li>Students should use the license wizard to select a license for their work. This license is a legal statement about how others may use their work.</li>
+          <li>Students will have to agree to a <%= link_to t('hyrax.deposit_agreement'), '/distribution_license_request' %> which grants University of Cincinnati the right to preserve, backup, and add metadata to their work. It also attests that the student has the necessary legal authority to submit the work and make it available. Students will retain full copyright of their work.</li>
+          <li>As a content editor, you can make changes to the work and to the attached content, including replacing a file with a different version or removing the work – but in this case the student submitter should be informed. Once you have reviewed the submission, make any necessary changes to the access rights, such as changing from private to open access.</li>
+        </ul></br>
+      </li>
+      <li>You can add a Digital Object Identifier (DOI) to the work if the student author has not already done so, but inform the student when you do. A DOI is intended to reference stable content and is a permanent URL that you may share and use in publications.</li></br>
+      <li>For some works, once a review is complete, you may wish to remove a student submitter's editing rights, so that they cannot make changes to the work or delete the work. (This may be the case with capstone projects or other degree requirements.) For other works, it may be fine to leave the student as the editor of the work. Contact <%= link_to t('hyrax.product_name'), hyrax.contact_path %> if a change to editing rights is required as a last step in project workflow. Once the student graduates or is no longer associated with UC, they will lose access to the work record. If the work's access rights have been set to open access, they will still be able to view the work. If the faculty advisor has been made a content editor, they can still edit the work. If both the student and advisor are no longer associated with UC and edits are necessary, please contact <%= link_to t('hyrax.product_name'), hyrax.contact_path %>.</li>
+    </ol>
+  </div>
+</div>

--- a/app/views/static/coll_policy.html.erb
+++ b/app/views/static/coll_policy.html.erb
@@ -1,35 +1,38 @@
 <% content_for :page_title, "Collection Policy // #{application_name}" %>
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2">
+    <h2>Collection Policy</h2>
 
-<h2>Collection Policy</h2>
 
+    <h3>Mission</h3>
+    <p>
+      The mission of <%=t('hyrax.product_name') %> is to preserve the intellectual output of UC, to advance discovery and innovation, to foster scholarship and learning through the transformation of data into knowledge, to collect a corpus of works that can be used for teaching and to inspire derivative works, and to enhance discoverability and access to these resources.
+    </p>
 
-<h3>Mission</h3>
-<p>
-  The mission of <%=t('hyrax.product_name') %> is to preserve the intellectual output of UC, to advance discovery and innovation, to foster scholarship and learning through the transformation of data into knowledge, to collect a corpus of works that can be used for teaching and to inspire derivative works, and to enhance discoverability and access to these resources.
-</p>
+    <h3>Content</h3>
+    <p>
+      <%=t('hyrax.product_name') %> was developed to store and share the scholarly output and creative works of UC faculty (current and emeritus), staff, and students. Original research outputs and creative works of the University community will be preserved and made available. Works that are deposited in <%=t('hyrax.product_name') %> should support the mission of the University of Cincinnati. Students should work with a faculty member to share scholarly output and creative works, such a capstone projects. Those interested in depositing UC records should contact <a href="http://www.libraries.uc.edu/arb/records-management.html">Records Management</a>.
+    </p>
 
-<h3>Content</h3>
-<p>
-  <%=t('hyrax.product_name') %> was developed to store and share the scholarly output and creative works of UC faculty (current and emeritus), staff, and students. Original research outputs and creative works of the University community will be preserved and made available. Works that are deposited in <%=t('hyrax.product_name') %> should support the mission of the University of Cincinnati. Students should work with a faculty member to share scholarly output and creative works, such a capstone projects. Those interested in depositing UC records should contact <a href="http://www.libraries.uc.edu/arb/records-management.html">Records Management</a>.
-</p>
+    <p>
+      Examples of appropriate content include, but are not limited to: <a href="https://en.wikipedia.org/wiki/Grey_literature">grey literature</a>; <a href="https://en.wikipedia.org/wiki/Preprint">pre-</a>, <a href="https://en.wikipedia.org/wiki/Postprint">post-</a>, and published versions of academic papers, manuscripts, senior design projects, theses and dissertations (mediated by the Graduate School), posters, datasets, presentations, and other creative works. Content may be text, image, video, audio, or mixed-media in nature.
+    </p>
 
-<p>
-  Examples of appropriate content include, but are not limited to: <a href="https://en.wikipedia.org/wiki/Grey_literature">grey literature</a>; <a href="https://en.wikipedia.org/wiki/Preprint">pre-</a>, <a href="https://en.wikipedia.org/wiki/Postprint">post-</a>, and published versions of academic papers, manuscripts, senior design projects, theses and dissertations (mediated by the Graduate School), posters, datasets, presentations, and other creative works. Content may be text, image, video, audio, or mixed-media in nature.
-</p>
+    <p>
+      <strong>Content classified as restricted by <a href="https://www.uc.edu/content/dam/uc/infosec/docs/policies/Data_Governance_and_Classification_Policy_9.1.1.pdf">University of Cincinnati Policy 9.1.1 (Data Protection Policy)</a> or by export control should never be deposited to <%=t('hyrax.product_name') %>.</strong>
+    </p>
 
-<p>
-  <strong>Content classified as restricted by <a href="https://www.uc.edu/content/dam/uc/infosec/docs/policies/Data_Governance_and_Classification_Policy_9.1.1.pdf">University of Cincinnati Policy 9.1.1 (Data Protection Policy)</a> or by export control should never be deposited to <%=t('hyrax.product_name') %>.</strong>
-</p>
+    <h3>Intellectual Property, Copyright, and Access</h3>
+    <p>
+      In order to submit content to <%=t('hyrax.product_name') %>, creators must agree to a <%= link_to t('hyrax.deposit_agreement'), '/distribution_license_request' %> that authorizes UC to preserve, to transform, to enhance metadata, and to make available their content. Creators may choose, though are not required, to issue their content with a <a href="https://creativecommons.org/about">Creative Commons license</a> that clearly indicates how their content may be reused. Creators may choose to issue content as public domain or all rights reserved.
+    </p>
 
-<h3>Intellectual Property, Copyright, and Access</h3>
-<p>
-  In order to submit content to <%=t('hyrax.product_name') %>, creators must agree to a <%= link_to t('hyrax.deposit_agreement'), '/distribution_license_request' %> that authorizes UC to preserve, to transform, to enhance metadata, and to make available their content. Creators may choose, though are not required, to issue their content with a <a href="https://creativecommons.org/about">Creative Commons license</a> that clearly indicates how their content may be reused. Creators may choose to issue content as public domain or all rights reserved.
-</p>
+    <p>
+      Creators are able to control access to their content. Creators may choose to make content visible to themselves only, to a group of predetermined individuals, to embargo content for a defined time period, or to make their content open access.
+    </p>
 
-<p>
-  Creators are able to control access to their content. Creators may choose to make content visible to themselves only, to a group of predetermined individuals, to embargo content for a defined time period, or to make their content open access.
-</p>
-
-<h3>Withdrawal</h3>
-  <p><%=t('hyrax.product_name') %> is intended to permanently preserve the intellectual output of UC. However, creators retain the right to delete their content at any time. If deleted content included a Digital Object Identifier (DOI), a record of the last known metadata (tombstone) may be displayed to users attempting to access the content through the DOI.
-</p>
+    <h3>Withdrawal</h3>
+      <p><%=t('hyrax.product_name') %> is intended to permanently preserve the intellectual output of UC. However, creators retain the right to delete their content at any time. If deleted content included a Digital Object Identifier (DOI), a record of the last known metadata (tombstone) may be displayed to users attempting to access the content through the DOI.
+    </p>
+  </div>
+</div>

--- a/app/views/static/creators_rights.html.erb
+++ b/app/views/static/creators_rights.html.erb
@@ -1,85 +1,88 @@
 <% content_for :page_title, "Creator's Rights // #{application_name}" %>
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2">
+    <h2>Creator&#39s Rights</h2>
 
-<h2>Creator&#39s Rights</h2>
+    <p>
+      Contributing to <%= link_to t('hyrax.product_name'), root_path %> may raise questions about what rights you may hold as the creator of a work.
 
-<p>
-  Contributing to <%= link_to t('hyrax.product_name'), root_path %> may raise questions about what rights you may hold as the creator of a work.
+      First and foremost, you are the creator of your work and you are in control of its copyright.  This is your
+      right; in no way does contributing to <%= link_to t('hyrax.product_name'), root_path %></a> limit your ability to
+      claim or enforce copyright on your work.  However, you may have entered into publishing agreements that
+      restrict you from sharing your work, especially if you agreed to relinquish or transfer your copyright as part of an author agreement.
+    </p>
 
-  First and foremost, you are the creator of your work and you are in control of its copyright.  This is your
-  right; in no way does contributing to <%= link_to t('hyrax.product_name'), root_path %></a> limit your ability to
-  claim or enforce copyright on your work.  However, you may have entered into publishing agreements that
-  restrict you from sharing your work, especially if you agreed to relinquish or transfer your copyright as part of an author agreement.
-</p>
+    <p>
+      <a href="http://www.sparc.arl.org" target="_blank">The Scholarly Publishing and Academic Resources
+        Coalition</a> has created useful guidelines to help you navigate through the legalese of scholarly
+      communications.  We encourage you to visit this website for a fuller understanding and to take a look at the
+      <a href="http://www.sparc.arl.org/resources/authors/addendum-2007" target="_blank">author addendum</a>,
+      &#34a legal instrument that modifies the publisher’s agreement and allows you to keep key rights to your articles.&#34
+      Adding an author addendum to your authorship agreements grants you rights you may otherwise lose under a standard agreement.
+    </p>
 
-<p>
-  <a href="http://www.sparc.arl.org" target="_blank">The Scholarly Publishing and Academic Resources
-    Coalition</a> has created useful guidelines to help you navigate through the legalese of scholarly
-  communications.  We encourage you to visit this website for a fuller understanding and to take a look at the
-  <a href="http://www.sparc.arl.org/resources/authors/addendum-2007" target="_blank">author addendum</a>,
-  &#34a legal instrument that modifies the publisher’s agreement and allows you to keep key rights to your articles.&#34
-  Adding an author addendum to your authorship agreements grants you rights you may otherwise lose under a standard agreement.
-</p>
+    <p>
+      Another resource that may be useful is the <a href="http://www.sherpa.ac.uk/romeo/" target="_blank">SHERPA/RoMEO</a> resource from the University of Nottingham.
+      This resource is a database of academic publishers and their standard terms. If you signed a standard
+      publishing agreement with one of these companies, this resource will help you determine what rights you have
+      under that agreement.  For example, it may help you determine whether it is okay to archive, or submit to
+      <%= link_to t('hyrax.product_name'), root_path %></a> a pre-print, post-print, publisher’s version, or other version.
+    </p>
 
-<p>
-  Another resource that may be useful is the <a href="http://www.sherpa.ac.uk/romeo/" target="_blank">SHERPA/RoMEO</a> resource from the University of Nottingham.
-  This resource is a database of academic publishers and their standard terms. If you signed a standard
-  publishing agreement with one of these companies, this resource will help you determine what rights you have
-  under that agreement.  For example, it may help you determine whether it is okay to archive, or submit to
-  <%= link_to t('hyrax.product_name'), root_path %></a> a pre-print, post-print, publisher’s version, or other version.
-</p>
+    <p>
+      For future scholarly works, consider seeking out an open access journal.  These are journals that are more
+      generous with ensuring authors retain their intellectual property rights.  A typical OA journal may request
+      right of first publication, but assures that the author retains copyright, and may allow authors to add pre-
+      and post-prints of articles to institutional or subject repositories.
+    </p>
 
-<p>
-  For future scholarly works, consider seeking out an open access journal.  These are journals that are more
-  generous with ensuring authors retain their intellectual property rights.  A typical OA journal may request
-  right of first publication, but assures that the author retains copyright, and may allow authors to add pre-
-  and post-prints of articles to institutional or subject repositories.
-</p>
+    <div class="well">
+      <h3>Taking Back Control: Managing Copyright and Intellectual Property</h3>
 
-<div class="well">
-  <h3>Taking Back Control: Managing Copyright and Intellectual Property</h3>
+      <strong>How does copyright affect me?</strong><br/>
+      As the author of an article published in a scholarly journal, you may be asked to sign away your copyrights, in full or in part, to the publisher as a condition of publication. When you transfer copyright you:
+      <ul>
+        <li>
+          lose the right to post copies of your own work on your own website without permission of the publisher.
+        </li>
+        <li>
+          you cannot legally make copies of your own work for distribution to students or colleagues.
+        </li>
+      </ul>
 
-  <strong>How does copyright affect me?</strong><br/>
-  As the author of an article published in a scholarly journal, you may be asked to sign away your copyrights, in full or in part, to the publisher as a condition of publication. When you transfer copyright you:
-  <ul>
-    <li>
-      lose the right to post copies of your own work on your own website without permission of the publisher.
-    </li>
-    <li>
-      you cannot legally make copies of your own work for distribution to students or colleagues.
-    </li>
-  </ul>
+      <p>
+          <strong>How does copyright affect my publisher?</strong><br/>
+          When you surrender your copyright you also surrender control of your work. You give up your scholarly
+        output to publishers for free and the publishers, in turn, sell your intellectual property back to our
+        institutions for increasingly unreasonable subscription rates. This business model has made science,
+        technology and medicine (STM) publishing a highly profitable sector of the publishing industry.
+      </p>
 
-  <p>
-      <strong>How does copyright affect my publisher?</strong><br/>
-      When you surrender your copyright you also surrender control of your work. You give up your scholarly
-    output to publishers for free and the publishers, in turn, sell your intellectual property back to our
-    institutions for increasingly unreasonable subscription rates. This business model has made science,
-    technology and medicine (STM) publishing a highly profitable sector of the publishing industry.
-  </p>
+      <p>
+          <strong>What is copyright?</strong><br/>
+          Copyright gives the author or creator of an original work, exclusive control of how that work is
+        reproduced, distributed or performed. When you transfer copyright, you no longer have control of how your work is distributed.
+      </p>
 
-  <p>
-      <strong>What is copyright?</strong><br/>
-      Copyright gives the author or creator of an original work, exclusive control of how that work is
-    reproduced, distributed or performed. When you transfer copyright, you no longer have control of how your work is distributed.
-  </p>
+      <p>
+        <strong>Why would an individual relinquish copyright to a corporation?</strong><br/>
+        One reason for surrendering copyright is that corporations may have better capabilities for marketing and
+        distribution of that work. In the recording industry, for example, an artist might transfer copyright to
+        the record label in exchange for royalties.  The record label, in turn, would then ensure that the
+        recording is marketed and distributed widely in order to maximize the artist’s royalties.
+      </p>
+      <p>
+        <strong>Why should I retain copyright?</strong><br/>
+          By retaining copyright for articles you submit to commercial or society publishers, you are taking back
+        control of your own scholarly output. When you own the copyright of your own work, you have the freedom to
+        disseminate your work as you please whether this means posting a copy of your article on your own website,
+        distributing copies to students and colleagues or posting it to a repository [such as <%= link_to t('hyrax.product_name'), root_path %></a>].
+        Widespread dissemination of your work, in turn, means that your work can be read by more people and thus has greater potential impact.
+      </p>
 
-  <p>
-    <strong>Why would an individual relinquish copyright to a corporation?</strong><br/>
-    One reason for surrendering copyright is that corporations may have better capabilities for marketing and
-    distribution of that work. In the recording industry, for example, an artist might transfer copyright to
-    the record label in exchange for royalties.  The record label, in turn, would then ensure that the
-    recording is marketed and distributed widely in order to maximize the artist’s royalties.
-  </p>
-  <p>
-    <strong>Why should I retain copyright?</strong><br/>
-      By retaining copyright for articles you submit to commercial or society publishers, you are taking back
-    control of your own scholarly output. When you own the copyright of your own work, you have the freedom to
-    disseminate your work as you please whether this means posting a copy of your article on your own website,
-    distributing copies to students and colleagues or posting it to a repository [such as <%= link_to t('hyrax.product_name'), root_path %></a>].
-    Widespread dissemination of your work, in turn, means that your work can be read by more people and thus has greater potential impact.
-  </p>
-
-  <small>Source: “Take Back Control: Managing Copyright and Intellectual Property.” 2005. Accessed February 12,
-               2015. <a href="http://www.lib.berkeley.edu/scholarlypublishing/copyright.pdf" target="_blank">http://www.lib
-    .berkeley.edu/scholarlypublishing/copyright.pdf</a></small>
+      <small>Source: “Take Back Control: Managing Copyright and Intellectual Property.” 2005. Accessed February 12,
+                  2015. <a href="http://www.lib.berkeley.edu/scholarlypublishing/copyright.pdf" target="_blank">http://www.lib
+        .berkeley.edu/scholarlypublishing/copyright.pdf</a></small>
+    </div>
+  </div>
 </div>

--- a/app/views/static/documenting_data_help.html.erb
+++ b/app/views/static/documenting_data_help.html.erb
@@ -1,47 +1,50 @@
 <% content_for :page_title, "Documenting Data // #{application_name}" %>
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2">
+    <h2>Documenting Data</h2>
 
-<h2>Documenting Data</h2>
+    <blockquote>
+      “Data without context are inert, but data within contexts become information, knowledge.”
+      <br>
+      From: Changing the Subject: Art and Attention in the Internet Age By Sven Birkerts
+    </blockquote>
 
-<blockquote>
-  “Data without context are inert, but data within contexts become information, knowledge.”
-  <br>
-  From: Changing the Subject: Art and Attention in the Internet Age By Sven Birkerts
-</blockquote>
+    <p>
+      Proper documentation provides the context that your data needs to persist through time, to integrate into new systems and to give you credit for your contributions in the form of data citations. Where possible, you should contribute the following information along with your dataset:
+    </p>
 
-<p>
-  Proper documentation provides the context that your data needs to persist through time, to integrate into new systems and to give you credit for your contributions in the form of data citations. Where possible, you should contribute the following information along with your dataset:
-</p>
+    <ol type="1">
+      <li><b>Complete Metadata</b> - Metadata aids Discovery and Reuse. <%=t('hyrax.product_name') %> requires metadata such as title of work, creator name, data submitted and description. All text is searchable. You should write a detailed description to increase discoverability of your content. Also provided are additional metadata fields under the Show Additional Description link. Here you can add in additional fields such as subject terms for search enhancement. If you are following a suggested schema for your discipline, indicate that in the description or in the next document – the README file. </li>
+      <br>
 
-<ol type="1">
-  <li><b>Complete Metadata</b> - Metadata aids Discovery and Reuse. <%=t('hyrax.product_name') %> requires metadata such as title of work, creator name, data submitted and description. All text is searchable. You should write a detailed description to increase discoverability of your content. Also provided are additional metadata fields under the Show Additional Description link. Here you can add in additional fields such as subject terms for search enhancement. If you are following a suggested schema for your discipline, indicate that in the description or in the next document – the README file. </li>
-  <br>
+      <li><b>README.txt File</b> - This is a text document that provides relevant information such as purpose of the project and the organizational structure or relationship of the files. It explains terms that are unique to the dataset, keywords, omissions and errors. If you are using a file naming convention, you can explain it in the readme file. It is also the place to put additional details that were not included in the metadata, such as additional information about external storage of the data, metadata schema followed and researcher contact information.     <br><br>
 
-  <li><b>README.txt File</b> - This is a text document that provides relevant information such as purpose of the project and the organizational structure or relationship of the files. It explains terms that are unique to the dataset, keywords, omissions and errors. If you are using a file naming convention, you can explain it in the readme file. It is also the place to put additional details that were not included in the metadata, such as additional information about external storage of the data, metadata schema followed and researcher contact information.     <br><br>
+      A good example can be found in the <a href="http://dataabinitio.com/?p=378" target="_blank">Data ab Initio blog post README.txt by Kristin Briney</a></li>
+      <br>
 
-  A good example can be found in the <a href="http://dataabinitio.com/?p=378" target="_blank">Data ab Initio blog post README.txt by Kristin Briney</a></li>
-  <br>
+      <li><b>Data Dictionary/Codebook</b> - This document explains all the variables and abbreviations associated with the dataset.
+      <br><br>
 
-  <li><b>Data Dictionary/Codebook</b> - This document explains all the variables and abbreviations associated with the dataset.
-  <br><br>
+      Here are links to example data dictionaries from The University of Texas at Austin's Population Research Center (<a href="http://www.utexas.edu/cola/redcap/Project-Examples.php" target="_blank">data dictionary examples</a>) and IRSA (<a href="http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/dd_tbl.html" target="_blank">data dictionary example</a>) provide two quick examples of data dictionaries.</li>
+      <br>
 
-  Here are links to example data dictionaries from The University of Texas at Austin's Population Research Center (<a href="http://www.utexas.edu/cola/redcap/Project-Examples.php" target="_blank">data dictionary examples</a>) and IRSA (<a href="http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/dd_tbl.html" target="_blank">data dictionary example</a>) provide two quick examples of data dictionaries.</li>
-  <br>
+      <li><b>Methodology/Protocol</b> - This document details the steps taken to collect the data. If you submitted modified data instead of a raw data set, you can explain those steps in this document.</li>
+    </ol>
 
-  <li><b>Methodology/Protocol</b> - This document details the steps taken to collect the data. If you submitted modified data instead of a raw data set, you can explain those steps in this document.</li>
-</ol>
+    <h3>Additional Resources on Documentation for Data:</h3>
 
-<h3>Additional Resources on Documentation for Data:</h3>
+    <ol type="1">
+      <li><a href="http://www.icpsr.umich.edu/icpsrweb/content/deposit/guide/index.html" target="_blank">ICPSR's Guide to Social Science Data Preparation and Archiving</a></li>
+      <li><a href="https://www.dataone.org/best-practices" target="_blank">DataOne Best Practices</a></li>
+      <li><a href="http://datalib.edina.ac.uk/mantra/" target="_blank">Mantra Research Data Management Training</a></li>
+      <li><a href="http://datadryad.org/pages/faq" target="_blank">DataDryad FAQ</a></li>
+      <li><a href="http://www.dcc.ac.uk/resources/how-guides" target="_blank">Digital Curation Centre How-to Guides & Checklists</a></li>
+    </ol>
 
-<ol type="1">
-  <li><a href="http://www.icpsr.umich.edu/icpsrweb/content/deposit/guide/index.html" target="_blank">ICPSR's Guide to Social Science Data Preparation and Archiving</a></li>
-  <li><a href="https://www.dataone.org/best-practices" target="_blank">DataOne Best Practices</a></li>
-  <li><a href="http://datalib.edina.ac.uk/mantra/" target="_blank">Mantra Research Data Management Training</a></li>
-  <li><a href="http://datadryad.org/pages/faq" target="_blank">DataDryad FAQ</a></li>
-  <li><a href="http://www.dcc.ac.uk/resources/how-guides" target="_blank">Digital Curation Centre How-to Guides & Checklists</a></li>
-</ol>
+    <h3>Copyright and Data</h3>
 
-<h3>Copyright and Data</h3>
-
-<p>
-  Copyright is intended to protect creators’ rights concerning their creative works such as written works, images, video. In most cases data is considered fact and not protected by copyright. For guidance on whether your data falls under copyright, you can consult <a href="http://dataabinitio.com/?p=632" target="_blank">this blog post</a> and <a href="https://figshare.com/articles/Data_and_Copyright/3117838" target="_blank">flyer</a> by Kristen Briney.
-</p>
+    <p>
+      Copyright is intended to protect creators’ rights concerning their creative works such as written works, images, video. In most cases data is considered fact and not protected by copyright. For guidance on whether your data falls under copyright, you can consult <a href="http://dataabinitio.com/?p=632" target="_blank">this blog post</a> and <a href="https://figshare.com/articles/Data_and_Copyright/3117838" target="_blank">flyer</a> by Kristen Briney.
+    </p>
+  </div>
+</div>

--- a/app/views/static/doi_help.html.erb
+++ b/app/views/static/doi_help.html.erb
@@ -1,26 +1,29 @@
 <% content_for :page_title, "DOI Help // #{application_name}" %>
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2">
+    <h2>DOI Help</h2>
 
-<h2>DOI Help</h2>
+    <h3>I am getting an "Invalid DOI detected" error:</h3>
 
-<h3>I am getting an "Invalid DOI detected" error:</h3>
+    <p>
+      At times you may want to attach a pre-existing DOI to a work in <%=t('hyrax.product_name') %>. If you are having trouble adding
+      an existing DOI to a work in <%=t('hyrax.product_name') %>, it is most likely because of the "http://dx.doi.org/" added to your DOI
+      when copy and pasted from a web browser.
+    </p>
 
-<p>
-  At times you may want to attach a pre-existing DOI to a work in <%=t('hyrax.product_name') %>. If you are having trouble adding
-  an existing DOI to a work in <%=t('hyrax.product_name') %>, it is most likely because of the "http://dx.doi.org/" added to your DOI
-  when copy and pasted from a web browser.
-</p>
+    <p>
+      If you are trying to create a work with an existing DOI and you try to enter
+      "http://dx.doi.org<b>/doi:10.5072/FK2WD3X38W</b>". You will receive the following error:
+    </p>
 
-<p>
-  If you are trying to create a work with an existing DOI and you try to enter
-  "http://dx.doi.org<b>/doi:10.5072/FK2WD3X38W</b>". You will receive the following error:
-</p>
+    <%= image_tag('doi-help-1.png', class: 'center-block') %>
 
-<%= image_tag('doi-help-1.png', class: 'center-block') %>
+    <p>
+      However, if you were to remove the first part of the DOI URL, of the form:
+      <span class="doi-strike"><strike>http://dx.doi.org/</strike></span><span class="doi-needed"><b>doi:10.5072/FK2WD3X38W</b></span>,
+      You will see that <%=t('hyrax.product_name') %> now recognizes the DOI and work creation can proceed as normal:
+    </p>
 
-<p>
-  However, if you were to remove the first part of the DOI URL, of the form:
-  <span class="doi-strike"><strike>http://dx.doi.org/</strike></span><span class="doi-needed"><b>doi:10.5072/FK2WD3X38W</b></span>,
-  You will see that <%=t('hyrax.product_name') %> now recognizes the DOI and work creation can proceed as normal:
-</p>
-
-<%= image_tag('doi-help-2.png', class: 'center-block') %>
+    <%= image_tag('doi-help-2.png', class: 'center-block') %>
+  </div>
+</div>

--- a/app/views/static/faq.html.erb
+++ b/app/views/static/faq.html.erb
@@ -1,147 +1,150 @@
 <% content_for :page_title, "FAQ // #{application_name}" %>
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2">
+    <h2>Frequently Asked Questions</h2>
 
-<h2>Frequently Asked Questions</h2>
+    <ul>
+      <li><a href="#faq_1234">If I have a problem with the system, where do I go for assitance?</a></li>
+      <li><a href="#faq_951">How can I allow someone else to submit works on my behalf?</a></li>
+      <li><a href="#faq_5678">How can I group my works into collections of related works?</a></li>
+      <li><a href="#faq_4321">How can I share access to selected works with a group of collaborators?</a></li>
+      <li><a href="#faq_8765">How do I upload an access file? </a></li>
+      <li><a href="#faq_1346">How do I upload a preservation file? </a></li>
+      <li><a href="#faq_4679">I'm having trouble uploading a file over 200 MB; what should I do?</a></li>
+      <li><a href="#faq_7946">May I publish, contribute, or otherwise distribute my content elsewhere?</a></li>
+      <li><a href="#faq_1379">What file formats should I use when uploading to <%=t('hyrax.product_name') %>?</a></li>
+      <li><a href="#faq_7913">What happens to my works if I delete them?</a></li>
+      <li><a href="#faq_159">Where do I go if I want to consult with subject area specialists on content?</a></li>
+      <li><a href="#faq_3456">What's restricted data?</a></li>
+      <li><a href="#faq_6543">What’s the difference between delegates, editors, and groups?</a></li>
+      <li><a href="#faq_1010">How do work access rights impact my DOIs?</a></li>
 
-<ul>
-  <li><a href="#faq_1234">If I have a problem with the system, where do I go for assitance?</a></li>
-  <li><a href="#faq_951">How can I allow someone else to submit works on my behalf?</a></li>
-  <li><a href="#faq_5678">How can I group my works into collections of related works?</a></li>
-  <li><a href="#faq_4321">How can I share access to selected works with a group of collaborators?</a></li>
-  <li><a href="#faq_8765">How do I upload an access file? </a></li>
-  <li><a href="#faq_1346">How do I upload a preservation file? </a></li>
-  <li><a href="#faq_4679">I'm having trouble uploading a file over 200 MB; what should I do?</a></li>
-  <li><a href="#faq_7946">May I publish, contribute, or otherwise distribute my content elsewhere?</a></li>
-  <li><a href="#faq_1379">What file formats should I use when uploading to <%=t('hyrax.product_name') %>?</a></li>
-  <li><a href="#faq_7913">What happens to my works if I delete them?</a></li>
-  <li><a href="#faq_159">Where do I go if I want to consult with subject area specialists on content?</a></li>
-  <li><a href="#faq_3456">What's restricted data?</a></li>
-  <li><a href="#faq_6543">What’s the difference between delegates, editors, and groups?</a></li>
-  <li><a href="#faq_1010">How do work access rights impact my DOIs?</a></li>
+    </ul>
+    <p>
+      <a name="faq_1234" id="faq_1234"></a>If I have a problem with the system, where do I go for assistance? </p>
+    <blockquote>
+      Use the <%= link_to 'contact us', hyrax.contact_path %> to submit any inquiry about <%=t('hyrax.product_name') %>, including technical issues.
+    </blockquote>
+    <p><a name="faq_951" id="faq_951"></a>
+      How can I allow someone else to submit works on my behalf?
+    </p>
+    <blockquote>
+      <%=t('hyrax.product_name') %> allows you to assign delegates, who will be able to submit new works on your behalf. They will retain access to modify these works until you remove their access. If you're logged in, you can access this from the “My Delegates” link under your account name, above.
+    </blockquote>
 
-</ul>
-<p>
-  <a name="faq_1234" id="faq_1234"></a>If I have a problem with the system, where do I go for assistance? </p>
-<blockquote>
-  Use the <%= link_to 'contact us', hyrax.contact_path %> to submit any inquiry about <%=t('hyrax.product_name') %>, including technical issues.
-</blockquote>
-<p><a name="faq_951" id="faq_951"></a>
-  How can I allow someone else to submit works on my behalf?
-</p>
-<blockquote>
-  <%=t('hyrax.product_name') %> allows you to assign delegates, who will be able to submit new works on your behalf. They will retain access to modify these works until you remove their access. If you're logged in, you can access this from the “My Delegates” link under your account name, above.
-</blockquote>
+    <p><a name="faq_5678" id="faq_5678"></a>
+      How can I group my works into collections of related works?
+    </p>
+    <blockquote>
+      <%=t('hyrax.product_name') %> allows you to create collections, to which you can add any works that you or others have submitted to <%=t('hyrax.product_name') %>. You can set a custom title, description, and image for your collections.
+    </blockquote>
 
-<p><a name="faq_5678" id="faq_5678"></a>
-  How can I group my works into collections of related works?
-</p>
-<blockquote>
-  <%=t('hyrax.product_name') %> allows you to create collections, to which you can add any works that you or others have submitted to <%=t('hyrax.product_name') %>. You can set a custom title, description, and image for your collections.
-</blockquote>
-
-<p><a name="faq_4321" id="faq_4321"></a>
-  How can I share access to selected works with a group of collaborators?
-</p>
-<blockquote>
-  <%=t('hyrax.product_name') %> allows you to create groups of collaborators, which you can assign to individual works. This will give individuals in the group the ability to edit assigned works and to view restricted works of yours. You can also assign editing rights to individuals, without first placing them in groups, by designating them as editors of your work. If you're logged in, you can access this from the “My Groups” link under your account name, above.
-</blockquote>
-
-
-<p><a name="faq_8765" id="faq_8765"></a>
-  How do I upload an access file?
-</p>
-<blockquote>
-  When completing the submission form for <%=t('hyrax.product_name') %>, you may upload files. We recommend uploading your access file at the same time you are describing your work.
-  <br><br>
-  For more information, please see <%= link_to 'File Format Advice', format_advice_path %>.
-</blockquote>
-
-<p><a name="faq_1346" id="faq_1346"></a>
-  How do I upload a preservation file?
-</p>
-
-<blockquote>
-  After your work is uploaded and you are viewing the record, you will see a row of buttons towards the bottom of the page (if logged in). In the row of buttons, click <span class="fakebutton">Attach a File</span> to upload an additional file to your record. We recommend granting private access rights to preservation files. This will make it easier for users to know which they should download.
-  <br><br>
-  For more information, please see <%= link_to 'File Format Advice', format_advice_path %>.
-</blockquote>
-
-<p><a name="faq_4679" id="faq_4679"></a>
-  I'm having trouble uploading a file over 200 MB; what should I do?
-</p>
-
-<blockquote>
-  We recommend that you use the <%= link_to 'contact form', hyrax.contact_path %> for assistance with files larger than 200 MB, but if you have trouble uploading any file, please use the <%= link_to 'contact form', hyrax.contact_path %> for assistance.
-</blockquote>
+    <p><a name="faq_4321" id="faq_4321"></a>
+      How can I share access to selected works with a group of collaborators?
+    </p>
+    <blockquote>
+      <%=t('hyrax.product_name') %> allows you to create groups of collaborators, which you can assign to individual works. This will give individuals in the group the ability to edit assigned works and to view restricted works of yours. You can also assign editing rights to individuals, without first placing them in groups, by designating them as editors of your work. If you're logged in, you can access this from the “My Groups” link under your account name, above.
+    </blockquote>
 
 
-<p><a name="faq_7946" id="faq_7946"></a>
-  May I publish, contribute, or otherwise distribute my content elsewhere?
-</p>
-<blockquote>
-  Yes. When you submit content to <%=t('hyrax.product_name') %> you agree to a non-exclusive <%= link_to t('hyrax.deposit_agreement'), '/distribution_license_request' %> that grants UC the right to enhance metadata, to replicate the content for preservation, and to make the content available through computer interfaces. This license in no way prevents you from distributing your content through other channels.
-</blockquote>
+    <p><a name="faq_8765" id="faq_8765"></a>
+      How do I upload an access file?
+    </p>
+    <blockquote>
+      When completing the submission form for <%=t('hyrax.product_name') %>, you may upload files. We recommend uploading your access file at the same time you are describing your work.
+      <br><br>
+      For more information, please see <%= link_to 'File Format Advice', format_advice_path %>.
+    </blockquote>
 
-<p><a name="faq_1379" id="faq_1379"></a>
-  What file formats should I use when uploading to <%=t('hyrax.product_name') %>?
-</p>
+    <p><a name="faq_1346" id="faq_1346"></a>
+      How do I upload a preservation file?
+    </p>
 
-<blockquote>
-  File format is an important consideration when contributing your work to <%=t('hyrax.product_name') %>. The future usability of your content will depend on the file format you use. Because of this, we recommend uploading two files for each work: an access file and a preservation file.
-  <br><br>
-  An access file typically uses common formats that people are familiar with, usually compressed. It makes them easy to download and use. Examples of access formats are JPEG and MP3.
-  <br><br>
-  Preservation files should be the highest quality format available for your content, preferably uncompressed. They can be used to create new access files in the future, as formats change over time. Examples of preservation formats are TIFF and WAV. Uploading a preservation file will help guarantee your content will be easily used in the future.
-  <br><br>
-  For more information, please see <%= link_to 'File Format Advice', format_advice_path %>.
-</blockquote>
+    <blockquote>
+      After your work is uploaded and you are viewing the record, you will see a row of buttons towards the bottom of the page (if logged in). In the row of buttons, click <span class="fakebutton">Attach a File</span> to upload an additional file to your record. We recommend granting private access rights to preservation files. This will make it easier for users to know which they should download.
+      <br><br>
+      For more information, please see <%= link_to 'File Format Advice', format_advice_path %>.
+    </blockquote>
 
+    <p><a name="faq_4679" id="faq_4679"></a>
+      I'm having trouble uploading a file over 200 MB; what should I do?
+    </p>
 
-<p><a name="faq_7913" id="faq_7913"></a>
-  What happens to my works if I delete them?
-</p>
-<blockquote>
-  If you have not requested a Digital Object Identifier (DOI) for your work, you can withdraw any works you have submitted and they will be removed from <%=t('hyrax.product_name') %>. If you have requested a DOI, the work will be removed from <%=t('hyrax.product_name') %>, but a brief citation will be retained at our DOI provider's website that displays the work's citation information, and the reason for it's unavailability.
-</blockquote>
+    <blockquote>
+      We recommend that you use the <%= link_to 'contact form', hyrax.contact_path %> for assistance with files larger than 200 MB, but if you have trouble uploading any file, please use the <%= link_to 'contact form', hyrax.contact_path %> for assistance.
+    </blockquote>
 
 
+    <p><a name="faq_7946" id="faq_7946"></a>
+      May I publish, contribute, or otherwise distribute my content elsewhere?
+    </p>
+    <blockquote>
+      Yes. When you submit content to <%=t('hyrax.product_name') %> you agree to a non-exclusive <%= link_to t('hyrax.deposit_agreement'), '/distribution_license_request' %> that grants UC the right to enhance metadata, to replicate the content for preservation, and to make the content available through computer interfaces. This license in no way prevents you from distributing your content through other channels.
+    </blockquote>
 
-<p><a name="faq_159" id="faq_159"></a>
-  Where do I go if I want to consult with subject area specialists on content?
-</p>
-<blockquote>
-  Access the <a href="http://www.libraries.uc.edu/help/subject-librarians.html">Subject Librarians directory</a> to find contact info for subject area specialists.
-</blockquote>
+    <p><a name="faq_1379" id="faq_1379"></a>
+      What file formats should I use when uploading to <%=t('hyrax.product_name') %>?
+    </p>
+
+    <blockquote>
+      File format is an important consideration when contributing your work to <%=t('hyrax.product_name') %>. The future usability of your content will depend on the file format you use. Because of this, we recommend uploading two files for each work: an access file and a preservation file.
+      <br><br>
+      An access file typically uses common formats that people are familiar with, usually compressed. It makes them easy to download and use. Examples of access formats are JPEG and MP3.
+      <br><br>
+      Preservation files should be the highest quality format available for your content, preferably uncompressed. They can be used to create new access files in the future, as formats change over time. Examples of preservation formats are TIFF and WAV. Uploading a preservation file will help guarantee your content will be easily used in the future.
+      <br><br>
+      For more information, please see <%= link_to 'File Format Advice', format_advice_path %>.
+    </blockquote>
 
 
-<p><a name="faq_3456" id="faq_3456"></a>
-  What's restricted data?
-</p>
-<blockquote>
-  Restricted data is data that is private, confidential, classified as restricted by export control, or data that could be used to personally identify an individual. Some examples include social security numbers, financial account numbers, electronically stored bio-metric information, and data from research involving human subjects. Restricted Data is defined by <a href="https://www.uc.edu/content/dam/uc/infosec/docs/policies/Data_Governance_and_Classification_Policy_9.1.1.pdf">University of Cincinnati Policy 9.1.1 (Data Protection Policy)</a> and should be reviewed for additional information.
-</blockquote>
+    <p><a name="faq_7913" id="faq_7913"></a>
+      What happens to my works if I delete them?
+    </p>
+    <blockquote>
+      If you have not requested a Digital Object Identifier (DOI) for your work, you can withdraw any works you have submitted and they will be removed from <%=t('hyrax.product_name') %>. If you have requested a DOI, the work will be removed from <%=t('hyrax.product_name') %>, but a brief citation will be retained at our DOI provider's website that displays the work's citation information, and the reason for it's unavailability.
+    </blockquote>
 
 
-<p><a name="faq_6543" id="faq_6543"></a>
-  What’s the difference between delegates, editors, and groups?
-</p>
-<blockquote>
-  Delegates are people you authorize who can create, edit, and delete works on your behalf. They can do anything you can do, so please exercise discretion when authorizing another person as a delegate. Your delegates may be managed from the My Delegates page.
-  <br><br>
-  Editors are individuals to whom you have granted the ability to view and make changes to a specific work. If you would like to grant a group of individuals these rights, you can create a Group on the My Groups page. For example, if you work with a group of researchers on a single work, you can create a group of those researchers and grant that group viewing and editing privileges.
-  <br><br>
-  Editors (and groups) are like delegates, but whereas delegates have all the powers of the person they represent, editors (and groups) can only view and make changes to specific works.
-</blockquote>
 
-<p><a name="faq_1010" id="faq_1010"></a>
-  How do work access rights impact my DOIs?
-</p>
-<blockquote>
-  If you use <%=t('hyrax.product_name') %> to request a DOI, it will be either <i>public</i>, <i>reserved</i>, or <i>unavailable</i>.
-  <br><br>
-  <i>Public</i> DOIs are available for all <strong><%=t('hyrax.visibility.open.label_html') %></strong> works, and work normally.
-  <br><br>
-  <i>Reserved</i> DOIs are granted to any <strong><%=t('hyrax.visibility.open.label_html') %></strong>, <strong><%=t('hyrax.visibility.authenticated.label_html') %></strong>, or <strong><%=t('hyrax.visibility.private.label_html') %></strong> works for which you request a DOI. A <i>reserved</i> DOI will not yet redirect to your work, but it will be availble on the display page for your work for your reference. A <i>reserved</i> DOI will become <i>public</i> if you make your work <strong><%=t('hyrax.visibility.open.label_html') %></strong> or if your <strong><%=t('hyrax.visibility.embargo.label_html') %></strong> expires.
-  <br><br>
-  <i>Unavailable</i> DOIs are maintained for works for which you have requested a DOI where you have deleted the work or where you have changed the access rights from <strong><%=t('hyrax.visibility.open.label_html') %></strong> to <strong><%=t('hyrax.visibility.embargo.label_html') %></strong>, <strong><%=t('hyrax.visibility.authenticated.label_html') %></strong>, or <strong><%=t('hyrax.visibility.private.label_html') %></strong>. A tombstone page will indicate that the work is not available because it was withdrawn from the author. If you change your work back to <strong><%=t('hyrax.visibility.open.label_html') %></strong>, the DOI will change back to <i>public</i> status.
-  <br><br>
-</blockquote>
+    <p><a name="faq_159" id="faq_159"></a>
+      Where do I go if I want to consult with subject area specialists on content?
+    </p>
+    <blockquote>
+      Access the <a href="http://www.libraries.uc.edu/help/subject-librarians.html">Subject Librarians directory</a> to find contact info for subject area specialists.
+    </blockquote>
+
+
+    <p><a name="faq_3456" id="faq_3456"></a>
+      What's restricted data?
+    </p>
+    <blockquote>
+      Restricted data is data that is private, confidential, classified as restricted by export control, or data that could be used to personally identify an individual. Some examples include social security numbers, financial account numbers, electronically stored bio-metric information, and data from research involving human subjects. Restricted Data is defined by <a href="https://www.uc.edu/content/dam/uc/infosec/docs/policies/Data_Governance_and_Classification_Policy_9.1.1.pdf">University of Cincinnati Policy 9.1.1 (Data Protection Policy)</a> and should be reviewed for additional information.
+    </blockquote>
+
+
+    <p><a name="faq_6543" id="faq_6543"></a>
+      What’s the difference between delegates, editors, and groups?
+    </p>
+    <blockquote>
+      Delegates are people you authorize who can create, edit, and delete works on your behalf. They can do anything you can do, so please exercise discretion when authorizing another person as a delegate. Your delegates may be managed from the My Delegates page.
+      <br><br>
+      Editors are individuals to whom you have granted the ability to view and make changes to a specific work. If you would like to grant a group of individuals these rights, you can create a Group on the My Groups page. For example, if you work with a group of researchers on a single work, you can create a group of those researchers and grant that group viewing and editing privileges.
+      <br><br>
+      Editors (and groups) are like delegates, but whereas delegates have all the powers of the person they represent, editors (and groups) can only view and make changes to specific works.
+    </blockquote>
+
+    <p><a name="faq_1010" id="faq_1010"></a>
+      How do work access rights impact my DOIs?
+    </p>
+    <blockquote>
+      If you use <%=t('hyrax.product_name') %> to request a DOI, it will be either <i>public</i>, <i>reserved</i>, or <i>unavailable</i>.
+      <br><br>
+      <i>Public</i> DOIs are available for all <strong><%=t('hyrax.visibility.open.label_html') %></strong> works, and work normally.
+      <br><br>
+      <i>Reserved</i> DOIs are granted to any <strong><%=t('hyrax.visibility.open.label_html') %></strong>, <strong><%=t('hyrax.visibility.authenticated.label_html') %></strong>, or <strong><%=t('hyrax.visibility.private.label_html') %></strong> works for which you request a DOI. A <i>reserved</i> DOI will not yet redirect to your work, but it will be availble on the display page for your work for your reference. A <i>reserved</i> DOI will become <i>public</i> if you make your work <strong><%=t('hyrax.visibility.open.label_html') %></strong> or if your <strong><%=t('hyrax.visibility.embargo.label_html') %></strong> expires.
+      <br><br>
+      <i>Unavailable</i> DOIs are maintained for works for which you have requested a DOI where you have deleted the work or where you have changed the access rights from <strong><%=t('hyrax.visibility.open.label_html') %></strong> to <strong><%=t('hyrax.visibility.embargo.label_html') %></strong>, <strong><%=t('hyrax.visibility.authenticated.label_html') %></strong>, or <strong><%=t('hyrax.visibility.private.label_html') %></strong>. A tombstone page will indicate that the work is not available because it was withdrawn from the author. If you change your work back to <strong><%=t('hyrax.visibility.open.label_html') %></strong>, the DOI will change back to <i>public</i> status.
+      <br><br>
+    </blockquote>
+  </div>
+</div>

--- a/app/views/static/format_advice.html.erb
+++ b/app/views/static/format_advice.html.erb
@@ -1,195 +1,198 @@
 <% content_for :page_title, "File Format Advice // #{application_name}" %>
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2">
+    <h2>File Format Advice</h2>
 
-<h2>File Format Advice</h2>
+    <p>
+      Choosing the right file format for your content is an important consideration when contributing your work to <%=t('hyrax.product_name') %>. The future usability of your content will depend on the file format you use. Because of this, we recommend uploading two files for each work: an access file and a preservation file.
+    </p>
 
-<p>
-  Choosing the right file format for your content is an important consideration when contributing your work to <%=t('hyrax.product_name') %>. The future usability of your content will depend on the file format you use. Because of this, we recommend uploading two files for each work: an access file and a preservation file.
-</p>
+    <h3>
+      Access Files
+    </h3>
 
-<h3>
-  Access Files
-</h3>
+    <p>
+      Access files use common formats, ones that we typically use every day. They often use compression, for easy delivery over the web. Access files are what most people will download when viewing you work. Below are some typical access formats.
+    </p>
 
-<p>
-  Access files use common formats, ones that we typically use every day. They often use compression, for easy delivery over the web. Access files are what most people will download when viewing you work. Below are some typical access formats.
-</p>
+    <table class="table-bordered table-format-advice">
+      <thead>
+        <tr>
+          <th>
+            Text
+          </th>
+          <th>
+            Still Image
+          </th>
+          <th>
+            Audio
+          </th>
+          <th>
+            Media
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <ul>
+              <li>
+                MS Office (DOCX, XSLSX, etc.)
+              </li>
+              <li>
+                PDF
+              </li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>
+                JPG
+              </li>
+              <li>
+                PNG
+              </li>
+              <li>
+                GIF
+              </li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>
+                MP3
+              </li>
+              <li>
+                MP4
+              </li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>
+                MP4
+              </li>
+              <li>
+                MPEG
+              </li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
+    </table>
 
-<table class="table-bordered table-format-advice">
-  <thead>
-    <tr>
-      <th>
-        Text
-      </th>
-      <th>
-        Still Image
-      </th>
-      <th>
-        Audio
-      </th>
-      <th>
-        Media
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <ul>
-          <li>
-            MS Office (DOCX, XSLSX, etc.)
-          </li>
-          <li>
-            PDF
-          </li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>
-            JPG
-          </li>
-          <li>
-            PNG
-          </li>
-          <li>
-            GIF
-          </li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>
-            MP3
-          </li>
-          <li>
-            MP4
-          </li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>
-            MP4
-          </li>
-          <li>
-            MPEG
-          </li>
-        </ul>
-      </td>
-    </tr>
-  </tbody>
-</table>
+    <p>
+      It is recommended that you upload an access file at the time you complete your submission.
+    </p>
 
-<p>
-  It is recommended that you upload an access file at the time you complete your submission.
-</p>
+    <h3>Accessibility</h3>
+    <p>
+      How you create your access files can have a great impact on those with disabilities. <%=t('hyrax.product_name') %> encourages submitters to create accessible content for all. Some resources for creating accessible content can be found on the <a href="http://www.uc.edu/aess/disability/faculty_resources.html" target= "_blank" alt="UC Faculty Resources on creating accessible content">Disability Services’ Faculty Resources</a> page. Additional resources are available from the <a href="http://ncdae.org/resources/cheatsheets/" target= "_blank" alt="Cheatsheets for creating accessible content.">National Center on Disability and Access to Education</a>.
+    </p>
 
-<h3>Accessibility</h3>
-<p>
-  How you create your access files can have a great impact on those with disabilities. <%=t('hyrax.product_name') %> encourages submitters to create accessible content for all. Some resources for creating accessible content can be found on the <a href="http://www.uc.edu/aess/disability/faculty_resources.html" target= "_blank" alt="UC Faculty Resources on creating accessible content">Disability Services’ Faculty Resources</a> page. Additional resources are available from the <a href="http://ncdae.org/resources/cheatsheets/" target= "_blank" alt="Cheatsheets for creating accessible content.">National Center on Disability and Access to Education</a>.
-</p>
+    <h3>
+      Preservation Files
+    </h3>
 
-<h3>
-  Preservation Files
-</h3>
+    <p>
+      Preservation files use more stable formats than access files, whose formats are more likely to change with technology. They are often uncompressed and very large. Preservation formats can be used to create new access files, when new formats emerge. Below are some typical preservation formats.
+    </p>
 
-<p>
-  Preservation files use more stable formats than access files, whose formats are more likely to change with technology. They are often uncompressed and very large. Preservation formats can be used to create new access files, when new formats emerge. Below are some typical preservation formats.
-</p>
+    <table class="table-bordered table-format-advice">
+      <thead>
+        <tr>
+          <th>
+            Text
+          </th>
+          <th>
+            Still Image
+          </th>
+          <th>
+            Audio
+          </th>
+          <th>
+            Media
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <ul>
+              <li>
+                Open Office (ODT, ODS)
+              </li>
+              <li>
+                CSV
+              </li>
+              <li>
+                PDF/A-1
+              </li>
+              <li>
+                PDF/A-2
+              </li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>
+                TIFF
+              </li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>
+                WAV
+              </li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>
+                AVI
+              </li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
+    </table>
 
-<table class="table-bordered table-format-advice">
-  <thead>
-    <tr>
-      <th>
-        Text
-      </th>
-      <th>
-        Still Image
-      </th>
-      <th>
-        Audio
-      </th>
-      <th>
-        Media
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <ul>
-          <li>
-            Open Office (ODT, ODS)
-          </li>
-          <li>
-            CSV
-          </li>
-          <li>
-            PDF/A-1
-          </li>
-          <li>
-            PDF/A-2
-          </li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>
-            TIFF
-          </li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>
-            WAV
-          </li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>
-            AVI
-          </li>
-        </ul>
-      </td>
-    </tr>
-  </tbody>
-</table>
+    <p>
+      It is recommended that you upload a preservation file after the work submission has been completed. When logged in and viewing the work, near the bottom of your screen you will see a row of buttons that includes:  <span class='fakebutton'>Attach a File</span>
+    </p>
+    <p>
+      It is also recommended that preservation files be set to private access rights, so users will not be confused about which they should download.
+    </p>
 
-<p>
-  It is recommended that you upload a preservation file after the work submission has been completed. When logged in and viewing the work, near the bottom of your screen you will see a row of buttons that includes:  <span class='fakebutton'>Attach a File</span>
-</p>
-<p>
-  It is also recommended that preservation files be set to private access rights, so users will not be confused about which they should download.
-</p>
+    <p>
+      The file format you use will affect its preservability. Some specific guidance is offered below. If you have any questions, please <%= link_to "contact "+t('hyrax.product_name'), hyrax.contact_path %>.
+    </p>
 
-<p>
-  The file format you use will affect its preservability. Some specific guidance is offered below. If you have any questions, please <%= link_to "contact "+t('hyrax.product_name'), hyrax.contact_path %>.
-</p>
-
-<ul>
-  <li>
-    Most common formats used on the web are
     <ul>
       <li>
-        highly compressed, making it easy to share content over the internet; compression means some information has been removed to make the file smaller; and
+        Most common formats used on the web are
+        <ul>
+          <li>
+            highly compressed, making it easy to share content over the internet; compression means some information has been removed to make the file smaller; and
+          </li>
+          <li>
+            brittle. Formats used on the web change over time and are dependent on browser technology. For example, the introduction of HTML5, which natively supports videos, has drastically reduced the use of Flash Video (FLV) while increasing the use of MPEG-4 (MP4).
+          </li>
+        </ul>
       </li>
       <li>
-        brittle. Formats used on the web change over time and are dependent on browser technology. For example, the introduction of HTML5, which natively supports videos, has drastically reduced the use of Flash Video (FLV) while increasing the use of MPEG-4 (MP4).
+        For long term preservation, the use of uncompressed formats is important. The content if uncompressed is a true master copy, which can be used to create new derivative files as web formats change over time.
+      </li>
+      <li>
+        It's also important to use open (non-proprietary) and stable formats, when possible. This means the format itself is openly documented, widely used, and has likely been in use for many years. For example, it’s preferable to use an uncompressed WAV file for a sound recording over Windows Media Audio.
+      </li>
+      <li>
+        PDF or PDF/A is the best format for documents
+      </li>
+      <li>
+        If uploading music scores, it may be desirable to upload them in a musical notation format (such as Sibelius) if the creator is encouraging reuse. However, they should also be uploaded as PDF (or PDF/A) to ensure their long-term preservation and access.
       </li>
     </ul>
-  </li>
-  <li>
-    For long term preservation, the use of uncompressed formats is important. The content if uncompressed is a true master copy, which can be used to create new derivative files as web formats change over time.
-  </li>
-  <li>
-    It's also important to use open (non-proprietary) and stable formats, when possible. This means the format itself is openly documented, widely used, and has likely been in use for many years. For example, it’s preferable to use an uncompressed WAV file for a sound recording over Windows Media Audio.
-  </li>
-  <li>
-    PDF or PDF/A is the best format for documents
-  </li>
-  <li>
-    If uploading music scores, it may be desirable to upload them in a musical notation format (such as Sibelius) if the creator is encouraging reuse. However, they should also be uploaded as PDF (or PDF/A) to ensure their long-term preservation and access.
-  </li>
-</ul>
+  </div>
+</div>

--- a/app/views/static/help.html.erb
+++ b/app/views/static/help.html.erb
@@ -1,30 +1,33 @@
 <% content_for :page_title, "Help // #{application_name}" %>
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2">
+    <h2>Help Resources</h2>
 
-<h2>Help Resources</h2>
+    <dl class="help-description">
+      <dt><%= link_to "Accessibility at UC", "http://uc.edu/ucit/community/accessibility.html", target: '_blank' %></dt>
+      <dd>Information about the University of Cincinnati's Accessibility Network</dd>
 
-<dl class="help-description">
-  <dt><%= link_to "Accessibility at UC", "http://uc.edu/ucit/community/accessibility.html", target: '_blank' %></dt>
-  <dd>Information about the University of Cincinnati's Accessibility Network</dd>
+      <dt><%= link_to "Creator's Rights", creators_rights_path %></dt>
+      <dd>An explanation of what rights you may hold as the creator of a work</dd>
 
-  <dt><%= link_to "Creator's Rights", creators_rights_path %></dt>
-  <dd>An explanation of what rights you may hold as the creator of a work</dd>
+      <dt><%= link_to 'Documenting Data', documenting_data_path %></dt>
+      <dd>Suggestions for providing context for your data</dd>
 
-  <dt><%= link_to 'Documenting Data', documenting_data_path %></dt>
-  <dd>Suggestions for providing context for your data</dd>
+      <dt><%= link_to 'Fair Use', "http://librarycopyright.net/resources/fairuse/", target: '_blank' %></dt>
+      <dd>A resource for evaluating fair use</dd>
 
-  <dt><%= link_to 'Fair Use', "http://librarycopyright.net/resources/fairuse/", target: '_blank' %></dt>
-  <dd>A resource for evaluating fair use</dd>
+      <dt><%= link_to 'FAQ', faq_path %></dt>
+      <dd>Answers to frequently asked questions about <%=t('hyrax.product_name')%></dd>
 
-  <dt><%= link_to 'FAQ', faq_path %></dt>
-  <dd>Answers to frequently asked questions about <%=t('hyrax.product_name')%></dd>
+      <dt><%= link_to 'File Format Advice', format_advice_path %></dt>
+      <dd>How to choose the best file formats for your content</dd>
 
-  <dt><%= link_to 'File Format Advice', format_advice_path %></dt>
-  <dd>How to choose the best file formats for your content</dd>
+      <dt><%= link_to "Student Works", student_work_help_path %></dt>
+      <dd>Help for students wanting to add content to <%=t('hyrax.product_name') %></dd>
 
-  <dt><%= link_to "Student Works", student_work_help_path %></dt>
-  <dd>Help for students wanting to add content to <%=t('hyrax.product_name') %></dd>
+      <dt><%= link_to 'Welcome Page', welcome_page_index_path %></dt>
+      <dd>The welcome page all <%=t('hyrax.product_name') %> users see after their first log in</dd>
 
-  <dt><%= link_to 'Welcome Page', welcome_page_index_path %></dt>
-  <dd>The welcome page all <%=t('hyrax.product_name') %> users see after their first log in</dd>
-
-</dl>
+    </dl>
+  </div>
+</div>

--- a/app/views/static/login.html.erb
+++ b/app/views/static/login.html.erb
@@ -1,12 +1,16 @@
-<h2>Log In</h2>
+ <div class="row">
+  <div class="col-lg-8 col-lg-offset-2">
+    <h2>Log In</h2>
 
-<div id="central-login">
-  <p>If you have a <a href="https://www.uc.edu/distance/Student_Orientation/One_Stop_Student_Resources/central-log-in-.html">UC Central Login username</a>, you can use it to log in to Scholar@UC.</p>
-  <p><%= link_to 'Log in using your UC Central Login', '/users/auth/shibboleth', class: 'btn btn-primary', style: 'font-size: larger' %></p>
-</div>
+    <div id="central-login">
+      <p>If you have a <a href="https://www.uc.edu/distance/Student_Orientation/One_Stop_Student_Resources/central-log-in-.html">UC Central Login username</a>, you can use it to log in to Scholar@UC.</p>
+      <p><%= link_to 'Log in using your UC Central Login', '/users/auth/shibboleth', class: 'btn btn-primary', style: 'font-size: larger' %></p>
+    </div>
 
-<div id="local-login">
-  &nbsp;<br />
-  <h3>Other Users</h3>
-  <p>If you're not affiliated with UC, but have been given an account for <%= t('hyrax.product_name') %>, you can <strong><%= link_to 'log in using a local account', new_user_session_path %></strong>.  To request an account, <%= link_to 'use the contact page', contact_path %>.</p>
+    <div id="local-login">
+      &nbsp;<br />
+      <h3>Other Users</h3>
+      <p>If you're not affiliated with UC, but have been given an account for <%= t('hyrax.product_name') %>, you can <strong><%= link_to 'log in using a local account', new_user_session_path %></strong>.  To request an account, <%= link_to 'use the contact page', contact_path %>.</p>
+    </div>
+  </div>
 </div>

--- a/app/views/static/student_instructions.html.erb
+++ b/app/views/static/student_instructions.html.erb
@@ -1,106 +1,109 @@
 <% content_for :page_title, "Student Instructions // #{application_name}" %>
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2">
+    <h2>Student Self Submissions to <%=t('hyrax.product_name') %></h2>
+    <h2>Instructions for Students</h2>
 
-<h2>Student Self Submissions to <%=t('hyrax.product_name') %></h2>
-<h2>Instructions for Students</h2>
+    <p>
+      Works that are deposited in <%=t('hyrax.product_name') %> should be related to scholarship and research and be consistent with the <%=t('hyrax.product_name') %> <%= link_to "Mission and Collection Policy", coll_policy_path %>. Students should work with a faculty advisor to share scholarly output and creative works, such a capstone projects. <b>All official theses and dissertations must be submitted directly to the Graduate School and not <%=t('hyrax.product_name') %></b>. If you have any questions or problems with these instructions, please contact <%= link_to t('hyrax.product_name'), hyrax.contact_path %>.
+    </p>
 
-<p>
-  Works that are deposited in <%=t('hyrax.product_name') %> should be related to scholarship and research and be consistent with the <%=t('hyrax.product_name') %> <%= link_to "Mission and Collection Policy", coll_policy_path %>. Students should work with a faculty advisor to share scholarly output and creative works, such a capstone projects. <b>All official theses and dissertations must be submitted directly to the Graduate School and not <%=t('hyrax.product_name') %></b>. If you have any questions or problems with these instructions, please contact <%= link_to t('hyrax.product_name'), hyrax.contact_path %>.
-</p>
-
-<ol>
-  <li>
-  Log in to <%=t('hyrax.product_name') %> using the <a href="#" style="color:white;background-color:black;padding:3px;">
-            <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span > Login
-          </a> &nbsp;link (upper right corner of <a href="http://curly.libraries.uc.edu:3002/">curly.libraries.uc.edu</a>).
-  </li></br>
-
-  <li>
-    Click on the <p class="btn make-me-not-blue btn-primary" style="font-size: larger">Log in using your UC Central Login</p> button. Use your 6+2 and password to login. Upon your first login, you will be prompted to edit your profile. Basic information will be pre-supplied through the UC Central Login system. You will also be shown a welcome page until you check the box "I don’t need to see this." After you complete this process you will be directed to the <%=t('hyrax.product_name') %> browse page.
-  </li></br>
-
-  <li>
-  Click on the <a role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="color:white;background-color:black;padding:3px;" href="#"><span class="fa fa-cube"></span> Works <span class="caret"></span></a> menu and select "<b>New Work</b>."
-  </li></br>
-
-  <li>
-  Click on the <a class="add-button btn btn-primary add_new_article" href="#">Add New</a> button for the <b>Student Work</b> type.
-  </li></br>
-
-  <li>
-    Please see the <%= link_to "File Format Advice instructions", format_advice_path %> for information about accessible, usable, and preservable formats. Add a file to your work by:
-    <ul>
+    <ol>
       <li>
-        Uploading a file. If your file exceeds 3.0 GB, do not upload and <%= link_to "contact "+t('hyrax.product_name'), hyrax.contact_path %>.
-      </li>
-      <li>
-        Adding an external link. Please use permanent links whenever possible. Permanent links are usually advertised as such – links that will not change as content moves.
-      </li>
-      <li>
-        Pulling in a cloud file. If your project files are saved in Box, you can retrieve the files without having to first download them to your local device.
-      </li>
-    </ul>
-  </li>
-  <p>
-    <%= image_tag 'scholar_screens/add_file_image.png', alt: 'Add File', title: 'Add File' %>
-  </p></br>
+      Log in to <%=t('hyrax.product_name') %> using the <a href="#" style="color:white;background-color:black;padding:3px;">
+                <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span > Login
+              </a> &nbsp;link (upper right corner of <a href="http://curly.libraries.uc.edu:3002/">curly.libraries.uc.edu</a>).
+      </li></br>
 
-  <li>
-    Describe your work using the Metadata section, some fields are required. Specific field notes below.
-    <ul>
       <li>
-        Type of Work – select the predominant format of your work.
-      </li>
+        Click on the <p class="btn make-me-not-blue btn-primary" style="font-size: larger">Log in using your UC Central Login</p> button. Use your 6+2 and password to login. Upon your first login, you will be prompted to edit your profile. Basic information will be pre-supplied through the UC Central Login system. You will also be shown a welcome page until you check the box "I don’t need to see this." After you complete this process you will be directed to the <%=t('hyrax.product_name') %> browse page.
+      </li></br>
+
       <li>
-        Creator – you will automatically be tagged as a creator, but you may add collaborators as needed.
-      </li>
+      Click on the <a role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="color:white;background-color:black;padding:3px;" href="#"><span class="fa fa-cube"></span> Works <span class="caret"></span></a> menu and select "<b>New Work</b>."
+      </li></br>
+
       <li>
-        Advisor – enter the name of your faculty advisor. (Last name first.)
-      </li>
+      Click on the <a class="add-button btn btn-primary add_new_article" href="#">Add New</a> button for the <b>Student Work</b> type.
+      </li></br>
+
       <li>
-        College and Program or Department – please select your degree granting College and enter the name of your degree program.
+        Please see the <%= link_to "File Format Advice instructions", format_advice_path %> for information about accessible, usable, and preservable formats. Add a file to your work by:
+        <ul>
+          <li>
+            Uploading a file. If your file exceeds 3.0 GB, do not upload and <%= link_to "contact "+t('hyrax.product_name'), hyrax.contact_path %>.
+          </li>
+          <li>
+            Adding an external link. Please use permanent links whenever possible. Permanent links are usually advertised as such – links that will not change as content moves.
+          </li>
+          <li>
+            Pulling in a cloud file. If your project files are saved in Box, you can retrieve the files without having to first download them to your local device.
+          </li>
+        </ul>
       </li>
+      <p>
+        <%= image_tag 'scholar_screens/add_file_image.png', alt: 'Add File', title: 'Add File' %>
+      </p></br>
+
       <li>
-        If this work is associated with a degree, please enter that information. For example, "BSIT" (for Bachelor of Science in Information Technology).
-      </li>
-    </ul>
-  </li></br>
+        Describe your work using the Metadata section, some fields are required. Specific field notes below.
+        <ul>
+          <li>
+            Type of Work – select the predominant format of your work.
+          </li>
+          <li>
+            Creator – you will automatically be tagged as a creator, but you may add collaborators as needed.
+          </li>
+          <li>
+            Advisor – enter the name of your faculty advisor. (Last name first.)
+          </li>
+          <li>
+            College and Program or Department – please select your degree granting College and enter the name of your degree program.
+          </li>
+          <li>
+            If this work is associated with a degree, please enter that information. For example, "BSIT" (for Bachelor of Science in Information Technology).
+          </li>
+        </ul>
+      </li></br>
 
-  <li>
-    You may assign a Digital Object Identifier to your work. A DOI is intended to reference stable content and is a permanent URL that you may share and use in publications.
-  </li></br>
-
-  <li>
-    Add your faculty advisor or sponsor as a user with Edit access under the Sharing tab. Search for them by name or by email address. If your advisor has not yet logged in to <%=t('hyrax.product_name') %>, you will not find them – contact them and ask them to login.
-  </li>
-  <p>
-    <%= image_tag 'scholar_screens/content_editors_image.png', alt: 'Content Editors', title: 'Content Editors' %>
-  </p></br>
-
-  <li>
-    Discuss with your advisor whether they will approve your submission before it is made public – in this case mark this work as "private" in the Access Rights section.
-    <ul>
       <li>
-        For various reasons, such as potential commercialization, you may wish the work to remain private, be accessible only to UC users, or to assign an embargo period so that your work would automatically become public after a certain time period. Please make sure your faculty advisor knows your wishes so that you work isn’t made public prematurely.
-      </li>
+        You may assign a Digital Object Identifier to your work. A DOI is intended to reference stable content and is a permanent URL that you may share and use in publications.
+      </li></br>
+
       <li>
-        If your advisor has given you permission to publish without their review, then do not mark the work as "private", but choose between Open Access, accessible only to UC users, or assign an embargo period. You may want to discuss this choice with your advisor.
+        Add your faculty advisor or sponsor as a user with Edit access under the Sharing tab. Search for them by name or by email address. If your advisor has not yet logged in to <%=t('hyrax.product_name') %>, you will not find them – contact them and ask them to login.
       </li>
-    </ul>
-  </li></br>
+      <p>
+        <%= image_tag 'scholar_screens/content_editors_image.png', alt: 'Content Editors', title: 'Content Editors' %>
+      </p></br>
 
-  <li>
-    You may choose to assign a Creative Commons license to your work or choose "All rights reserved." A Creative Commons license is an easy way to communicate how you would like people to use or share your work. You may find it useful to use the <p class="btn make-me-not-blue btn-success selector">License Wizard</p> button which will guide you through the selection process. We suggest discussing this choice with your advisor.
-  </li></br>
+      <li>
+        Discuss with your advisor whether they will approve your submission before it is made public – in this case mark this work as "private" in the Access Rights section.
+        <ul>
+          <li>
+            For various reasons, such as potential commercialization, you may wish the work to remain private, be accessible only to UC users, or to assign an embargo period so that your work would automatically become public after a certain time period. Please make sure your faculty advisor knows your wishes so that you work isn’t made public prematurely.
+          </li>
+          <li>
+            If your advisor has given you permission to publish without their review, then do not mark the work as "private", but choose between Open Access, accessible only to UC users, or assign an embargo period. You may want to discuss this choice with your advisor.
+          </li>
+        </ul>
+      </li></br>
 
-  <li>
-    You must agree to the <%= link_to t('hyrax.deposit_agreement'), '/distribution_license_request' %> which grants UC the right to preserve, provide access (under the licensing terms chosen), and enhance the work with additional metadata. The license also states that you have not violated the intellectual property of another and that your work contains no restricted data, as defined by UC. <b>Note: You will retain fully copyright for the work and you can share or submit the work with additional repositories and websites.</b>
-  </li></br>
+      <li>
+        You may choose to assign a Creative Commons license to your work or choose "All rights reserved." A Creative Commons license is an easy way to communicate how you would like people to use or share your work. You may find it useful to use the <p class="btn make-me-not-blue btn-success selector">License Wizard</p> button which will guide you through the selection process. We suggest discussing this choice with your advisor.
+      </li></br>
 
-  <li>
-    Click the <b>Save</b> button to submit your work. Send an email to your faculty advisor with a link to the permanent URL of the work. In your email, inform them that you have submitted the final version work for their review. The advisor will check to make sure the appropriate fields are completed and take the steps necessary to make the work available through the appropriate Creative Commons license which you have chosen.
-  </li></br>
-</ol>
+      <li>
+        You must agree to the <%= link_to t('hyrax.deposit_agreement'), '/distribution_license_request' %> which grants UC the right to preserve, provide access (under the licensing terms chosen), and enhance the work with additional metadata. The license also states that you have not violated the intellectual property of another and that your work contains no restricted data, as defined by UC. <b>Note: You will retain fully copyright for the work and you can share or submit the work with additional repositories and websites.</b>
+      </li></br>
 
-<p>
-  Particularly for capstone projects, where successful completion is part of a degree requirement, you may lose edit access to your work once it is submitted. Your faculty advisor will retain editing rights as a Content Editor. If you need to change metadata or files from your work, contact your faculty advisor first. If you are unsuccessful, please contact <%= link_to t('hyrax.product_name'), hyrax.contact_path %>.
-</p>
+      <li>
+        Click the <b>Save</b> button to submit your work. Send an email to your faculty advisor with a link to the permanent URL of the work. In your email, inform them that you have submitted the final version work for their review. The advisor will check to make sure the appropriate fields are completed and take the steps necessary to make the work available through the appropriate Creative Commons license which you have chosen.
+      </li></br>
+    </ol>
+
+    <p>
+      Particularly for capstone projects, where successful completion is part of a degree requirement, you may lose edit access to your work once it is submitted. Your faculty advisor will retain editing rights as a Content Editor. If you need to change metadata or files from your work, contact your faculty advisor first. If you are unsuccessful, please contact <%= link_to t('hyrax.product_name'), hyrax.contact_path %>.
+    </p>
+  </div>
+</div>

--- a/app/views/static/student_work_help.html.erb
+++ b/app/views/static/student_work_help.html.erb
@@ -1,20 +1,23 @@
 <% content_for :page_title, "Student Works Help // #{application_name}" %>
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2">
+    <h2>Student Works Help</h2>
 
-<h2>Student Works Help</h2>
+    <p>
+      <%=t('hyrax.product_name') %> was developed to store and share the scholarly output and creative works of UC faculty (current and emeritus), staff, and students. Works that are deposited in <%=t('hyrax.product_name') %> should support the mission of the University of Cincinnati. Students should work with a faculty member to share scholarly output and creative works, such a capstone projects. <b>All official theses and dissertations must be submitted directly to the Graduate School and not <%=t('hyrax.product_name') %>.</b>
 
-<p>
-  <%=t('hyrax.product_name') %> was developed to store and share the scholarly output and creative works of UC faculty (current and emeritus), staff, and students. Works that are deposited in <%=t('hyrax.product_name') %> should support the mission of the University of Cincinnati. Students should work with a faculty member to share scholarly output and creative works, such a capstone projects. <b>All official theses and dissertations must be submitted directly to the Graduate School and not <%=t('hyrax.product_name') %>.</b>
+      There are two main workflows for submitting student works to <%=t('hyrax.product_name') %>: Self-Submission and Indirect Submission.
 
-  There are two main workflows for submitting student works to <%=t('hyrax.product_name') %>: Self-Submission and Indirect Submission.
+      Self-Submission of Student Works is the preferred method of submitting student works.
+    </p>
 
-  Self-Submission of Student Works is the preferred method of submitting student works.
-</p>
+    <ul>
+      <li><%= link_to "Guidelines for Faculty", advisor_guidelines_path %></li>
+      <li><%= link_to "Instructions for Students", student_instructions_path %></li>
+    </ul>
 
-<ul>
-  <li><%= link_to "Guidelines for Faculty", advisor_guidelines_path %></li>
-  <li><%= link_to "Instructions for Students", student_instructions_path %></li>
-</ul>
-
-<p>
-  Indirect submissions are when students submit first to a system other than <%=t('hyrax.product_name') %>, such as <a href="https://canopy.uc.edu" target="_blank">Canopy</a>. Direct, self-submission is preferred as it allows students, in <%=t('hyrax.product_name') %>, to agree to the non-exclusive distribution license and to select their own licensing terms for reuse (Creative Commons). In some cases indirect submissions are necessary, and in that case please contact <%= link_to t('hyrax.product_name'), hyrax.contact_path %> for additional help.
-</p>
+    <p>
+      Indirect submissions are when students submit first to a system other than <%=t('hyrax.product_name') %>, such as <a href="https://canopy.uc.edu" target="_blank">Canopy</a>. Direct, self-submission is preferred as it allows students, in <%=t('hyrax.product_name') %>, to agree to the non-exclusive distribution license and to select their own licensing terms for reuse (Creative Commons). In some cases indirect submissions are necessary, and in that case please contact <%= link_to t('hyrax.product_name'), hyrax.contact_path %> for additional help.
+    </p>
+  </div>
+</div>

--- a/app/views/static/whats_new.html.erb
+++ b/app/views/static/whats_new.html.erb
@@ -1,81 +1,84 @@
 <% content_for :page_title, "What's New in Scholar@UC 4.0 // #{application_name}" %>
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2">
+    <div class="whats-new">
 
-<div class="whats-new">
+    <h2>What's New in Scholar@UC 4.0</h2>
 
-<h2>What's New in Scholar@UC 4.0</h2>
+    <p>In addition to layout and styling enhancements, there are some important changes and new features available in version 4.0.
 
-<p>In addition to layout and styling enhancements, there are some important changes and new features available in version 4.0.
+    <h3>Collections can now contain other collections</h3>
 
-<h3>Collections can now contain other collections</h3>
+    <p>You can now create a multi-level hierarchy of sub-collections to organize your content.</p>
 
-<p>You can now create a multi-level hierarchy of sub-collections to organize your content.</p>
+    <p>To create a sub-collection, click on a collection in your dashboard and then click the "Add a subcollection" or "Create new collection as subcollection" button.  Existing collections can also added to a collection.</p>
 
-<p>To create a sub-collection, click on a collection in your dashboard and then click the "Add a subcollection" or "Create new collection as subcollection" button.  Existing collections can also added to a collection.</p>
+    <p>
+      <%= image_tag 'whats_new/whats-new-subcollections.png', width: "50%", alt: 'Sub-collections', title: 'Sub-collections' %>
+    </p>
 
-<p>
-  <%= image_tag 'whats_new/whats-new-subcollections.png', width: "50%", alt: 'Sub-collections', title: 'Sub-collections' %>
-</p>
+    <h3>Collections now support collaboration</h3>
 
-<h3>Collections now support collaboration</h3>
+    <p>You can now give other users the ability to manage, deposit into, or view your collections.</p>
 
-<p>You can now give other users the ability to manage, deposit into, or view your collections.</p>
+    <p>To collaborate on collections, click on the Edit button for your collection and then click on the Share tab.</p>
 
-<p>To collaborate on collections, click on the Edit button for your collection and then click on the Share tab.</p>
+    <p>
+      <%= image_tag 'whats_new/whats-new-collection-collaboration.png', width: "50%", alt: 'Collection Collaboration', title: 'Collection Collaboration' %>
+    </p>
 
-<p>
-  <%= image_tag 'whats_new/whats-new-collection-collaboration.png', width: "50%", alt: 'Collection Collaboration', title: 'Collection Collaboration' %>
-</p>
+    <h3>Collections have a new layout and branding options</h3>
 
-<h3>Collections have a new layout and branding options</h3>
+    <p>Each collection can be branded with a wide banner image.</p>
 
-<p>Each collection can be branded with a wide banner image.</p>
+    <p>To brand a collection, click on the Edit button for your collection and then click on the Branding tab.</p>
 
-<p>To brand a collection, click on the Edit button for your collection and then click on the Branding tab.</p>
+    <p>Note: collections no longer allow an avatar to be assigned.</p>
 
-<p>Note: collections no longer allow an avatar to be assigned.</p>
+    <p>
+      <%= image_tag 'whats_new/whats-new-collection-branding.png', width: "50%", alt: 'Collection Branding', title: 'Collection Branding' %>
+    </p>
 
-<p>
-  <%= image_tag 'whats_new/whats-new-collection-branding.png', width: "50%", alt: 'Collection Branding', title: 'Collection Branding' %>
-</p>
+    <h3>Faceting by collection</h3>
 
-<h3>Faceting by collection</h3>
+    <p>You can now facet (limit) your search results by collection.</p>
 
-<p>You can now facet (limit) your search results by collection.</p>
+    <p>
+      <%= image_tag 'whats_new/whats-new-collection-faceting.png', width: "30%", alt: 'Collection Faceting', title: 'Collection Faceting' %>
+    </p>
 
-<p>
-  <%= image_tag 'whats_new/whats-new-collection-faceting.png', width: "30%", alt: 'Collection Faceting', title: 'Collection Faceting' %>
-</p>
+    <!--
+    <h3>Collections can now be exported to .csv (experimental)</h3>
 
-<!--
-<h3>Collections can now be exported to .csv (experimental)</h3>
+    <p>you can now export a collection of content to a .csv file.  </p>
+    -->
 
-<p>you can now export a collection of content to a .csv file.  </p>
--->
+    <h3>Changes to the Dashboard</h3>
 
-<h3>Changes to the Dashboard</h3>
+    <p>Your dashboard has been reorganized with most of the links now displayed in a sidebar on the left-hand side of the page.
 
-<p>Your dashboard has been reorganized with most of the links now displayed in a sidebar on the left-hand side of the page.
+    <p>In the dashboard sidebar you will find links to your collections, works, profile, notifications, transferred works, and proxies.</p>
 
-<p>In the dashboard sidebar you will find links to your collections, works, profile, notifications, transferred works, and proxies.</p>
+    <p>
+      <%= image_tag 'whats_new/whats-new-sidebar.png', width: "25%", alt: 'Dashboard Sidebar', title: 'Dashboard Sidebar' %>
+    </p>
 
-<p>
-  <%= image_tag 'whats_new/whats-new-sidebar.png', width: "25%", alt: 'Dashboard Sidebar', title: 'Dashboard Sidebar' %>
-</p>
+    <h3>Support for Multiple Languages (experimental)</h3>
 
-<h3>Support for Multiple Languages (experimental)</h3>
+    <p>You can now change Scholar@UC's interface to Spanish or Chinese.</p>
 
-<p>You can now change Scholar@UC's interface to Spanish or Chinese.</p>
+    <p>Click on the "English" dropdown menu at the top of any page to immediately change languages.</p>
 
-<p>Click on the "English" dropdown menu at the top of any page to immediately change languages.</p>
+    <p>Note: This setting only affects Scholar@UC's interface.  The content stored in the repository will not be translated.</p>
 
-<p>Note: This setting only affects Scholar@UC's interface.  The content stored in the repository will not be translated.</p>
+    <p>
+      <%= image_tag 'whats_new/whats-new-translate.png', width: "30%", alt: 'Translation Option', title: 'Translation Option' %>
+    </p>
 
-<p>
-  <%= image_tag 'whats_new/whats-new-translate.png', width: "30%", alt: 'Translation Option', title: 'Translation Option' %>
-</p>
+    <h3>Behind the Scenes</h3>
+    
+    <p>Many enhancements have been made behind the scenes to make Scholar@UC more reliable and to prepare for additional upcoming features.</p>
 
-<h3>Behind the Scenes</h3>
- 
-<p>Many enhancements have been made behind the scenes to make Scholar@UC more reliable and to prepare for additional upcoming features.</p>
-
+    </div>
+  </div>
 </div>

--- a/app/views/welcome_page/index.html.erb
+++ b/app/views/welcome_page/index.html.erb
@@ -1,16 +1,20 @@
-<% if skip_new_user_help? && user_waived_welcome_page? %>
-  <%= raw show_welcome_page %>
-<% elsif skip_new_user_help? %>
-  <%= form_tag welcome_page_index_path, method: :post, id: "waive_welcome_page" do %>
-    <div class="form-actions centered">
-      <%= submit_tag t('hyrax.welcome.waive_page'), :class=> 'btn btn-primary' %>
-    </div>
-  <% end %>
-  <%= raw show_welcome_page %>
-<% else %>
-  <p>Next you’re going to edit your profile to make sure all your personal details are correct, but first please take a moment to review the help information below.</p>
-  <%= raw show_welcome_page %>
-  <div class="btn-group">
-    <%= link_to "Edit my Profile", Hyrax::Engine.routes.url_helpers.edit_dashboard_profile_path(current_user), class: 'btn btn-primary' %>
+<div class="row">
+  <div class="col-lg-8 col-lg-offset-2">
+    <% if skip_new_user_help? && user_waived_welcome_page? %>
+      <%= raw show_welcome_page %>
+    <% elsif skip_new_user_help? %>
+      <%= form_tag welcome_page_index_path, method: :post, id: "waive_welcome_page" do %>
+        <div class="form-actions centered">
+          <%= submit_tag t('hyrax.welcome.waive_page'), :class=> 'btn btn-primary' %>
+        </div>
+      <% end %>
+      <%= raw show_welcome_page %>
+    <% else %>
+      <p>Next you’re going to edit your profile to make sure all your personal details are correct, but first please take a moment to review the help information below.</p>
+      <%= raw show_welcome_page %>
+      <div class="btn-group">
+        <%= link_to "Edit my Profile", Hyrax::Engine.routes.url_helpers.edit_dashboard_profile_path(current_user), class: 'btn btn-primary' %>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>


### PR DESCRIPTION
Fixes #672

After going through several resources to see what the recommended length for a line is, I ended up following the guide here: https://webaim.org/techniques/textlayout/#column_width, however it is often recommended to be smaller but it looked rather ridiculous at some of the recommended sizing. I ended up testing a few variations of a fix, but settled on using a bootstrap col sizing as it is less intrusive than a custom CSS class, and can be easily changed at a later date.

The affected pages are:
https://scholar.uc.edu/about
https://scholar.uc.edu/advisor_guidelines
https://scholar.uc.edu/coll_policy
https://scholar.uc.edu/creators_rights
https://scholar.uc.edu/documenting_data
https://scholar.uc.edu/doi_help
https://scholar.uc.edu/faq
https://scholar.uc.edu/format_advice
https://scholar.uc.edu/help
https://scholar.uc.edu/login
https://scholar.uc.edu/student_instructions
https://scholar.uc.edu/student_work_help
https://scholar.uc.edu/whats_new
https://scholar.uc.edu/welcome_page

Note: This includes both login pages, for local logins and the production login page, since in development it only shows the Local Account Login Page.