### PR TITLE
Add Capistrano support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,11 +30,10 @@ coverage/*
 # Application files to ingore
 fits.log
 
-# Ignore uploaded avatars and banners
-public/branding/*
-public/system/avatars/*
-
-* Ignore dotenv config files
+# Ignore dotenv config files
 .env.development.local
 .env.test.local
 .env.production.local
+
+# Ignore compiled assets
+public/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install:
   - gem install chromedriver-helper -v 1.2.0
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
 
+install: bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle} --without production
+
 rvm:
   - 2.5.3
 

--- a/Capfile
+++ b/Capfile
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require "capistrano/setup"
+require "capistrano/deploy"
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
+
+require "capistrano/bundler"
+require "capistrano/rails/assets"
+require "capistrano/rails/migrations"
+
+# Load custom tasks from `lib/capistrano/tasks` if you have any defined
+Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
+
+task :use_rvm do
+  require 'capistrano/rvm'
+end
+
+task local: :use_rvm
+task curly: :use_rvm

--- a/Gemfile
+++ b/Gemfile
@@ -48,8 +48,6 @@ gem 'active_attr'
 gem 'bootstrap-sass', '~> 3.4.1'
 gem 'bundler', '~> 1.17'
 gem 'change_manager', git: "https://github.com/uclibs/change_manager.git", ref: 'd8e1b552740df00922a0a40796999c4e2a0cb8b6'
-gem 'sassc-rails', '>= 2.1.0'
-# gem 'clamav'
 gem 'devise', '~> 4.6.0'
 gem 'devise-guests', '~> 0.6'
 gem 'devise-multi_auth', git: 'https://github.com/uclibs/devise-multi_auth', branch: 'rails-5.1.6.2'
@@ -63,6 +61,7 @@ gem 'omniauth-shibboleth'
 gem 'orcid', git: 'https://github.com/uclibs/orcid', branch: 'rails-5.1.6.2'
 gem 'riiif', '~> 2.0'
 gem 'rsolr', '>= 1.0'
+gem 'sassc-rails', '>= 2.1.0'
 gem 'sidekiq'
 
 group :development, :test do
@@ -87,6 +86,10 @@ group :development do
   # Disabling Spring because in interferes with loading environment variables
   # gem 'spring'
   # gem 'spring-watcher-listen', '~> 2.0.0'
+  gem "capistrano", "~> 3.10", require: false
+  gem 'capistrano-bundler', '~> 1.6', require: false
+  gem "capistrano-rails", "~> 1.3", require: false
+  gem "capistrano-rvm", require: false
 end
 
 group :test do
@@ -100,4 +103,8 @@ group :test do
   gem 'selenium-webdriver', '3.12.0'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'webdrivers', '~> 3.0'
+end
+
+group :production do
+  gem 'clamav'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    airbrussh (1.3.2)
+      sshkit (>= 1.6.1, != 1.7.0)
     almond-rails (0.1.0)
       rails (>= 4.2, < 6)
     arel (8.0.0)
@@ -248,6 +250,19 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     cancancan (1.17.0)
+    capistrano (3.11.0)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    capistrano-bundler (1.6.0)
+      capistrano (~> 3.1)
+    capistrano-rails (1.4.0)
+      capistrano (~> 3.1)
+      capistrano-bundler (~> 1.1)
+    capistrano-rvm (0.1.2)
+      capistrano (~> 3.0)
+      sshkit (~> 1.2)
     capybara (2.17.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -264,6 +279,7 @@ GEM
       mime-types (>= 1.16)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    clamav (0.4.1)
     clipboard-rails (1.7.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -593,6 +609,9 @@ GEM
       redic
     net-http-persistent (3.1.0)
       connection_pool (~> 2.2)
+    net-scp (2.0.0)
+      net-ssh (>= 2.6.5, < 6.0.0)
+    net-ssh (5.2.0)
     netrc (0.11.0)
     nio4r (2.3.1)
     noid (0.9.0)
@@ -902,6 +921,9 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
+    sshkit (1.19.1)
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
     stomp (1.4.6)
     sxp (1.0.1)
       rdf (>= 2.2, < 4.0)
@@ -969,9 +991,14 @@ DEPENDENCIES
   browse-everything!
   bundler (~> 1.17)
   byebug
+  capistrano (~> 3.10)
+  capistrano-bundler (~> 1.6)
+  capistrano-rails (~> 1.3)
+  capistrano-rvm
   capybara (~> 2.4, < 2.18.0)
   capybara-maleficent (~> 0.2)
   change_manager!
+  clamav
   coffee-rails (~> 4.2)
   coveralls (~> 0.8.22)
   database_cleaner

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+# config valid for current version and patch releases of Capistrano
+lock "~> 3.11.0"
+set :application, "Scholar"
+set :repo_url, "https://github.com/uclibs/ucrate.git"
+set :keep_releases, 2
+
+task :shared_db do
+  on roles(:all) do
+    execute "mkdir -p #{fetch(:deploy_to)}/shared/db/ && touch #{fetch(:deploy_to)}/shared/db/development.sqlite3"
+    execute "cp #{fetch(:deploy_to)}/static/.env.development.local #{fetch(:release_path)}/ || true"
+  end
+end
+
+task :start_local do
+  on roles(:all) do
+    execute "export PATH=$PATH:/usr/local/bin && cd #{fetch(:deploy_to)}/current/script && source start_local.sh migrate"
+  end
+end
+
+task :start_curly do
+  on roles(:all) do
+    execute "export PATH=$PATH:/usr/sbin/ && cd #{fetch(:deploy_to)}/current/script && chmod u+x * && source start_curly.sh"
+  end
+end
+
+task :init_dev do
+  on roles(:all) do
+    execute "echo 'The deploy to Scholar@UC DEV has started' | mail -s 'Scholar@UC deploy started (scholar-dev)' scholar@uc.edu"
+    execute "gem install --user-install bundler"
+    execute "cp #{fetch(:deploy_to)}/static/scholar-dev.variables #{fetch(:release_path)}/.env.development.local 2> /dev/null"
+  end
+end
+
+task :start_dev do
+  on roles(:all) do
+    execute "cd #{fetch(:deploy_to)}/current/script && chmod a+x * && source start_dev.sh"
+  end
+end
+
+task :init_qa do
+  on roles(:all) do
+    execute 'echo "The deploy to `hostname` has started" | mail -s "Scholar@UC deploy started (`hostname`)" scholar@uc.edu'
+    execute "gem install --user-install bundler"
+    execute "cp #{fetch(:deploy_to)}/static/scholar-qa.variables #{fetch(:release_path)}/.env.production.local 2> /dev/null"
+  end
+end
+
+task :start_qa do
+  on roles(:all) do
+    execute "cd #{fetch(:deploy_to)}/current/script && chmod a+x * && source start_qa.sh"
+  end
+end
+
+task :init_prod do
+  on roles(:all) do
+    execute 'echo "The deploy to `hostname` has started" | mail -s "Scholar@UC deploy started (`hostname`)" scholar@uc.edu'
+    execute "gem install --user-install bundler"
+    execute "cp #{fetch(:deploy_to)}/static/scholar-production.variables #{fetch(:release_path)}/.env.production.local 2> /dev/null"
+  end
+end
+
+task :start_prod do
+  on roles(:all) do
+    execute "cd #{fetch(:deploy_to)}/current/script && chmod a+x * && source start_prod.sh"
+  end
+end

--- a/config/deploy/curly.rb
+++ b/config/deploy/curly.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+set :rails_env, :development
+set :bundle_without, %w[production test].join(' ')
+set :branch, 'sandbox'
+set :default_env, path: "$PATH:/usr/sbin/"
+append :linked_files, "db/development.sqlite3"
+# Note: Fedora and Solr are external
+append :linked_dirs, "tmp", "log", "public/system"
+ask(:username, nil)
+ask(:password, nil, echo: false)
+server "curly.libraries.uc.edu", user: fetch(:username), password: fetch(:password), port: 22, roles: [:web, :app, :db]
+set :deploy_to, '/opt/rails-apps/scholar_capistrano'
+after "deploy:updating", "shared_db"
+before "deploy:cleanup", "start_curly"

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+set :rails_env, :development
+set :bundle_without, %w[production test].join(' ')
+set :branch, 'develop'
+set :default_env, path: "$PATH:/srv/apps/.gem/ruby/2.5.0/bin:/opt/fits/fits"
+set :bundle_path, -> { shared_path.join('vendor/bundle') }
+# No db/development.sqlite3 file
+# Note: Fedora and Solr are external
+append :linked_dirs, "tmp", "log", "public"
+ask(:username, nil)
+ask(:password, nil, echo: false)
+server "localhost", user: fetch(:username), password: fetch(:password), port: 2222, roles: [:web, :app, :db]
+set :deploy_to, '/srv/apps/scholar_capistrano'
+after "deploy:updating", "init_dev"
+before "deploy:cleanup", "start_dev"

--- a/config/deploy/local.rb
+++ b/config/deploy/local.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+set :rails_env, :development
+set :bundle_without, %w[production test].join(' ')
+set :branch, 'chore/#761-deployment-alternative'
+set :default_env, path: "$PATH:/usr/local/bin"
+append :linked_files, "db/development.sqlite3"
+append :linked_dirs, "tmp", "log", "public/system"
+ask(:username, nil)
+ask(:password, nil, echo: false)
+server "localhost", user: fetch(:username), password: fetch(:password), port: 22, roles: [:web, :app, :db]
+set :deploy_to, '~/scholar_capistrano'
+after "deploy:updating", "shared_db"
+before "deploy:cleanup", "start_local"

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+set :rails_env, :production
+set :bundle_without, %w[test].join(' ')
+set :branch, 'master'
+set :default_env, path: "$PATH:/srv/apps/.gem/ruby/2.5.0/bin:/opt/fits/fits"
+set :bundle_path, -> { shared_path.join('vendor/bundle') }
+# No db/development.sqlite3 file
+# Note: Fedora and Solr are external
+# Removed log linked directory for symlinks in script
+append :linked_dirs, "tmp", "public"
+ask(:username, nil)
+ask(:password, nil, echo: false)
+# Note: Removing :db from one of the servers makes the migrations run only once between thems
+server "localhost", user: fetch(:username), password: fetch(:password), port: 2222, roles: [:web, :app, :db]
+server "localhost", user: fetch(:username), password: fetch(:password), port: 2223, roles: [:web, :app]
+set :deploy_to, '/srv/apps/scholar_capistrano'
+after "deploy:updating", "init_prod"
+before "deploy:cleanup", "start_prod"

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+set :rails_env, :production
+set :bundle_without, %w[test].join(' ')
+set :branch, 'release'
+set :default_env, path: "$PATH:/srv/apps/.gem/ruby/2.5.0/bin:/opt/fits/fits"
+set :bundle_path, -> { shared_path.join('vendor/bundle') }
+# No db/development.sqlite3 file
+# Note: Fedora and Solr are external
+# Removed log linked directory for symlinks in script
+append :linked_dirs, "tmp", "public"
+ask(:username, nil)
+ask(:password, nil, echo: false)
+# Note: Removing :db from one of the servers makes the migrations run only once between thems
+server "localhost", user: fetch(:username), password: fetch(:password), port: 2222, roles: [:web, :app, :db]
+server "localhost", user: fetch(:username), password: fetch(:password), port: 2223, roles: [:web, :app]
+set :deploy_to, '/srv/apps/scholar_capistrano'
+after "deploy:updating", "init_qa"
+before "deploy:cleanup", "start_qa"

--- a/script/check_sidekiq_running.sh
+++ b/script/check_sidekiq_running.sh
@@ -6,7 +6,7 @@
 RECIPIENTS="scholar@uc.edu"
 HOSTNAME=$(hostname -s)
 ENVIRONMENT=$1
-APP_DIRECTORY="/srv/apps/curate_uc"
+APP_DIRECTORY="$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )"
 
 function banner {
   echo -e "$0 ↠ $1"

--- a/script/custom_stats.sh
+++ b/script/custom_stats.sh
@@ -3,6 +3,6 @@
 # Update work and file index, and update stats
 # Runs as a cron job daily 
 
-cd /srv/apps/curate_uc
+cd "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )"
 RAILS_ENV=production bundle exec rake custom_stats:update_index
 RAILS_ENV=production bundle exec rake custom_stats:collect LIMIT="1000" DELAY="2" RETRIES="8"

--- a/script/riiif_cache_clean.sh
+++ b/script/riiif_cache_clean.sh
@@ -7,7 +7,7 @@
 # CAUTION - This script deletes files. Be careful where you point it!
 #
 
-LOG="/srv/apps/curate_uc/log/riiif_cache_clean.log"
+LOG="$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/log/riiif_cache_clean.log"
 
 # Check that the cache directories...
 IMG_CACHE_DIR="/mnt/common/scholar-riiif-cache"

--- a/script/rotate_log.sh
+++ b/script/rotate_log.sh
@@ -13,7 +13,7 @@ then
 
   # Restart the app and generate a blank log file
   touch $file_name
-  touch /srv/apps/curate_uc/tmp/restart.txt
+  touch "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/tmp/restart.txt"
   
   # Compress the moved log file
   gzip $new_fileName

--- a/script/start_curly.sh
+++ b/script/start_curly.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+if [ ! -f "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/static/.env.development.local" ]; then
+    echo "Missing updated .env.development.local file in the static directory. The server may not function properly"
+else
+    cp "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/static/.env.development.local" "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )"
+fi
+
+# Kill rails server if exists
+kill -9 $(lsof -i tcp:3002 -t) 2> /dev/null
+source "$HOME/.rvm/scripts/rvm" && bundle exec rails server -p 3002 -b 0.0.0.0 -d
+source restart_sidekiq.sh development 1
+bin/rails hyrax:default_admin_set:create
+bundle exec rails hyrax:default_collection_types:create
+bin/rails hyrax:workflow:load

--- a/script/start_dev.sh
+++ b/script/start_dev.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+if [ ! -f "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/static/scholar-dev.variables" ]; then
+    echo "Missing scholar-dev.variables file in static"
+else 
+    cp "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/static/scholar-dev.variables" ../.env.development.local
+fi
+ln -s /srv/apps/scholar_capistrano/current /srv/apps/curate_uc 2> /dev/null
+ln -s /srv/apps/scholar-avatars "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/shared/public/system/avatars" 2> /dev/null
+ln -s /srv/apps/scholar-public-uploads "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/shared/public/uploads" 2> /dev/null
+/bin/date +"%m-%d-%Y %r" > "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/config/deploy_timestamp"
+touch "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/tmp/restart.txt"
+source "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/script/restart_sidekiq.sh" development 8 no
+echo "The deploy to Scholar@UC DEV is finished" | mail -s 'Scholar@UC deploy finished (scholar-dev)' scholar@uc.edu

--- a/script/start_local.sh
+++ b/script/start_local.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+MODE=$1
+tmux kill-session -t localhost 2> /dev/null
+source "$HOME/.rvm/scripts/rvm"
+cd "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )"
+tmux new-session -As localhost -d
+tmux split-window -h
+tmux select-pane -t 0
+tmux split-window -v
+tmux select-pane -t 2
+tmux split-window -v
+tmux send-keys -t 0 "bundle exec fcrepo_wrapper -p 8984" C-m
+tmux send-keys -t 1 "bundle exec solr_wrapper -d solr/config/ --collection_name hydra-development" C-m
+tmux send-keys -t 2 "redis-server" C-m
+tmux send-keys -t 3 "rails server" C-m
+
+if [ $MODE == "migrate" ]; then
+    bin/rails hyrax:default_admin_set:create
+    bundle exec rails hyrax:default_collection_types:create
+    bin/rails hyrax:workflow:load
+fi

--- a/script/start_prod.sh
+++ b/script/start_prod.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+source "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/script/kill_sidekiq.sh"
+yes | cp -rf "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )"/public/assets/banner_image-*.jpg "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )"/public/assets/banner_image.jpg
+
+# Create symlinks for log files
+touch /mnt/common/scholar-logs/libschpwl1_production.log
+rm -f "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/log/production.log"
+ln -s /mnt/common/scholar-logs/libschpwl1_production.log "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/log/production.log"
+touch /mnt/common/scholar-logs/libschpwl1_sidekiq.log
+rm -f "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/log/sidekiq.log"
+ln -s /mnt/common/scholar-logs/libschpwl1_sidekiq.log "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/log/sidekiq.log"
+
+ln -s /srv/apps/scholar_capistrano/current /srv/apps/curate_uc 2> /dev/null
+rm /srv/apps/scholar_capistrano/shared/public/system/avatars 2> /dev/null
+rm /srv/apps/scholar_capistrano/shared/public/uploads 2> /dev/null
+rm /srv/apps/scholar_capistrano/shared/public/branding 2> /dev/null
+mkdir -p "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/shared/public/system" 2> /dev/null
+ln -s /mnt/common/avatars "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/shared/public/system/avatars" 2> /dev/null
+ln -s /mnt/common/scholar-public-uploads "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/shared/public/uploads/" 2> /dev/null
+ln -s /mnt/common/branding "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/shared/public/branding" 2> /dev/null
+/bin/date +"%m-%d-%Y %r" > "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/config/deploy_timestamp"
+touch "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/tmp/restart.txt"
+source "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/script/restart_sidekiq.sh" production 8 no
+echo "The deploy to `hostname` is finished" | mail -s "Scholar@UC deploy finished (`hostname`)" scholar@uc.edu

--- a/script/start_qa.sh
+++ b/script/start_qa.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+source "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/script/kill_sidekiq.sh"
+yes | cp -rf "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )"/public/assets/banner_image-*.jpg "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )"/public/assets/banner_image.jpg
+
+# Create symlinks for log files
+touch /mnt/common/scholar-logs/libschqwl1_production.log
+rm -f "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/log/production.log"
+ln -s /mnt/common/scholar-logs/libschqwl1_production.log "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/log/production.log"
+touch /mnt/common/scholar-logs/libschqwl1_sidekiq.log
+rm -f "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/log/sidekiq.log"
+ln -s /mnt/common/scholar-logs/libschqwl1_sidekiq.log "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/log/sidekiq.log"
+
+ln -s /srv/apps/scholar_capistrano/current /srv/apps/curate_uc 2> /dev/null
+rm /srv/apps/scholar_capistrano/shared/public/system/avatars 2> /dev/null
+rm /srv/apps/scholar_capistrano/shared/public/uploads 2> /dev/null
+rm /srv/apps/scholar_capistrano/shared/public/branding 2> /dev/null
+mkdir -p "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/shared/public/system" 2> /dev/null
+ln -s /mnt/common/avatars "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/shared/public/system" 2> /dev/null
+ln -s /mnt/common/scholar-public-uploads "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/shared/public/uploads" 2> /dev/null
+ln -s /mnt/common/branding "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/shared/public" 2> /dev/null
+/bin/date +"%m-%d-%Y %r" > "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/config/deploy_timestamp"
+touch "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/tmp/restart.txt"
+source "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )/script/restart_sidekiq.sh" production 8 no
+echo "The deploy to `hostname` is finished" | mail -s "Scholar@UC deploy finished (`hostname`)" scholar@uc.edu


### PR DESCRIPTION
Fixes #761

This commit allows us to use the Capistrano tool to do all of our deploys. The official documentation is in the ucrate wiki (https://github.com/uclibs/ucrate/wiki/Deploy-using-Capistrano). The only change outside of deployment that this impacts is the clamav gem. Instead of the commented out line, it was put into a group called production, so when you do future bundles, you'll need to run `bundle install --without production`.