### PR TITLE
Fix RIIIF deprecation warning.

### DIFF
--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Riiif::Image.file_resolver = Riiif::HTTPFileResolver.new
+Riiif::Image.file_resolver = Riiif::HttpFileResolver.new
 Riiif::Image.info_service = lambda do |id, _file|
   # id will look like a path to a pcdm:file
   # (e.g. rv042t299%2Ffiles%2F6d71677a-4f80-42f1-ae58-ed1063fd79c7)


### PR DESCRIPTION
Fixes #841 

Fixes deprecation warning in the browse_everything initializer.