### PR TITLE
Fix DOI embargo change

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,6 +88,7 @@ RSpec/AnyInstance:
     - 'spec/controllers/hyrax/contact_form_controller_spec.rb'
     - 'spec/controllers/collection_exports_controller_spec.rb'
     - 'spec/models/job_io_wrapper_spec.rb'
+    - 'spec/services/expiration_service_spec.rb'
 
 RSpec/DescribeClass:
   Exclude:
@@ -162,6 +163,7 @@ RSpec/ExampleLength:
     - 'spec/models/file_view_stat_spec.rb'
     - 'spec/jobs/attach_files_to_work_job_spec.rb'
     - 'spec/controllers/callbacks_controller_spec.rb'
+    - 'spec/jobs/identifier_embargo_update_job_spec.rb'
 
 RSpec/ExpectActual:
   Enabled: false
@@ -208,6 +210,7 @@ RSpec/VerifiedDoubles:
     - 'spec/services/hyrax/default_middleware_stack_spec.rb'
     - 'spec/jobs/attach_files_to_work_job_spec.rb'
     - 'spec/models/collection_spec.rb'
+    - 'spec/jobs/identifier_embargo_update_job_spec.rb'
     
 RSpec/NamedSubject:
   Exclude:

--- a/app/jobs/identifier_embargo_update_job.rb
+++ b/app/jobs/identifier_embargo_update_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class IdentifierEmbargoUpdateJob < ActiveJob::Base
+  def perform(identifier_uri)
+    RestClient.put(post_uri(identifier_uri), "{\n  \"data\": {\n    \"type\": \"dois\",\n    \"attributes\": {\n      \"event\": \"publish\"\n    }\n  }\n}", content_type: :json)
+  end
+
+  private
+
+    def post_uri(identifier_uri)
+      u = URI.parse(identifier_uri)
+      u.user = ENV["SCHOLAR_DOI_USERNAME"]
+      u.password = ENV["SCHOLAR_DOI_PASSWORD"]
+      u.to_s
+    end
+end

--- a/app/services/expiration_service.rb
+++ b/app/services/expiration_service.rb
@@ -22,6 +22,12 @@ class ExpirationService
     embargo_expirations(object_types).each do |expiration|
       next unless expiration.embargo.active?
       expiration.visibility = expiration.embargo.visibility_after_embargo
+      if expiration.respond_to? :doi
+        if expiration.doi.present?
+          temp_doi = expiration.doi.at(4..-1)
+          IdentifierEmbargoUpdateJob.perform_now("https://api.test.datacite.org/dois/" + temp_doi)
+        end
+      end
       expiration.deactivate_embargo!
       expiration.embargo.save
       expiration.save

--- a/script/release_embargo.sh
+++ b/script/release_embargo.sh
@@ -3,5 +3,6 @@
 # Change and expired embargoed objects to open access
 # Runs as a cron job daily just after midnight
 
-cd /srv/apps/curate_uc
-bundle exec rake embargo_manager:release
+cd "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )"
+export RELEASE_DATE=`date -v +1d "+%Y-\%m-\%d"`
+bundle exec rake embargo_release["$RELEASE_DATE"]

--- a/spec/jobs/identifier_embargo_update_job_spec.rb
+++ b/spec/jobs/identifier_embargo_update_job_spec.rb
@@ -1,0 +1,30 @@
+
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe IdentifierEmbargoUpdateJob do
+  let(:doi_remote_service) do
+    double("Doi Remote Service", username: "foo", password: "bar")
+  end
+
+  let(:identifier_uri) { "https://api.test.datacite.org/dois/10.23676/2j0v-ft05" }
+  let(:expected_post_uri) { "https://apitest:apitest@api.test.datacite.org/dois/10.23676/2j0v-ft05" }
+
+  before do
+    allow(Hydra::RemoteIdentifier).to receive(:remote_service).and_return(doi_remote_service)
+  end
+
+  describe "#perform" do
+    it "calls RestClient with the correct params" do
+      VCR.use_cassette "remotely_identified_doi_embargo_update_work", record: :new_episodes do
+        expect(RestClient).to receive(:put).with(
+          expected_post_uri,
+          "{\n  \"data\": {\n    \"type\": \"dois\",\n    \"attributes\": {\n      \"event\": \"publish\"\n    }\n  }\n}",
+          content_type: :json
+        )
+
+        described_class.perform_now(identifier_uri)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #774

Created a new job that sends an API call to Datacite to change the status of a DOI from draft to findable. Also reworked the release_embargo script to be compatible everywhere