### PR TITLE
Move Collection Information

### DIFF
--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -56,17 +56,6 @@
     <div class="col-md-8 hyc-description">
       <%= render 'collection_description', presenter: @presenter %>
 
-      <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
-          <div class="hyc-blacklight hyc-bl-title">
-            <h2>
-              <%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)
-            </h2>
-          </div>
-          <div class="hyc-blacklight hyc-bl-results">
-            <%= render 'show_parent_collections', presenter: @presenter %>
-          </div>
-      <% end %>
-
     </div>
     <div class="col-md-4 hyc-metadata">
       <% unless has_collection_search_parameters? %>
@@ -93,6 +82,18 @@
       <%= render 'search_form', presenter: @presenter, url: hyrax.collection_path(@presenter.id) %>
     </div>
   </div>
+
+  <!-- Parent Collections -->
+  <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
+      <div class="hyc-blacklight hyc-bl-title">
+        <h2>
+          <%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)
+        </h2>
+      </div>
+      <div class="hyc-blacklight hyc-bl-results">
+        <%= render 'show_parent_collections', presenter: @presenter %>
+      </div>
+  <% end %>
 
   <!-- Subcollections -->
   <% if @presenter.collection_type_is_nestable? && @subcollection_count > 0 %>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -1,0 +1,104 @@
+<% provide :page_title, construct_page_title(@presenter.title) %>
+
+<% provide :page_header do %>
+  <h1><span class="fa fa-file" aria-hidden="true"></span> <%= t('.header') %></h1>
+<% end %>
+
+<div class="collections-wrapper">
+  <section class="panel panel-default collections-panel-wrapper admin-show-page">
+    <div class="panel-heading">
+      <%= render 'collection_title', presenter: @presenter %>
+    </div>
+
+    <div class="panel-body">
+      <section>
+        <div itemscope itemtype="http://schema.org/CollectionPage" class="row collection">
+          <div class="col-sm-3 text-center">
+              <%= render 'hyrax/collections/media_display', presenter: @presenter %>
+              <%= link_to t('.public_view_label'), collection_path(id: @presenter.id) %>
+          </div>
+          <div class="col-sm-9 collection-description-wrapper">
+            <!-- Collection Description(s) -->
+            <section>
+              <%= render 'hyrax/collections/collection_description', presenter: @presenter %>
+            </section>
+
+            <% unless has_collection_search_parameters? %>
+              <%= render 'show_descriptions' %>
+            <% end %>
+          </div>
+        </div>
+      </section>
+
+      <!-- Search results label -->
+
+      <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
+          <div class="hyc-blacklight hyc-bl-title">
+            <h2>
+              <% if has_collection_search_parameters? %>
+                  <%= t('hyrax.dashboard.collections.show.search_results') %>
+              <% end %>
+              <p class="sr-only"><%= t('hyrax.dashboard.collections.show.search_results') %></p>
+            </h2>
+          </div>
+      <% end %>
+
+      <!-- Search bar -->
+      <section class="collections-search-wrapper">
+        <div class="row">
+          <div class="col-sm-8">
+            <%# TODO: leaving this as it was causes rerouting to the public show page. needs work %>
+            <%= render 'hyrax/collections/search_form', presenter: @presenter, url: hyrax.collection_path(@presenter.id) %>
+          </div>
+        </div>
+      </section>
+
+      <!-- Parent Collection(s) -->
+      <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
+          <h3><%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)</h3>
+          <section id="parent-collections-wrapper" class="parent-collections-wrapper">
+            <%= render 'hyrax/dashboard/collections/show_parent_collections', presenter: @presenter %>
+          </section>
+      <% end %>
+      <!-- Subcollections -->
+      <% if @presenter.collection_type_is_nestable? %>
+        <section id="sub-collections-wrapper" class="sub-collections-wrapper">
+          <h3><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h3>
+          <div class="row">
+            <div class="col-md-7">
+              <%= render 'subcollection_list', id: @presenter.id, collection: @subcollection_docs %>
+            </div>
+            <% unless has_collection_search_parameters? %>
+              <div class="col-md-5">
+                <%= render 'show_subcollection_actions', presenter: @presenter %>
+              </div>
+            <% end %>
+          </div>
+        </section>
+      <% end %>
+
+      <!-- Works -->
+      <section class="works-wrapper">
+        <h3><%= t('.item_count') %> (<%= @members_count %>)</h3>
+        <% unless has_collection_search_parameters? %>
+          <%= render 'show_add_items_actions', presenter: @presenter %>
+        <% end %>
+
+        <%= render 'sort_and_per_page', collection: @presenter %>
+        <%= render_document_index @member_docs %>
+        <%= render 'hyrax/collections/paginate' %>
+      </section>
+
+    </div><!-- /panel-body -->
+  </section><!-- /collections-panel-wrapper -->
+</div><!-- /collections-wrapper -->
+
+<% if @presenter.collection_type_is_nestable? && !has_collection_search_parameters? %>
+  <%= render 'hyrax/my/collections/modal_add_to_collection', source: 'show' %>
+  <%= render 'hyrax/my/collections/modal_add_subcollection', id: @presenter.id, source: 'show' %>
+  <%= render 'hyrax/dashboard/collections/modal_parent_collection_remove_deny', source: 'show' %>
+<% end %>
+
+<% unless has_collection_search_parameters? %>
+  <%= render '/shared/select_work_type_modal', create_work_presenter: @presenter.create_work_presenter if @presenter.draw_select_work_modal? %>
+<% end %>

