### PR TITLE
Fix file labels in Create Work

### DIFF
--- a/app/views/hyrax/uploads/_js_templates.html.erb
+++ b/app/views/hyrax/uploads/_js_templates.html.erb
@@ -65,12 +65,14 @@
                     </button>
                 </div>
             </div>
+            {% if (document.location["href"].includes("<%= hyrax.new_batch_upload_path(locale: nil) %>"))  { %}
             <div class="row">
                 <label for="title_{%=file.id%}" class="col-sm-2 control-label">Display label</label>
                 <div class="col-sm-10 padding-bottom">
                     <input type="text" class="form-control" name="title[{%=file.id%}]" id="title_{%=file.id%}" value="{%=file.name%}">
                 </div>
             </div>
+            {% } %}
         </td>
     </tr>
 {% } %}


### PR DESCRIPTION
Fixes #698 

After looking into why the file labels work for batch upload but not file upload, it started to look like it was due to the different ways that the app/views/hyrax/uploads/_js_templates.html.erb file was called. SO rather than messing with that, I decided that it would be simplier to check whether the page was batch_uploads. If it was then show the label, else don't.