### PR TITLE
Update bootstrap-sass gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,10 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'active-fedora', '11.5.4'
 gem 'active_attr'
+gem 'bootstrap-sass', '~> 3.4.1'
 gem 'bundler', '~> 1.17'
 gem 'change_manager', git: "https://github.com/uclibs/change_manager.git", ref: '8d151d1123aa35658f061a63bc72435afdf0ec8a'
+gem 'sassc-rails', '>= 2.1.0'
 # gem 'clamav'
 gem 'devise'
 gem 'devise-guests', '~> 0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,7 @@ GEM
       io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.3.1)
+    autoprefixer-rails (9.5.0)
       execjs
     awesome_nested_set (3.1.4)
       activerecord (>= 4.0.0, < 5.3)
@@ -240,9 +240,9 @@ GEM
       bootstrap-sass (~> 3.0)
       openseadragon (>= 0.2.0)
       rails
-    bootstrap-sass (3.3.7)
+    bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
-      sass (>= 3.3.4)
+      sassc (>= 2.0.0)
     bootstrap_form (4.0.0)
       rails (>= 5.0)
     breadcrumbs_on_rails (3.0.1)
@@ -368,7 +368,7 @@ GEM
       faraday
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
-    ffi (1.9.25)
+    ffi (1.10.0)
     figaro (1.1.1)
       thor (~> 0.14)
     flipflop (2.4.0)
@@ -680,8 +680,8 @@ GEM
     rainbow (3.0.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
     rdf (3.0.6)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
@@ -807,7 +807,7 @@ GEM
     safe_yaml (1.0.4)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
-    sass (3.7.2)
+    sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -818,6 +818,15 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
+    sassc-rails (2.1.0)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     select2-rails (3.5.10)
       thor (~> 0.14)
     selenium-webdriver (3.12.0)
@@ -946,6 +955,7 @@ DEPENDENCIES
   active-fedora (= 11.5.4)
   active_attr
   bixby (>= 1.0.0)
+  bootstrap-sass (~> 3.4.1)
   browse-everything!
   bundler (~> 1.17)
   byebug
@@ -984,6 +994,7 @@ DEPENDENCIES
   rspec-rails
   rspec-retry
   sass-rails (~> 5.0)
+  sassc-rails (>= 2.1.0)
   selenium-webdriver (= 3.12.0)
   shoulda-matchers (~> 3.1)
   show_me_the_cookies


### PR DESCRIPTION
Fixes #692

Follows the recommendation from https://github.com/twbs/bootstrap-sass and added bootstrap-sass and sassc-rails gems to the gemfile