### PR TITLE
Always show english worktype in work show view

### DIFF
--- a/app/views/classify_concerns/new.html.erb
+++ b/app/views/classify_concerns/new.html.erb
@@ -9,7 +9,7 @@
     <% (order + classify_concern.all_curation_concern_classes).uniq.each do |klass| %>
       <% if can? :create, klass %>
         <li class="work-type">
-          <h3 class="title"><%= klass.human_readable_type %></h3>
+          <h3 class="title"><%= t("hyrax.select_type.#{klass.model_name.i18n_key}.name") %></h3>
           <p class="short-description"><%= t("hyrax.select_type.#{klass.model_name.i18n_key}.description") %></p>
           <% if params[:type] == 'batch' %>
             <%= link_to 'Add Batch',

--- a/config/locales/article.es.yml
+++ b/config/locales/article.es.yml
@@ -6,5 +6,5 @@ es:
       article:
         # TODO: translate `human_name` into Spanish
         description:        "Article trabajos"
-        name:               "Article"
+        name:               "Articulo"
         # TODO: translate `human_name` into Spanish

--- a/config/locales/article.zh.yml
+++ b/config/locales/article.zh.yml
@@ -6,5 +6,5 @@ zh:
       article:
         # TODO: translate `human_name` into Chinese
         description:        "Article 作品"
-        name:               "Article"
+        name:               "文章"
         # TODO: translate `human_name` into Chinese

--- a/config/locales/dataset.es.yml
+++ b/config/locales/dataset.es.yml
@@ -6,5 +6,5 @@ es:
       dataset:
         # TODO: translate `human_name` into Spanish
         description:        "Dataset trabajos"
-        name:               "Dataset"
+        name:               "Conjunto de datos"
         # TODO: translate `human_name` into Spanish

--- a/config/locales/dataset.zh.yml
+++ b/config/locales/dataset.zh.yml
@@ -6,5 +6,5 @@ zh:
       dataset:
         # TODO: translate `human_name` into Chinese
         description:        "Dataset 作品"
-        name:               "Dataset"
+        name:               "数据集"
         # TODO: translate `human_name` into Chinese

--- a/config/locales/document.es.yml
+++ b/config/locales/document.es.yml
@@ -6,5 +6,5 @@ es:
       document:
         # TODO: translate `human_name` into Spanish
         description:        "Document trabajos"
-        name:               "Document"
+        name:               "Documento"
         # TODO: translate `human_name` into Spanish

--- a/config/locales/document.zh.yml
+++ b/config/locales/document.zh.yml
@@ -6,5 +6,5 @@ zh:
       document:
         # TODO: translate `human_name` into Chinese
         description:        "Document 作品"
-        name:               "Document"
+        name:               "文件"
         # TODO: translate `human_name` into Chinese

--- a/config/locales/generic_work.es.yml
+++ b/config/locales/generic_work.es.yml
@@ -6,5 +6,5 @@ es:
       generic_work:
         # TODO: translate `human_name` into Spanish
         description:        "Generic work trabajos"
-        name:               "Generic Work"
+        name:               "Trabajo genérico"
         # TODO: translate `human_name` into Spanish

--- a/config/locales/generic_work.zh.yml
+++ b/config/locales/generic_work.zh.yml
@@ -6,5 +6,5 @@ zh:
       generic_work:
         # TODO: translate `human_name` into Chinese
         description:        "Generic work 作品"
-        name:               "Generic Work"
+        name:               "普通文件"
         # TODO: translate `human_name` into Chinese

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -1,14 +1,4 @@
 es:
-  activefedora:
-    models:
-      article: 'Artículo'
-      dataset: 'Conjunto de datos'
-      document: 'Documento'
-      etd: 'Etd'
-      generic_work: 'Trabajo genérico'
-      image: 'Imagen'
-      medium: 'Medios de comunicación'
-      student_work: 'Trabajo de estudiante'
   blacklight:
     search:
       collections: Colecciones

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -1,14 +1,4 @@
 zh:
-  activefedora:
-    models:
-      article: '文章'
-      dataset: '数据集'
-      document: '文件'
-      etd: 'Etd'
-      generic_work: '普通文件'
-      image: '图像'
-      medium: '媒体'
-      student_work: '学生作品'
   blacklight:
     search:
       collections: 收藏

--- a/config/locales/image.es.yml
+++ b/config/locales/image.es.yml
@@ -6,5 +6,5 @@ es:
       image:
         # TODO: translate `human_name` into Spanish
         description:        "Image trabajos"
-        name:               "Image"
+        name:               "Imagen"
         # TODO: translate `human_name` into Spanish

--- a/config/locales/image.zh.yml
+++ b/config/locales/image.zh.yml
@@ -6,5 +6,5 @@ zh:
       image:
         # TODO: translate `human_name` into Chinese
         description:        "Image 作品"
-        name:               "Image"
+        name:               "图像"
         # TODO: translate `human_name` into Chinese

--- a/config/locales/medium.es.yml
+++ b/config/locales/medium.es.yml
@@ -6,5 +6,5 @@ es:
       medium:
         # TODO: translate `human_name` into Spanish
         description:        "Medium trabajos"
-        name:               "Medium"
+        name:               "Medios de comunicación"
         # TODO: translate `human_name` into Spanish

--- a/config/locales/medium.zh.yml
+++ b/config/locales/medium.zh.yml
@@ -6,5 +6,5 @@ zh:
       medium:
         # TODO: translate `human_name` into Chinese
         description:        "Medium 作品"
-        name:               "Medium"
+        name:               "媒体"
         # TODO: translate `human_name` into Chinese

--- a/config/locales/student_work.es.yml
+++ b/config/locales/student_work.es.yml
@@ -6,5 +6,5 @@ es:
       student_work:
         # TODO: translate `human_name` into Spanish
         description:        "Student work trabajos"
-        name:               "Student Work"
+        name:               "Trabajo de estudiante"
         # TODO: translate `human_name` into Spanish

--- a/config/locales/student_work.zh.yml
+++ b/config/locales/student_work.zh.yml
@@ -6,5 +6,5 @@ zh:
       student_work:
         # TODO: translate `human_name` into Chinese
         description:        "Student work 作品"
-        name:               "Student Work"
+        name:               "学生作品"
         # TODO: translate `human_name` into Chinese


### PR DESCRIPTION
Fixes #788 

In Nurax, worktype is always displayed in English on the work show view. Previously, we were translating this value, we should stop to be inline with Hyrax/Nurax.


Changes proposed in this pull request:
* Breakout worktype name translations to the worktype yamls 
* Update worktype selector view to show locale values from worktype yamls
