### PR TITLE
Fix auto-fill for the publisher field

### DIFF
--- a/app/assets/javascripts/set_publisher.js
+++ b/app/assets/javascripts/set_publisher.js
@@ -27,5 +27,6 @@ var setPublisher = function()   {
         }
     }
 }
-
-$(document).on('turbolinks:load', setPublisher)
+document.addEventListener("turbolinks:load", function() {
+    setPublisher();
+})


### PR DESCRIPTION
After troubleshooting with @chuckgreenman, the issue seemed to come from the fact that the setPublisher file wasn't being loaded when the user tried to edit the file. This was due to the way that it used to load via turbolinks. This was changed to whenever a page loaded, and voila. 