### PR TITLE
Set flash message for publisher/doi validation

### DIFF
--- a/app/models/concerns/remotely_identified_by_doi.rb
+++ b/app/models/concerns/remotely_identified_by_doi.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module RemotelyIdentifiedByDoi
   NOT_NOW = 'not_now'
   ALREADY_GOT_ONE = 'already_got_one'
@@ -16,10 +17,17 @@ module RemotelyIdentifiedByDoi
       property :identifier_status, predicate: ::RDF::URI.new('http://purl.org/dc/terms/identifier#doiStatus'), multiple: false
       property :existing_identifier, predicate: ::RDF::URI.new('http://purl.org/dc/terms/identifier#unmanagedDOI'), multiple: false
 
-      validates :publisher, presence: { message: 'is required for remote DOI minting', if: :remote_doi_assignment_strategy? }
+      validate :publisher_presence
 
       attr_accessor :doi_assignment_strategy
       attr_writer :doi_remote_service
+
+      def publisher_presence
+        return if publisher.present?
+        return unless remote_doi_assignment_strategy?
+        errors.add(:base, "'Publisher' is required to mint a DOI")
+        errors.add(:publisher, "is required for remote DOI minting")
+      end
 
       def doi_status
         if visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC


### PR DESCRIPTION
Fixes #770 

We need to set base message for failed publisher validation when minting dois.

Changes proposed in this pull request:
* Add custom publisher validation to `app/models/concerns/remotely_identified_by_doi.rb`
* Add validation test to `spec/support/shared/doi_request.rb`
