### PR TITLE
#691 - Adds missing fields to work manifest report

### DIFF
--- a/app/services/works_report.rb
+++ b/app/services/works_report.rb
@@ -30,40 +30,48 @@ class WorksReport < Report
   def self.all_attributes_list
     %i[
       abstract
+      admin_set_id
       advisor
+      alt_date_created
+      alt_description
       alternate_title
       bibliographic_citation
       college
-      contributor
       committee_member
-      geo_subject
-      time_period
-      degree
-      department
-      date_created
-      alt_date_created
-      date_digitized
+      contributor
       creator
       cultural_context
+      date_created
+      date_digitized
+      degree
+      department
       description
-      alt_description
+      embargo_release_date
+      etd_publisher
+      existing_identifier
       genre
+      geo_subject
       identifier
       inscription
       issn
       journal_title
       language
+      license
       location
       material
       measurement
       note
       publisher
+      related_url
       required_software
       source
       subject
+      time_period
       title
       type
       visibility
+      visibility_after_embargo
+      visibility_during_embargo
     ]
   end
 


### PR DESCRIPTION
Fixes #691 ; 

Used some javascript to get all the names of the fields on the work creation pages, then wrote a ruby script to develop a list of de-duped fields between those and the existing list which can be viewed in [this gist](https://gist.github.com/chuckgreenman/515a54d1d6a472c7674d6dcfebd67e1b) or below.

```fields = {
  etd: ["title", "creator", "college", "department", "description", "advisor", "license", "committee_member", "degree", "date_created", "etd_publisher", "alternate_title", "genre", "subject", "geo_subject", "time_period", "language", "required_software", "note", "related_url", "existing_identifier", "visibility_during_embargo", "embargo_release_date", "visibility_after_embargo"],
  article: ["title", "creator", "college", "department", "description", "license", "publisher", "date_created", "alternate_title", "journal_title", "issn", "subject", "geo_subject", "time_period", "language", "required_software", "note", "related_url", "existing_identifier", "admin_set_id", "new_user_permission_skel", "visibility_during_embargo", "embargo_release_date", "visibility_after_embargo"],
  document: ["title", "creator", "college", "department", "description", "license", "publisher", "date_created", "alternate_title", "genre", "subject", "geo_subject", "time_period", "language", "required_software", "note", "related_url", "existing_identifier", "admin_set_id", "new_user_permission_skel", "visibility_during_embargo", "embargo_release_date", "visibility_after_embargo"],
  dataset: ["title", "creator", "college", "department", "description", "required_software", "license", "publisher", "date_created", "alternate_title", "subject", "geo_subject", "time_period", "language", "note", "related_url", "existing_identifier", "admin_set_id", "new_user_permission_skel", "visibility_during_embargo", "embargo_release_date", "visibility_after_embargo"],
  image: ["title", "creator", "college", "department", "description", "license", "publisher", "date_created", "alternate_title", "genre", "subject", "geo_subject", "time_period", "language", "required_software", "note", "related_url", "existing_identifier", "admin_set_id", "new_user_permission_skel", "visibility_during_embargo", "embargo_release_date", "visibility_after_embargo"],
  medium: ["title", "creator", "college", "department", "description", "license", "publisher", "date_created", "alternate_title", "subject", "geo_subject", "time_period", "language", "required_software", "note", "related_url", "existing_identifier", "admin_set_id", "new_user_permission_skel", "visibility_during_embargo", "embargo_release_date", "visibility_after_embargo"],
  student_work: ["title", "creator", "college", "department", "description", "advisor", "license", "degree", "publisher", "date_created", "alternate_title", "genre", "subject", "geo_subject", "time_period", "language", "required_software", "note", "related_url", "existing_identifier", "admin_set_id", "new_user_permission_skel", "visibility_during_embargo", "embargo_release_date", "visibility_after_embargo"],
  generic_work: ["", "title", "creator", "college", "department", "description", "license", "publisher", "date_created", "alternate_title", "subject", "geo_subject", "time_period", "language", "required_software", "note", "related_url", "existing_identifier", "admin_set_id", "new_user_permission_skel", "visibility_during_embargo", "embargo_release_date", "visibility_after_embargo"]
}

unique_field_names = []

fields.each do |work_type, field_names|
  field_names.each do |name|
    unique_field_names |= [name]
  end
end

curr_lst = [
  "abstract", 
  "advisor", 
  "alternate_title", 
  "bibliographic_citation", 
  "college", 
  "contributor", 
  "committee_member",
  "geo_subject",
  "time_period",
  "degree",
  "department",
  "date_created",
  "alt_date_created",
  "date_digitized",
  "creator",
  "cultural_context",
  "description",
  "alt_description",
  "genre",
  "identifier",
  "inscription",
  "issn",
  "journal_title",
  "language",
  "location",
  "material",
  "measurement",
  "note",
  "publisher",
  "required_software",
  "source",
  "subject",
  "title",
  "type",
  "visibility"
]

unique_field_names.each do |name|
  if !curr_lst.include? name
    puts "Missing! " + name
    curr_lst |= [name]
  end
end

curr_lst.sort!

curr_lst.each do |name|
  puts name
end