### PR TITLE
Fix contact form error messages

### DIFF
--- a/app/controllers/hyrax/contact_form_controller.rb
+++ b/app/controllers/hyrax/contact_form_controller.rb
@@ -4,7 +4,6 @@ module Hyrax
   class ContactFormController < ApplicationController
     extend ActiveSupport::Concern
     before_action :build_contact_form
-    FAIL_NOTICE = "You must complete the Captcha to confirm the form. ".freeze
 
     def new; end
 
@@ -17,7 +16,7 @@ module Hyrax
         @contact_form = ContactForm.new
       else
         flash.now[:error] = 'Sorry, this message was not sent successfully. '
-        flash.now[:error] << FAIL_NOTICE
+        flash.now[:error] << 'You must complete the Captcha to confirm the form. ' unless passes_captcha_or_is_logged_in?
         flash.now[:error] << @contact_form.errors.full_messages.map(&:to_s).join(", ")
       end
       render :new

--- a/spec/controllers/hyrax/contact_form_controller_spec.rb
+++ b/spec/controllers/hyrax/contact_form_controller_spec.rb
@@ -52,31 +52,31 @@ RSpec.describe Hyrax::ContactFormController do
       context "without a name" do
         let(:params)  { required_params.except(:name) }
 
-        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. You must complete the Captcha to confirm the form. Name can't be blank") }
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Name can't be blank") }
       end
 
       context "without an email" do
         let(:params)  { required_params.except(:email) }
 
-        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. You must complete the Captcha to confirm the form. Email can't be blank") }
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Email can't be blank") }
       end
 
       context "without a subject" do
         let(:params)  { required_params.except(:subject) }
 
-        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. You must complete the Captcha to confirm the form. Subject can't be blank") }
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Subject can't be blank") }
       end
 
       context "without a message" do
         let(:params)  { required_params.except(:message) }
 
-        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. You must complete the Captcha to confirm the form. Message can't be blank") }
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Message can't be blank") }
       end
 
       context "with an invalid email" do
         let(:params)  { required_params.merge(email: "bad-wolf") }
 
-        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. You must complete the Captcha to confirm the form. Email is invalid") }
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Email is invalid") }
       end
     end
 


### PR DESCRIPTION
Fixes #690

Fixes the contact form error message for invalid CAPTCHA when it wasn't that. 