### PR TITLE
Stop parameterizing worktype in work show view

### DIFF
--- a/app/views/hyrax/base/_work_type.html.erb
+++ b/app/views/hyrax/base/_work_type.html.erb
@@ -1,4 +1,0 @@
-<h1 class="work-type-tag">
-  <span class="<%= Hyrax::ModelIcon.css_class_for(presenter.model) %>" aria-hidden="true"></span>
-  <%= t("activefedora.models.#{presenter.human_readable_type.to_s.parameterize.underscore}") %>
-</h1>


### PR DESCRIPTION
Fixes #785 

Non-roman characters are removed when parameterized in `app/views/hyrax/base/_work_type.html.erb`.  Change the view to simply display the human readable type.

* Remove `app/views/hyrax/base/_work_type.html.erb` override.
