### PR TITLE
Add link to parent work when viewing child works.

### DIFF
--- a/app/services/parent_query_service.rb
+++ b/app/services/parent_query_service.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+module ParentQueryService
+  def self.query_parents_for_id(child_id)
+    ActiveFedora::SolrService.get("member_ids_ssim:#{child_id}", rows: 1000)["response"]["docs"]
+  end
+end

--- a/app/views/hyrax/base/_parent_relationship_table.html.erb
+++ b/app/views/hyrax/base/_parent_relationship_table.html.erb
@@ -1,0 +1,13 @@
+<% parent_solr_docs = ParentQueryService.query_parents_for_id(child_id) %>
+
+<dt> <%= t('hyrax.relationships_parent_row.label') unless parent_solr_docs.blank? %> </dt>
+  <dd>
+    <ul class="tabular">
+      <% parent_solr_docs.each do |item| unless parent_solr_docs.blank? %>
+        <li class='attribute attribute-title'>
+          <%= link_to item["title_tesim"].first, url_for_document(SolrDocument.find(item["id"])) %>
+        </li>
+      <% end %>
+     <% end %> 
+    </ul>
+  </dd>

--- a/app/views/hyrax/base/_relationships_parent_rows.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_rows.html.erb
@@ -3,10 +3,13 @@
   <%= render 'relationships_parent_row', type: model_name, items: items, presenter: presenter %>
 <% end %>
 
+<%# [scholar-override] Show parent relationships for child %>
+<%= render 'parent_relationship_table', child_id: presenter.solr_document.id %>
+
+
 <%# Render grouped presenters. Show rows if there are any items of that type %>
 <% presenter.presenter_types.each do |type| %>
   <% presenter.grouped_presenters(filtered_by: type).each_pair do |_, items| %>
     <%= render 'relationships_parent_row', type: type, items: items, presenter: presenter %>
   <% end %>
 <% end %>
-

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -74,7 +74,11 @@ en:
         license: Rights
   hyrax:
     active_consent_to_agreement: I have read and agree to the
+    relationships_parent_row:
+      label: "In Parent Work:"
     base:
+      relationships_parent_row:
+        label: "In Collection:"
       form_progress:
         required_agreement: Check distribution license
       items:

--- a/spec/services/parent_query_service_spec.rb
+++ b/spec/services/parent_query_service_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe ParentQueryService do
+  let(:parent_doc) { { "response": { "docs": [{ "id": "asdf" }] } }.with_indifferent_access }
+  let(:empty_results) { { "response": { "docs": [] } }.with_indifferent_access }
+  let(:child_id) { "child_id" }
+  describe "#query_parents_for_id" do
+    context "when a child work exists with a parent" do
+      before do
+        allow(ActiveFedora::SolrService).to receive(:get).with("member_ids_ssim:#{child_id}", rows: 1000).and_return(parent_doc)
+      end
+      it "returns the parent works" do
+        expect(described_class.query_parents_for_id(child_id).length).to eq 1
+      end
+    end
+    context "when a work exists without a parent" do
+      before do
+        allow(ActiveFedora::SolrService).to receive(:get).with("member_ids_ssim:#{child_id}", rows: 1000).and_return(empty_results)
+      end
+      it "returns an empty array" do
+        expect(described_class.query_parents_for_id(child_id).length).to eq 0
+      end
+    end
+  end
+end

--- a/test_script.md
+++ b/test_script.md
@@ -101,6 +101,11 @@
 1. Delete the first file from the work
 1. Verify that the file is removed
 
+### Add child work to parent work
+1. Creates a child work (you can use the work already in the script as the parent)
+1. Adds the child work to a collection
+1. Visit the child work's show page and verify that In Collections and In Parent Work are displaying properly.
+
 ### View works
 1. View the Generic Work's show page
 1. Verify that the license being displayed is the same one you chose with the wizard


### PR DESCRIPTION
Fixes #710 

Present short summary (50 characters or less)

* Add link to parent when viewing child work
* Add link to parent record
* Add return to parent record button on child work
* Create parent query service and test for service.

