### PR TITLE
Explicitly state what a DOI is.

### DIFF
--- a/app/views/hyrax/base/_doi.html.erb
+++ b/app/views/hyrax/base/_doi.html.erb
@@ -1,4 +1,4 @@
-<h2>DOI</h2>
+<h2>Digital Object Identifier (DOI)</h2>
 
 <p>
   <% remote_service = Hydra::RemoteIdentifier.remote_service(:doi) %>

--- a/app/views/hyrax/base/_form_doi.html.erb
+++ b/app/views/hyrax/base/_form_doi.html.erb
@@ -1,7 +1,7 @@
 <% remote_service = Hydra::RemoteIdentifier.remote_service(:doi) %>
     <% if curation_concern.identifier_url.present? %>
       <div class="form-group doi">
-        <h2>DOI</h2>
+        <h2>Digital Object Identifier (DOI)</h2>
 
         <p>
           This work has a <abbr title="Digital Object Identifier">DOI</abbr>.
@@ -20,7 +20,7 @@
     <% else %>
 
       <div class="form-group set-doi">
-        <h2>Assign a DOI</h2>
+        <h2>Assign a Digital Object Identifier (DOI)</h2>
 
         <p>
           A <abbr title="Digital Object Identifier" data-placement="right">DOI</abbr> is a permanent link to your work.

--- a/spec/features/create_generic_work_spec.rb
+++ b/spec/features/create_generic_work_spec.rb
@@ -131,6 +131,9 @@ RSpec.describe 'Create a Generic Work', :feature, js: true do
       expect(page).to have_field('Note', with: note)
       expect(page).to have_field('External Link', with: external_link)
 
+      click_on('DOI')
+      expect(page).to have_text('Assign a Digital Object Identifier (DOI)')
+
       check('agreement')
       click_on('Save')
 

--- a/spec/services/works_report_spec.rb
+++ b/spec/services/works_report_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe WorksReport do
+describe WorksReport, clean_repo: true do
   describe '#report_location' do
     it 'is vendor/work_report.csv' do
       expect(described_class.report_location).to eq("#{Rails.root}/vendor/works_report.csv")

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -100,4 +100,8 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
   it 'shows last saved' do
     expect(page).to have_text '04/01/2011'
   end
+
+  it "has the correct DOI header" do
+    expect(page).to have_text 'Digital Object Identifier (DOI)'
+  end
 end


### PR DESCRIPTION
Fixes #708 ;

We now write out "Digital Object Identifier" on the edit and show page for increased clarity and accessibility. 
