### PR TITLE
Limit description to 5 lines on catalog index page.

### DIFF
--- a/app/assets/javascripts/clamp.min.js
+++ b/app/assets/javascripts/clamp.min.js
@@ -1,0 +1,28 @@
+/*!
+* Clamp.js 0.5.1
+*
+* Copyright 2011-2013, Joseph Schmitt http://joe.sh
+* Released under the WTFPL license
+* http://sam.zoy.org/wtfpl/
+*/
+(function(){window.$clamp=function(c,d){function s(a,b){n.getComputedStyle||(n.getComputedStyle=function(a,b){this.el=a;this.getPropertyValue=function(b){var c=/(\-([a-z]){1})/g;"float"==b&&(b="styleFloat");c.test(b)&&(b=b.replace(c,function(a,b,c){return c.toUpperCase()}));return a.currentStyle&&a.currentStyle[b]?a.currentStyle[b]:null};return this});return n.getComputedStyle(a,null).getPropertyValue(b)}function t(a){a=a||c.clientHeight;var b=u(c);return Math.max(Math.floor(a/b),0)}function x(a){return u(c)*
+a}function u(a){var b=s(a,"line-height");"normal"==b&&(b=1.2*parseInt(s(a,"font-size")));return parseInt(b)}function l(a){if(a.lastChild.children&&0<a.lastChild.children.length)return l(Array.prototype.slice.call(a.children).pop());if(a.lastChild&&a.lastChild.nodeValue&&""!=a.lastChild.nodeValue&&a.lastChild.nodeValue!=b.truncationChar)return a.lastChild;a.lastChild.parentNode.removeChild(a.lastChild);return l(c)}function p(a,d){if(d){var e=a.nodeValue.replace(b.truncationChar,"");f||(h=0<k.length?
+k.shift():"",f=e.split(h));1<f.length?(q=f.pop(),r(a,f.join(h))):f=null;m&&(a.nodeValue=a.nodeValue.replace(b.truncationChar,""),c.innerHTML=a.nodeValue+" "+m.innerHTML+b.truncationChar);if(f){if(c.clientHeight<=d)if(0<=k.length&&""!=h)r(a,f.join(h)+h+q),f=null;else return c.innerHTML}else""==h&&(r(a,""),a=l(c),k=b.splitOnChars.slice(0),h=k[0],q=f=null);if(b.animate)setTimeout(function(){p(a,d)},!0===b.animate?10:b.animate);else return p(a,d)}}function r(a,c){a.nodeValue=c+b.truncationChar}d=d||{};
+var n=window,b={clamp:d.clamp||2,useNativeClamp:"undefined"!=typeof d.useNativeClamp?d.useNativeClamp:!0,splitOnChars:d.splitOnChars||[".","-","\u2013","\u2014"," "],animate:d.animate||!1,truncationChar:d.truncationChar||"\u2026",truncationHTML:d.truncationHTML},e=c.style,y=c.innerHTML,z="undefined"!=typeof c.style.webkitLineClamp,g=b.clamp,v=g.indexOf&&(-1<g.indexOf("px")||-1<g.indexOf("em")),m;b.truncationHTML&&(m=document.createElement("span"),m.innerHTML=b.truncationHTML);var k=b.splitOnChars.slice(0),
+h=k[0],f,q;"auto"==g?g=t():v&&(g=t(parseInt(g)));var w;z&&b.useNativeClamp?(e.overflow="hidden",e.textOverflow="ellipsis",e.webkitBoxOrient="vertical",e.display="-webkit-box",e.webkitLineClamp=g,v&&(e.height=b.clamp+"px")):(e=x(g),e<=c.clientHeight&&(w=p(l(c),e)));return{original:y,clamped:w}}})();
+
+function clampCatalogDescription() {
+	desc = document.getElementsByClassName("field-text description_tesim");
+	for (i = 0; i<desc.length; i++) {
+		$clamp(desc[i], {clamp:5});
+	}
+}
+
+$(document).ready(function() {
+	clampCatalogDescription();
+	
+});
+
+$(document).on('turbolinks:load', function() {
+	clampCatalogDescription();
+})

--- a/app/assets/javascripts/clamp.min.js
+++ b/app/assets/javascripts/clamp.min.js
@@ -14,7 +14,7 @@ h=k[0],f,q;"auto"==g?g=t():v&&(g=t(parseInt(g)));var w;z&&b.useNativeClamp?(e.ov
 function clampCatalogDescription() {
 	desc = document.getElementsByClassName("field-text description_tesim");
 	for (i = 0; i<desc.length; i++) {
-		$clamp(desc[i], {clamp:5});
+		$clamp(desc[i], {clamp:5, useNativeClamp: true});
 	}
 }
 

--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -205,7 +205,7 @@ div[class*="_admin_set_id"] {
 }
 
 .dl-horizontal dd {                                                                                                                                                         
-  padding-bottom: 6px;
+  margin-bottom: 12px;
 }
 
 .people {

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -4,8 +4,8 @@
     <% doc_presenter = index_presenter(document) %>
     <% index_fields(document).each do |field_name, field| -%>
       <% if should_render_index_field? document, field %>
-          <dt><%= render_index_field_label document, field: field_name %></dt>
-          <dd><%= doc_presenter.field_value field_name %></dd>
+          <dt class="field-label <%= field_name %>"><%= render_index_field_label document, field: field_name %></dt>
+          <dd class="field-text <%= field_name %>"><%= doc_presenter.field_value field_name %></dd>
       <% end %>
     <% end %>
     </dl>


### PR DESCRIPTION
Fixes #728 ; 

Descriptions on the catalog controller are now limited to five lines.  My approach was to use the Clamp.js library since there is no universally supported line clamping css approach.  Ended up adding class names to the facets on the catalog page, writing a function that selects all the elements with the description class and calls clamp.  If we decide that we want to change the number of lines we just change the number we pass clamp.
