### PR TITLE
Creates fixity checking task.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -28,6 +28,10 @@ SCHOLAR_DATABASE_USERNAME=
 # Devise
 SCHOLAR_DEVISE_KEY=devise_secret_key
 
+# Fixity
+FIXITY_MAX_DAYS=-1
+FIXITY_NOTIFY_EMAIL=admin@example.com 
+
 # Google Analytics
 SCHOLAR_ANALYTICS_TOGGLE=false
 SCHOLAR_ANALYTICS_ID=analytics_id

--- a/.env.test
+++ b/.env.test
@@ -28,6 +28,10 @@ SCHOLAR_DATABASE_USERNAME=
 # Devise
 SCHOLAR_DEVISE_KEY=devise_secret_key
 
+# Fixity
+FIXITY_MAX_DAYS=-1
+FIXITY_NOTIFY_EMAIL=admin@example.com
+
 # Google Analytics
 SCHOLAR_ANALYTICS_TOGGLE=false
 SCHOLAR_ANALYTICS_ID=analytics_id

--- a/app/mailers/fixity_mailer.rb
+++ b/app/mailers/fixity_mailer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class FixityMailer < ActionMailer::Base
+  default from: 'scholar@uc.edu'
+  def fixity_email(user, subject, message)
+    @user = user
+    @message = message
+    @subject = subject
+
+    send_mail
+  end
+
+  def send_mail
+    mail(
+      to: @user.email,
+      subject: @subject,
+      body: @message
+    )
+  end
+end

--- a/app/services/hyrax/fixity_check_failure_service.rb
+++ b/app/services/hyrax/fixity_check_failure_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+module Hyrax
+  class FixityCheckFailureService < AbstractMessageService
+    attr_reader :log_date, :checksum_audit_log, :file_set
+
+    def initialize(file_set, checksum_audit_log:)
+      @file_set = file_set
+      @checksum_audit_log = checksum_audit_log
+      @log_date = checksum_audit_log.created_at
+      user = select_notify_email
+      FixityMailer.fixity_email(user, subject, message).deliver
+      super(file_set, user)
+    end
+
+    def message
+      uri = file_set.original_file.uri.to_s
+      file_title = file_set.title.first
+      I18n.t('hyrax.notifications.fixity_check_failure.message', log_date: log_date, file_title: file_title, uri: uri)
+    end
+
+    def subject
+      I18n.t('hyrax.notifications.fixity_check_failure.subject')
+    end
+
+    def select_notify_email
+      if ::User.find_by_user_key(ENV["FIXITY_NOTIFY_EMAIL"])
+        ::User.find_by_user_key(ENV["FIXITY_NOTIFY_EMAIL"])
+      else
+        ::User.find_by_user_key(file_set.depositor)
+      end
+    end
+  end
+end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -37,7 +37,7 @@ Hyrax.config do |config|
   # config.max_notifications_for_dashboard = 5
 
   # How frequently should a file be fixity checked
-  # config.max_days_between_fixity_checks = 7
+  config.max_days_between_fixity_checks = ENV["FIXITY_MAX_DAYS"].to_i
 
   # Options to control the file uploader
   # config.uploader = {

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -100,6 +100,9 @@ en:
       header: Contact the Scholar@UC Team
       notice_html: 'Please us this form to send questions, feedback, or report a problem to the Scholar@UC team. You can also check %{href} for more information'
       help_resources_href: 'Help Resources'
+    file_sets:
+      show_details:
+        fixity_check: Fixity Check  
     passive_consent_to_agreement: I have read and agree to the
     homepage:
       browse: Browse
@@ -122,6 +125,10 @@ en:
         scholar_blog: Scholar Blog
       partners: partners
       what_is: what is
+    notifications:
+      fixity_check_failure:
+        message: The fixity check run at %{log_date} for %{file_title} (%{uri}) failed.
+        subject: Failing Fixity Check
     pages:
       tabs:
         agreement_page: 'Distribution License'

--- a/lib/tasks/fixity_check.rake
+++ b/lib/tasks/fixity_check.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :scholar do
+  desc 'Starts fixity check on all files'
+  task fixity_check: :environment do
+    ::Hyrax::RepositoryFixityCheckService.fixity_check_everything
+  end
+end

--- a/spec/services/hyrax/fixity_check_failure_service_spec.rb
+++ b/spec/services/hyrax/fixity_check_failure_service_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::FixityCheckFailureService do
+  let!(:log_date) { '2015-07-15 03:06:59' }
+  let(:file) { Hydra::PCDM::File.new }
+  let(:version_uri) { "#{file.uri}/fcr:versions/version1" }
+  let!(:depositor) { create(:user) }
+  let(:file_set) do
+    create(:file_set, user: depositor, title: ["World Icon"]).tap { |fs| fs.original_file = file }
+  end
+
+  let(:checksum_audit_log) do
+    ChecksumAuditLog.new(file_set_id: file_set.id,
+                         file_id: file_set.original_file.id,
+                         checked_uri: version_uri,
+                         created_at: log_date,
+                         updated_at: log_date,
+                         passed: false)
+  end
+
+  describe "#call" do
+    subject(:fixity_check) { described_class.new(file_set, checksum_audit_log: checksum_audit_log) }
+    context "when no admin" do
+      let(:depositor_inbox) { depositor.mailbox.inbox }
+      it "sends failing mail" do
+        fixity_check.call
+        expect(depositor_inbox.count).to eq(1)
+        depositor_inbox.each { |msg| expect(msg.last_message.subject).to eq('Failing Fixity Check') }
+        depositor_inbox.each { |msg| expect(msg.last_message.body).to eq('The fixity check run at ' + checksum_audit_log.created_at.to_s + ' for ' + file_set.to_s + ' (' + file.uri + ') failed.') }
+      end
+    end
+
+    context "when admin exists" do
+      let!(:admin) { create(:admin, email: 'admin@example.com') }
+      let(:admin_inbox) { admin.mailbox.inbox }
+      let(:admin_file_set) do
+        create(:file_set, user: admin, title: ["World Icon"]).tap { |fs| fs.original_file = file }
+      end
+      it "sends failing mail" do
+        fixity_check.call
+        expect(admin_inbox.count).to eq(1)
+        admin_inbox.each { |msg| expect(msg.last_message.subject).to eq('Failing Fixity Check') }
+        admin_inbox.each { |msg| expect(msg.last_message.body).to eq('The fixity check run at ' + checksum_audit_log.created_at.to_s + ' for ' + file_set.to_s + ' (' + file.uri + ') failed.') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #727

Present short summary (50 characters or less)

This PR provides rake task for fixity checking all files, overrides config to allow fixity check to always run, and updates the failure service to email the repo administrator.

When testing locally make sure to have a mail service running.
