### PR TITLE
Change DOI link on work show page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ git_source(:github) do |repo_name|
 end
 
 gem 'browse-everything', github: 'uclibs/browse-everything', branch: 'master'
-gem 'hydra-remote_identifier', github: 'uclibs/hydra-remote_identifier', branch: 'scholar-datacite'
+gem 'hydra-remote_identifier', github: 'uclibs/hydra-remote_identifier', ref: 'eb65b8e8bc9ebb8f42c77fc9ad65d32c0285730e'
 gem 'kaltura', '0.1.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,8 +92,8 @@ GIT
 
 GIT
   remote: https://github.com/uclibs/hydra-remote_identifier.git
-  revision: 215f36ac5c62c3b2b75631266a2147df8dee8dc0
-  branch: scholar-datacite
+  revision: eb65b8e8bc9ebb8f42c77fc9ad65d32c0285730e
+  ref: eb65b8e8bc9ebb8f42c77fc9ad65d32c0285730e
   specs:
     hydra-remote_identifier (0.6.8)
       activesupport (>= 3.2.13)
@@ -302,7 +302,7 @@ GEM
       devise
     diff-lcs (1.3)
     docile (1.3.1)
-    domain_name (0.5.20180417)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.5.0)
     dotenv-rails (2.5.0)
@@ -1007,4 +1007,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/spec/support/shared/doi_request.rb
+++ b/spec/support/shared/doi_request.rb
@@ -167,6 +167,7 @@ shared_examples 'doi request' do |work_class|
 
       expect(page).to have_content('My Test Work')
       expect(page).to have_content('doi:10.23676')
+      expect(page).to have_link('https://doi.org/10.23676')
 
       click_link "Edit"
       title_element = find_by_id("#{work_label}_title")


### PR DESCRIPTION
Fixes #773

Modified the hydra-remote_identifier gem to use the updated url convention given to us from Datacite. This commit has an updated spec to test that the changes are being used