### PR TITLE
Change Discovery to Visibility

### DIFF
--- a/config/locales/article.en.yml
+++ b/config/locales/article.en.yml
@@ -1,5 +1,10 @@
 en:
   hyrax:
+    dashboard:
+      collections:
+        form:
+          tabs:
+            discovery: Visibility
     icons:
       article:     'fa fa-file-text-o'
     select_type:

--- a/spec/features/hyrax/dashboard/collection_spec.rb
+++ b/spec/features/hyrax/dashboard/collection_spec.rb
@@ -919,12 +919,12 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
         it 'to true, it shows Discovery tab' do
           visit "/dashboard/collections/#{discoverable_collection_id}/edit"
-          expect(page).to have_link('Discovery', href: '#discovery')
+          expect(page).to have_link('Visibility', href: '#discovery')
         end
 
         it 'to false, it hides Discovery tab' do
           visit "/dashboard/collections/#{not_discoverable_collection_id}/edit"
-          expect(page).not_to have_link('Discovery', href: '#discovery')
+          expect(page).not_to have_link('Visibility', href: '#discovery')
         end
       end
 


### PR DESCRIPTION
Fixes #768

Changes a YAML file to display visibility instead of discovery for collections. Modified a spec test as well.