### PR TITLE
Users shouldn't be able to self assign proxy rights

### DIFF
--- a/app/assets/javascripts/hyrax/proxy_rights.js
+++ b/app/assets/javascripts/hyrax/proxy_rights.js
@@ -1,0 +1,79 @@
+(function( $ ){
+
+  $.fn.proxyRights = function( options ) {
+
+    // Create some defaults, extending them with any options that were provided
+    var settings = $.extend( { }, options);
+
+    var $container = this;
+
+    function addContributor(name, user_key, grantor) {
+      data = {name: name, user_key: user_key}
+
+      $.ajax({
+        type: "POST",
+        url: '/users/'+grantor+'/depositors',
+        dataType: 'json',
+        data: {grantee_id: user_key},
+        success: function (data) {
+          if (data.name !== undefined) {
+            row = rowTemplate(data);
+            $('#authorizedProxies tbody', $container).append(row);
+            if (settings.afterAdd)
+              settings.afterAdd(this, cloneElem);
+          } else {
+            $('#proxy-help').append(errorTemplate(data));
+          }
+        }
+      })
+      return false;
+    }
+
+    function removeContributor(event) {
+      event.preventDefault();
+      $.ajax({
+        url: $(this).closest('a').prop('href'),
+        type: "post",
+        dataType: "json",
+        data: {"_method":"delete"}
+      });
+      $(this).closest('tr').remove();
+      return false;
+    }
+
+    function rowTemplate (data) {
+      return '<tr>'+
+                '<td class="depositor-name">'+data.name+'</td>'+
+                '<td><a class="remove-proxy-button btn btn-danger" data-method="delete" href="'+data.delete_path+'" rel="nofollow">'+
+                $('#delete_button_label').data('label')+'</a>'+
+                '</td>'+
+              '</tr>'
+    }
+
+    function errorTemplate(data) {
+      return '<div class="alert alert-danger" role="alert">'+
+                data.error+
+                '<button type="button" class="close" data-dismiss="alert" aria-label="Close">'+
+                  '<span aria-hidden="true">&times;</span>'+
+                '</button>'+
+              '</div>'
+    }
+
+    $("#user").userSearch();
+    $("#user").on("change", function() {
+      // Remove the choice from the select2 widget and put it in the table.
+      obj = $("#user").select2("data")
+      grantor = $('#user').data('grantor')
+      $("#user").select2("val", '')
+      addContributor(obj.text, obj.user_key, grantor);
+    });
+
+    $('body').on('click', 'a.remove-proxy-button', removeContributor);
+
+  };
+
+})( jQuery );
+
+Blacklight.onLoad(function() {
+  $('.proxy-rights').proxyRights();
+});

--- a/app/views/hyrax/dashboard/_index_partials/_proxy_rights.html.erb
+++ b/app/views/hyrax/dashboard/_index_partials/_proxy_rights.html.erb
@@ -1,0 +1,32 @@
+<div class="clearfix proxy-rights">
+  <div class="row">
+    <div id="proxy-help" class="col-xs-12">
+      <p><%= t('hyrax.dashboard.proxy_help') %></p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-6 proxy-search">
+      <h2><%= t("hyrax.dashboard.authorize_proxies") %></h2>
+      <div class="form-group">
+        <label for="user"><%= t("hyrax.dashboard.proxy_user") %></label>
+        <%= hidden_field_tag :user, nil, data: { grantor: current_user.to_param } %>
+        <%= hidden_field_tag :delete_button_label, nil, data: { label: I18n.t('hyrax.dashboard.proxy_delete') } %>
+      </div>
+    </div>
+
+    <div class="col-xs-6">
+      <h2><%= t("hyrax.dashboard.current_proxies") %></h2>
+      <table class="table table-condensed table-striped" id="authorizedProxies">
+        <tbody>
+        <% user.can_receive_deposits_from.each do |depositor| %>
+            <tr><td class="depositor-name"><%= depositor.name %></td>
+              <td><%= link_to(I18n.t('hyrax.dashboard.proxy_delete'), hyrax.user_depositor_path(user, depositor),
+                              method: :delete,
+                              class: "remove-proxy-button btn btn-danger") %>
+              </td></tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/spec/controllers/hyrax/depositors_controller_spec.rb
+++ b/spec/controllers/hyrax/depositors_controller_spec.rb
@@ -9,14 +9,30 @@ describe Hyrax::DepositorsController, type: :controller do
   describe "create" do
     let(:request_to_grant_proxy) { post :create, params: { user_id: user.user_key, grantee_id: grantee.user_key, format: 'json', use_route: :hyrax } }
     let(:expected_delete_path) { "/users/" + user.user_key.gsub("\.", '-dot-') + "/depositors/" + grantee.user_key.gsub("\.", '-dot-') + "?locale=en" }
+    let(:bad_request_to_grant_proxy) { post :create, params: { user_id: user.user_key, grantee_id: user.user_key, format: 'json', use_route: :hyrax } }
 
     before do
       sign_in user
     end
 
-    it "is successful" do
-      expect { request_to_grant_proxy }.to change { ProxyDepositRights.count }.by(1)
-      expect(JSON.parse(response.body)["delete_path"]).to eq expected_delete_path
+    context "adding a proxy" do
+      let(:request_to_grant_proxy) { post :create, params: { user_id: user.user_key, grantee_id: grantee.user_key, format: 'json', use_route: :hyrax } }
+      let(:expected_delete_path) { "/users/" + user.user_key.gsub("\.", '-dot-') + "/depositors/" + grantee.user_key.gsub("\.", '-dot-') + "?locale=en" }
+
+      it "is successful" do
+        expect { request_to_grant_proxy }.to change { ProxyDepositRights.count }.by(1)
+        expect(JSON.parse(response.body)["delete_path"]).to eq expected_delete_path
+      end
+    end
+
+    context "fails when user adds themselves" do
+      let(:request_to_grant_proxy) { post :create, params: { user_id: user.user_key, grantee_id: user.user_key, format: 'json', use_route: :hyrax } }
+      let(:error_message) { "You can't be a proxy for yourself." }
+
+      it "fails when user adds themself as a proxy" do
+        expect { request_to_grant_proxy }.to change { ProxyDepositRights.count }.by(0)
+        expect(JSON.parse(response.body)["error"]).to eq error_message
+      end
     end
   end
 

--- a/spec/services/works_report_spec.rb
+++ b/spec/services/works_report_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe WorksReport do
+describe WorksReport, :clean_repo do
   describe '#report_location' do
     it 'is vendor/work_report.csv' do
       expect(described_class.report_location).to eq("#{Rails.root}/vendor/works_report.csv")


### PR DESCRIPTION
Fixes #675  ;

We don't want users to be able to assign themselves proxy rights.  We now prevent them from doing so.  If a user attempts to add themselves as a proxy they will see an error message explaining that they can't add themselves as a proxy.