### PR TITLE
Add research directory to user profile

### DIFF
--- a/app/controllers/hyrax/dashboard/profiles_controller.rb
+++ b/app/controllers/hyrax/dashboard/profiles_controller.rb
@@ -18,7 +18,7 @@ module Hyrax
           params.require(:user).permit(:avatar, :facebook_handle, :twitter_handle,
                                        :googleplus_handle, :linkedin_handle, :remove_avatar,
                                        :orcid, :first_name, :last_name, :title, :ucdepartment, :uc_affiliation,
-                                       :alternate_email, :telephone, :alternate_phone_number, :website, :blog)
+                                       :alternate_email, :telephone, :alternate_phone_number, :website, :blog, :rd_page)
         end
     end
   end

--- a/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
@@ -99,6 +99,15 @@
   </div>
 
   <div class="form-group">
+    <%= f.label :rd_page, class: 'col-xs-4 control-label' do %>
+      <%= t('hyrax.user_profile.rd_page') %>
+    <% end %>
+    <div class="col-xs-8">
+       <%= f.text_field :rd_page, class: "form-control", pattern: "https:\/\/researchdirectory.uc.edu\/p\/[a-z]+" %>
+    </div>
+  </div>
+
+  <div class="form-group">
     <%= f.label :website, class: 'col-xs-4 control-label' do %>
       <%= t('hyrax.user_profile.website') %>
     <% end %>

--- a/app/views/hyrax/users/_user_info.html.erb
+++ b/app/views/hyrax/users/_user_info.html.erb
@@ -81,6 +81,11 @@
     <dd><%= user.uc_affiliation %></dd>
   <% end %>
 
+   <% if user.rd_page.present? %>
+    <dt><i class="glyphicon glyphicon-globe" aria-hidden="true"></i> Research Directory Page</dt>
+    <dd><%= iconify_auto_link(user.rd_page) %></dd>
+  <% end %>
+
   <% if user.telephone.present? %>
     <dt><i class="glyphicon glyphicon-earphone" aria-hidden="true"></i> Telephone</dt>
     <dd><%= link_to_telephone(user) %></dd>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -158,6 +158,7 @@ en:
       title: "Job title"
       ucdepartment: "Department"
       uc_affiliation: "UC affiliation"
+      rd_page: "Research Directory webpage"
       alternate_email: "Alternate email"
       telephone: "Campus phone number"
       alternate_phone_number: "Alternate phone number"

--- a/db/migrate/20190822153117_add_rd_page_to_users.rb
+++ b/db/migrate/20190822153117_add_rd_page_to_users.rb
@@ -1,0 +1,5 @@
+class AddRdPageToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :rd_page, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181128154405) do
+ActiveRecord::Schema.define(version: 20190822153117) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -609,6 +609,7 @@ ActiveRecord::Schema.define(version: 20181128154405) do
     t.string "provider"
     t.string "uid"
     t.string "preferred_locale"
+    t.string "rd_page"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     telephone { 'Campus phone number' }
     alternate_phone_number { 'Alternate phone number' }
     website { 'Personal webpage' }
+    rd_page { 'https://researchdirectory.uc.edu/p/user' }
     blog { 'Blog' }
 
     transient do

--- a/spec/features/hyrax/users_spec.rb
+++ b/spec/features/hyrax/users_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "User Spec", type: :feature do
         expect(page).to have_field('Alternate email', with: user.alternate_email)
         expect(page).to have_field('Campus phone number', with: user.telephone)
         expect(page).to have_field('Alternate phone number', with: user.alternate_phone_number)
+        expect(page).to have_field('Research Directory webpage', with: user.rd_page)
         expect(page).to have_field('Personal webpage', with: user.website)
         expect(page).to have_field('Blog', with: user.blog)
         expect(page).to have_content('Create or Connect your ORCID iD')
@@ -60,6 +61,7 @@ RSpec.describe "User Spec", type: :feature do
         click_on('Save Profile')
         expect(page).to have_content("Link to this page: ")
         expect(page).to have_content("/users/#{user.user_key.gsub('.', '-dot-')}")
+        expect(page).to have_content("https://researchdirectory.uc.edu/p/user")
       end
     end
   end

--- a/spec/views/hyrax/dashboard/profiles/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/profiles/edit.html.erb_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'hyrax/dashboard/profiles/edit.html.erb', type: :view do
 
   it "shows the user's web fields" do
     render
+    expect(rendered).to match(/Research Directory webpage/)
     expect(rendered).to match(/Personal webpage/)
     expect(rendered).to match(/Blog/)
   end


### PR DESCRIPTION
Fixes #731

Adds a link to a persons research directory page to their user profile. Note: This includes a migration that adds a string to the User db for a link to their page