### PR TITLE
replace chromedriver with webdrivers for capybara tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,6 @@ end
 group :test do
   gem 'capybara', '~> 2.4', '< 2.18.0'
   gem 'capybara-maleficent', '~> 0.2'
-  gem "chromedriver-helper", '< 2.0'
   gem 'coveralls', '~> 0.8.22', require: false
   gem 'database_cleaner'
   gem 'factory_bot_rails'
@@ -100,4 +99,5 @@ group :test do
   gem 'rspec-retry'
   gem 'selenium-webdriver', '3.12.0'
   gem 'shoulda-matchers', '~> 3.1'
+  gem 'webdrivers', '~> 3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,8 +183,6 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     almond-rails (0.1.0)
       rails (>= 4.2, < 6)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.5.0)
@@ -265,9 +263,6 @@ GEM
       mime-types (>= 1.16)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (1.2.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     clipboard-rails (1.7.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -466,7 +461,6 @@ GEM
       activesupport (<= 6)
     iiif_manifest (0.5.0)
       activesupport (>= 4)
-    io-like (0.3.0)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -937,6 +931,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (3.8.0)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webmock (3.4.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -962,7 +960,6 @@ DEPENDENCIES
   capybara (~> 2.4, < 2.18.0)
   capybara-maleficent (~> 0.2)
   change_manager!
-  chromedriver-helper (< 2.0)
   coffee-rails (~> 4.2)
   coveralls (~> 0.8.22)
   database_cleaner
@@ -1006,6 +1003,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   vcr
   web-console (>= 3.3.0)
+  webdrivers (~> 3.0)
   webmock
 
 BUNDLED WITH

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,6 +32,10 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
+# pin chromedriver version so capybara tests pass
+
+Webdrivers::Chromedriver.version = '72.0.3626.69'
+
 unless ENV['SKIP_MALEFICENT']
   # See https://github.com/jeremyf/capybara-maleficent
   # Wrap Capybara matchers with sleep intervals to reduce fragility of specs.


### PR DESCRIPTION
Fixes #736 

Chrome driver gem is broken, preventing capybara tests from running on Travis. Replace with webdrivers gem.

* Remove chromedriver-helper gem
* Add webdrivers gem
* pin to stable version of chromedriver in rails_helper
