### PR TITLE
Adds a one worker limit to the fixity_check sidekiq queue.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ end
 gem 'browse-everything', github: 'uclibs/browse-everything', branch: 'master'
 gem 'hydra-remote_identifier', github: 'uclibs/hydra-remote_identifier', branch: 'scholar-datacite'
 gem 'kaltura', '0.1.1'
+gem 'sidekiq-limit_fetch'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -898,6 +898,8 @@ GEM
       rack (>= 1.5.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
+    sidekiq-limit_fetch (3.4.0)
+      sidekiq (>= 4)
     signet (0.12.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -1062,6 +1064,7 @@ DEPENDENCIES
   shoulda-matchers (~> 3.1)
   show_me_the_cookies
   sidekiq (~> 5.2.7)
+  sidekiq-limit_fetch
   solr_wrapper (>= 0.3)
   sqlite3 (= 1.3.13)
   turbolinks (~> 5)

--- a/app/jobs/fixity_check_job.rb
+++ b/app/jobs/fixity_check_job.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class FixityCheckJob < Hyrax::ApplicationJob
+  queue_as :fixity_check
+
+  # A Job class that runs a fixity check (using ActiveFedora::FixityService,
+  # which contacts fedora and requests a fixity check), and stores the results
+  # in an ActiveRecord ChecksumAuditLog row. It also prunes old ChecksumAuditLog
+  # rows after creating a new one, to keep old ones you don't care about from
+  # filling up your db.
+  #
+  # The uri passed in is a fedora URI that fedora can run fixity check on.
+  # It's normally a version URI like:
+  #     http://localhost:8983/fedora/rest/test/a/b/c/abcxyz/content/fcr:versions/version1
+  #
+  # But could theoretically be any URI fedora can fixity check on, like a file uri:
+  #     http://localhost:8983/fedora/rest/test/a/b/c/abcxyz/content
+  #
+  # The file_set_id and file_id are used only for logging context in the
+  # ChecksumAuditLog, and determining what old ChecksumAuditLogs can
+  # be pruned.
+  #
+  # If calling async as a background job, return value is irrelevant, but
+  # if calling sync with `perform_now`, returns the ChecksumAuditLog
+  # record recording the check.
+  #
+  # @param uri [String] uri - of the specific file/version to fixity check
+  # @param file_set_id [FileSet] the id for FileSet parent object of URI being checked.
+  # @param file_id [String] File#id, used for logging/reporting.
+  def perform(uri, file_set_id:, file_id:)
+    uri = uri.to_s # sometimes we get an RDF::URI gah
+    log = run_check(file_set_id, file_id, uri)
+
+    if log.failed? && Hyrax.config.callback.set?(:after_fixity_check_failure)
+      file_set = ::FileSet.find(file_set_id)
+      Hyrax.config.callback.run(:after_fixity_check_failure,
+                                file_set,
+                                checksum_audit_log: log)
+    end
+
+    log
+  end
+
+  private
+
+    def run_check(file_set_id, file_id, uri)
+      service = ActiveFedora::FixityService.new(uri)
+      begin
+        fixity_ok = service.check
+        expected_result = service.expected_message_digest
+      rescue Ldp::NotFound
+        # Either the #check or #expected_message_digest could raise this exception
+        error_msg = 'resource not found'
+      end
+
+      log = ChecksumAuditLog.create_and_prune!(passed: fixity_ok, file_set_id: file_set_id, checked_uri: uri, file_id: file_id, expected_result: expected_result)
+      # Note that the after_fixity_check_failure will be called if the fixity check fail. This
+      # logging is for additional information related to the failure. Wondering if we should
+      # also include the error message?
+      logger.error "FIXITY CHECK FAILURE: Fixity failed for #{uri} #{error_msg}: #{log}" unless fixity_ok
+      log
+    end
+
+    def logger
+      Hyrax.logger
+    end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,3 +5,8 @@ max_retries: 3
   - ingest
   - event
   - change
+  - fixity_check
+
+:limits:
+  fixity_check: 1
+

--- a/script/fixity_check.sh
+++ b/script/fixity_check.sh
@@ -1,0 +1,8 @@
+
+#!/bin/bash
+
+# Runs a fixity check to check everything
+# Runs as a cron job daily just after midnight
+
+cd "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )"
+bundle exec rake scholar:fixity_check 

--- a/spec/jobs/fixity_check_job_spec.rb
+++ b/spec/jobs/fixity_check_job_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe FixityCheckJob do
+  let(:user) { create(:user) }
+
+  let(:file_set) do
+    create(:file_set, user: user).tap do |file|
+      Hydra::Works::AddFileToFileSet.call(file, File.open(fixture_path + '/world.png'), :original_file, versioning: true)
+    end
+  end
+  let(:file_id) { file_set.original_file.id }
+
+  describe "called with perform_now" do
+    let(:log_record) { described_class.perform_now(uri, file_set_id: file_set.id, file_id: file_id) }
+
+    describe 'fixity check the content' do
+      let(:uri) { file_set.original_file.uri }
+
+      it 'passes' do
+        expect(log_record).to be_passed
+      end
+      it "returns a ChecksumAuditLog" do
+        expect(log_record).to be_kind_of ChecksumAuditLog
+        expect(log_record.checked_uri).to eq uri
+        expect(log_record.file_id).to eq file_id
+        expect(log_record.file_set_id).to eq file_set.id
+      end
+    end
+
+    describe 'fixity check a version of the content' do
+      let(:uri) { Hyrax::VersioningService.latest_version_of(file_set.original_file).uri }
+
+      it 'passes' do
+        expect(log_record).to be_passed
+      end
+      it "returns a ChecksumAuditLog" do
+        expect(log_record).to be_kind_of ChecksumAuditLog
+      end
+    end
+    describe 'fixity check an invalid version of the content' do
+      let(:uri) { Hyrax::VersioningService.latest_version_of(file_set.original_file).uri + 'bogus' }
+      let(:log_record) { described_class.perform_now(uri, file_set_id: file_set.id, file_id: file_id) }
+
+      it 'fails' do
+        #        expect(job).to eq(false)
+        expect(log_record).to be_failed
+      end
+      it "returns a ChecksumAuditLog" do
+        #        expect(log_record).to be_kind_of ChecksumAuditLog
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #835 

Present short summary (50 characters or less)

This PR uses a sidekiq_fetch_limit job to limit the fixity_check queue to 1 worker.
We then had to bring in app/jobs/ overwrite from Hyrax to assign it to the fixity_check queue.
We then included a mock script to be used with cron.