--- a/spec/features/hyrax/batch_edit_spec.rb
+++ b/spec/features/hyrax/batch_edit_spec.rb
@@ -82,10 +82,10 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
       click_on 'batch-edit'
       find('#edit_permissions_link').click
       expect(page).to have_content('Batch Edit Descriptions')
-
       # Set visibility to private
       within "#form_permissions_visibility" do
         batch_edit_expand('permissions_visibility')
+        find('#expand_link_permissions_visibility').click
         find('#generic_work_visibility_authenticated').click
         find('#permissions_visibility_save').click
         # This was `expect(page).to have_content 'Changes Saved'`, however in debugging,

--- a/spec/views/hyrax/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/show.html.erb_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/collections/show.html.erb', type: :view do
+  let(:parentdocument) do
+    SolrDocument.new(id: 'xyz123z4',
+                     'title_tesim' => ['Make Collections Great Again'],
+                     'rights_tesim' => ["http://creativecommons.org/licenses/by-sa/3.0/us/"])
+  end
+
+  let(:document) do
+    SolrDocument.new(id: 'zyx365z4',
+                     'title_tesim' => ['Make Collections Great Again'],
+                     'rights_tesim' => ["http://creativecommons.org/licenses/by-sa/3.0/us/"],
+                     'member_of_collection_ids_ssim' => ['xyz123z4'])
+  end
+  let(:ability) { double }
+  let(:collection_type) { create(:collection_type) }
+  let(:presenter) { Hyrax::CollectionPresenter.new(document, ability) }
+  let(:blacklight_config) { CatalogController.new.blacklight_config }
+  let(:blacklight_configuration_context) do
+    Blacklight::Configuration::Context.new(controller)
+  end
+
+  before do
+    allow(document).to receive(:hydra_model).and_return(::Collection)
+    allow(controller).to receive(:current_user).and_return(stub_model(User))
+    allow(view).to receive(:can?).with(:edit, document).and_return(false)
+    allow(view).to receive(:can?).with(:destroy, document).and_return(false)
+    allow(presenter).to receive(:collection_type_is_nestable?).and_return(true)
+    allow(presenter).to receive(:total_viewable_items).and_return(0)
+    allow(presenter).to receive(:banner_file).and_return("banner.gif")
+    allow(presenter).to receive(:logo_record).and_return([{ linkurl: "logo link url", alttext: "logo alt text", file_location: "logo.gif" }])
+    allow(presenter).to receive(:total_items).and_return(0)
+    allow(presenter).to receive(:collection_type).and_return(collection_type)
+    allow(presenter).to receive(:subcollection_count).and_return(1)
+    allow(presenter).to receive(:total_parent_collections).and_return(1)
+    assign(:collection_type_is_nestable, true)
+    assign(:subcollection_count, 1)
+    assign(:total_parent_collections, 1)
+    assign(:parent_collection_count, 1)
+    assign(:members_count, 1)
+
+    assign(:has_collection_search_parameters, true)
+    allow(ability).to receive(:user_groups).and_return([])
+    allow(ability).to receive(:current_user).and_return(build(:user, id: nil, email: ""))
+    assign(:presenter, presenter)
+
+    allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+    allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
+
+    # Stub route because view specs don't handle engine routes
+    allow(view).to receive(:collection_path).and_return("/collections/123")
+
+    stub_template 'hyrax/collections/_search_form.html.erb' => 'Search Results within this Collection'
+    stub_template 'hyrax/collections/_sort_and_per_page.html.erb' => 'sort and per page'
+    stub_template 'hyrax/collections/_document_list.html.erb' => 'document list'
+    stub_template 'hyrax/collections/_paginate.html.erb' => 'paginate'
+    stub_template 'hyrax/collections/_media_display.html.erb' => '<span class="fa fa-cubes collection-icon-search"></span>'
+    stub_template 'hyrax/collections/_show_parent_collections.html.erb' => '<div class="stubbed-actions">Parent Collections</div>'
+    stub_template '_subcollection_list.html.erb' => '<div class="stubbed-actions">Sub Collections</div>'
+  end
+
+  context 'when the rendered collection has parent collection' do
+    it 'renders parent followed by sub collections' do
+      render
+      # Making sure that we are verifyicng that the _show_actions.html.erb is rendering
+      expect(rendered).to match(/.*Search Results within this Collection.*Parent Collections .*Sub Collections.*/m)
+      expect(rendered).to have_text('Parent Collections (1)')
+      expect(rendered).to have_text('Subcollections (1)')
+    end
+  end
+
+  context 'when the rendered collection has a sub-collection' do
+    before do
+      assign(:subcollection_count, 1)
+      assign(:total_parent_collections, 0)
+      assign(:has_collection_search_parameters, true)
+      allow(presenter).to receive(:total_parent_collections).and_return(0)
+    end
+    it 'renders only sub collections' do
+      render
+      # Making sure that we are verifying that the _show_actions.html.erb is rendering
+      expect(rendered).to match(/.*Search Results within this Collection.*Sub Collections.*/m)
+      expect(rendered).not_to have_text('Parent Collections')
+      expect(rendered).to have_text('Subcollections (1)')
+    end
+  end
+end

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
+  let(:parentdocument) do
+    SolrDocument.new(id: 'xyz123z4',
+                     'title_tesim' => ['Make Collections Great Again'],
+                     'rights_tesim' => ["http://creativecommons.org/licenses/by-sa/3.0/us/"])
+  end
+
+  let(:document) do
+    SolrDocument.new(id: 'zyx365z4',
+                     'title_tesim' => ['Make Collections Great Again'],
+                     'rights_tesim' => ["http://creativecommons.org/licenses/by-sa/3.0/us/"],
+                     'member_of_collection_ids_ssim' => ['xyz123z4'])
+  end
+
+  let(:user) { create(:user, groups: 'admin') }
+  let(:ability) { Ability.new(user) }
+  let(:collection) { mock_model(::Collection) }
+  let(:presenter) { Hyrax::CollectionPresenter.new(document, ability) }
+  let(:collection_type) { double }
+  let(:blacklight_config) { CatalogController.new.blacklight_config }
+  let(:blacklight_configuration_context) do
+    Blacklight::Configuration::Context.new(controller)
+  end
+
+  before do
+    user = stub_model(User)
+    allow(document).to receive(:hydra_model).and_return(::Collection)
+    allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:can?).with(:edit, document).and_return(true)
+    allow(view).to receive(:can?).with(:destroy, document).and_return(true)
+    allow(view).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:current_user).and_return(user)
+
+    allow(Collection).to receive(:find).with(document.id).and_return(collection)
+
+    allow(presenter).to receive(:total_items).and_return(0)
+    allow(presenter).to receive(:collection_type).and_return(collection_type)
+    allow(presenter).to receive(:subcollection_count).and_return(0)
+    allow(presenter).to receive(:total_parent_collections).and_return(1)
+    assign(:collection_type_is_nestable, true)
+    assign(:subcollection_count, 1)
+    assign(:total_parent_collections, 1)
+    assign(:parent_collection_count, 1)
+    assign(:members_count, 1)
+
+    allow(collection_type).to receive(:nestable?).and_return(true)
+    allow(collection_type).to receive(:title).and_return("User Collection")
+    allow(collection_type).to receive(:badge_color).and_return("#ffa510")
+
+    assign(:presenter, presenter)
+    # Stub route because view specs don't handle engine routes
+    allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+    allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
+    allow(view).to receive(:edit_dashboard_collection_path).and_return("/dashboard/collection/123/edit")
+    allow(view).to receive(:dashboard_collection_path).and_return("/dashboard/collection/123")
+    allow(view).to receive(:collection_path).and_return("/collection/123")
+
+    stub_template 'hyrax/collections/_search_form.html.erb' => 'search form'
+    stub_template 'hyrax/dashboard/collections/_sort_and_per_page.html.erb' => 'sort and per page'
+    stub_template '_document_list.html.erb' => 'document list'
+    # This is tested ./spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
+    stub_template '_show_actions.html.erb' => '<div class="stubbed-actions">THE COLLECTION ACTIONS</div>'
+    stub_template '_show_subcollection_actions.html.erb' => '<div class="stubbed-actions">THE SUBCOLLECTION ACTIONS</div>'
+    stub_template '_show_add_items_actions.html.erb' => '<div class="stubbed-actions">THE ADD ITEMS ACTIONS</div>'
+    stub_template 'hyrax/dashboard/collections/_show_parent_collections.html.erb' => '<div class="stubbed-actions">Parent Collections</div>'
+    stub_template '_subcollection_list.html.erb' => '<div class="stubbed-actions">Sub Collections</div>'
+    stub_template 'hyrax/collections/_paginate.html.erb' => 'paginate'
+    stub_template 'hyrax/collections/_media_display.html.erb' => '<span class="fa fa-cubes collection-icon-search"></span>'
+    stub_template 'hyrax/my/collections/_modal_add_to_collection.html.erb' => 'modal add as subcollection'
+    stub_template 'hyrax/my/collections/_modal_add_subcollection.html.erb' => 'modal add as parent'
+  end
+
+  context 'when the rendered collection has parent collection' do
+    it 'renders parent followed by sub collections' do
+      render
+      # Making sure that we are verifying that the _show_actions.html.erb is rendering
+      expect(rendered).to match(/.*Search Results within this Collection.*Parent Collections .*Sub Collections.*/m)
+      expect(rendered).to have_text('Parent Collections (1)')
+      expect(rendered).to have_text('Subcollections (1)')
+    end
+  end
+
+  context 'when the rendered collection has a sub-collection' do
+    before do
+      assign(:subcollection_count, 1)
+      assign(:total_parent_collections, 0)
+      allow(presenter).to receive(:total_parent_collections).and_return(0)
+    end
+    it 'renders only sub collections' do
+      render
+      # Making sure that we are verifying that the _show_actions.html.erb is rendering
+      expect(rendered).not_to match(/.*Search Results within this Collection.*Parent Collections .*Sub Collections.*/m)
+      expect(rendered).to match(/.*Search Results within this Collection.*Sub Collections.*/m)
+      expect(rendered).not_to have_text('Parent Collections')
+      expect(rendered).to have_text('Subcollections (1)')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #807 

- Re-organizes the "Parent Collection" information to be displayed after the search form. (If Parent Collection exists). 
- The re-organized structure is as follows:
            - Search Form
            - Parent Collection
            - Sub Collection
            - Works