### PR TITLE
Adds doi field to works manifest.

### DIFF
--- a/app/services/works_report.rb
+++ b/app/services/works_report.rb
@@ -46,6 +46,7 @@ class WorksReport < Report
       degree
       department
       description
+      doi
       embargo_release_date
       etd_publisher
       existing_identifier


### PR DESCRIPTION
Fixes #746 
Present short summary (50 characters or less)

Adds the doi field to app/services/works_report.rb

This is necessary for the Datacite migration