### PR TITLE
Hide Relationship if empty

### DIFF
--- a/app/views/hyrax/base/_parent_relationship_table.html.erb
+++ b/app/views/hyrax/base/_parent_relationship_table.html.erb
@@ -1,5 +1,5 @@
 <% parent_solr_docs = ParentQueryService.query_parents_for_id(child_id) %>
-
+<h2><%= t('hyrax.base.relationships.label') unless parent_solr_docs.blank? %></h2>
 <dt> <%= t('hyrax.relationships_parent_row.label') unless parent_solr_docs.blank? %> </dt>
   <dd>
     <ul class="tabular">
@@ -8,6 +8,6 @@
           <%= link_to item["title_tesim"].first, url_for_document(SolrDocument.find(item["id"])) %>
         </li>
       <% end %>
-     <% end %> 
-    </ul>
-  </dd>
+    <% end %> 
+  </ul>
+</dd>

--- a/app/views/hyrax/base/_relationships.html.erb
+++ b/app/views/hyrax/base/_relationships.html.erb
@@ -1,0 +1,3 @@
+<dl class="work-show">
+<%= render 'relationships_parent_rows', presenter: presenter %>
+</dl>

--- a/app/views/hyrax/base/_relationships_parent_rows.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_rows.html.erb
@@ -6,8 +6,10 @@
 <%# [scholar-override] Show parent relationships for child %>
 <%= render 'parent_relationship_table', child_id: presenter.solr_document.id %>
 
-
 <%# Render grouped presenters. Show rows if there are any items of that type %>
+<% if !(presenter.member_of_collection_presenters.empty?) %>
+	<h2><%= t('hyrax.base.relationships.label') %></h2>
+<% end %>
 <% presenter.presenter_types.each do |type| %>
   <% presenter.grouped_presenters(filtered_by: type).each_pair do |_, items| %>
     <%= render 'relationships_parent_row', type: type, items: items, presenter: presenter %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -77,6 +77,8 @@ en:
     relationships_parent_row:
       label: "In Parent Work:"
     base:
+      relationships:
+        label: "Relationships"
       relationships_parent_row:
         label: "In Collection:"
       form_progress:

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -22,7 +22,11 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
                      depositor_tesim: depositor.user_key)
   end
 
-  let(:ability) { double }
+  let(:user) { create(:user, groups: 'admin') }
+  let(:ability) { Ability.new(user) }
+
+  let(:solr_doc) { instance_double(SolrDocument, id: '123', human_readable_type: 'Work', admin_set: nil) }
+  let(:presenter) { Hyrax::WorkShowPresenter.new(solr_doc, ability) }
 
   let(:presenter) do
     Hyrax::WorkShowPresenter.new(work_solr_document, ability, request)
@@ -46,7 +50,31 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
                twitter_handle: 'bot4lib')
   end
 
-  let(:search_state) { instance_double('SearchState', params_for_search: {}) }
+  let(:solr_doc) { instance_double(SolrDocument, id: '123', human_readable_type: 'Work', admin_set: nil) }
+
+  let(:generic_work) do
+    Hyrax::WorkShowPresenter.new(
+      SolrDocument.new(
+        id: '456',
+        has_model_ssim: ['GenericWork'],
+        title_tesim: ['Containing work']
+      ),
+      ability
+    )
+  end
+
+  let(:collection) do
+    Hyrax::CollectionPresenter.new(
+      SolrDocument.new(
+        id: '345',
+        has_model_ssim: ['Collection'],
+        title_tesim: ['Containing collection']
+      ),
+      ability
+    )
+  end
+  let(:blacklight_config) { CatalogController.blacklight_config }
+  let(:search_state) { Hyrax::SearchState.new(params, blacklight_config, controller) }
 
   before do
     allow(presenter).to receive(:workflow).and_return(workflow_presenter)
@@ -62,7 +90,6 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
     allow(view).to receive(:on_the_dashboard?).and_return(false)
     stub_template 'hyrax/base/_show_actions.html.erb' => ''
     stub_template 'hyrax/base/_metadata.html.erb' => ''
-    stub_template 'hyrax/base/_relationships.html.erb' => ''
     stub_template 'hyrax/base/_social_media.html.erb' => ''
     stub_template 'hyrax/base/_citations.html.erb' => ''
     stub_template 'hyrax/base/_items.html.erb' => ''
@@ -105,5 +132,62 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
 
   it "has the correct DOI header" do
     expect(page).to have_text 'Digital Object Identifier (DOI)'
+  end
+
+  context "when no parent collection/works are present" do
+    let(:member_of_collection_presenters) { [] }
+    let(:presenter_types) {["generic_work", "article", "document", "dataset", "image", "medium", "student_work", "etd", "collection"]}
+
+    before do
+      allow(view).to receive(:search_state).and_return(search_state)
+      allow(controller).to receive(:current_user).and_return user
+      allow(view).to receive(:contextual_path).and_return("/collections/456")
+      allow(presenter).to receive(:presenter_types).and_return(presenter_types)
+      allow(presenter).to receive(:member_of_collection_presenters).and_return(member_of_collection_presenters)
+      render 'hyrax/base/relationships', presenter: presenter
+    end
+    it "displays only the work/collection" do
+      expect(rendered).not_to match(/.*Digital Object Identifier (DOI).*Relationships .*/m)
+      expect(page).not_to have_text 'In Collection'
+      expect(page).not_to have_link 'Containing collection'
+      expect(page).not_to have_text 'In Generic work'
+    end
+  end
+
+  context "when collections are present and no parents are present" do
+    let(:member_of_collection_presenters) { [collection] }
+    let(:presenter_types) {["generic_work", "article", "document", "dataset", "image", "medium", "student_work", "etd", "collection"]}
+
+    before do
+      allow(view).to receive(:search_state).and_return(search_state)
+      allow(controller).to receive(:current_user).and_return user
+      allow(view).to receive(:contextual_path).and_return("/collections/456")
+      allow(presenter).to receive(:presenter_types).and_return(presenter_types)
+      allow(presenter).to receive(:member_of_collection_presenters).and_return(member_of_collection_presenters)
+      render 'hyrax/base/relationships', presenter: presenter
+    end
+    it "links to collections" do
+      expect(page).to have_text 'Relationships'
+      expect(page).to have_text 'In Collection'
+      expect(page).to have_link 'Containing collection'
+      expect(page).not_to have_text 'In Generic work'
+    end
+  end
+
+  context "when parents are present and collections are present" do
+    let(:member_of_collection_presenters) { [generic_work, collection] }
+
+    before do
+      allow(view).to receive(:search_state).and_return(search_state)
+      allow(controller).to receive(:current_user).and_return user
+      allow(view).to receive(:contextual_path).and_return("/concern/generic_works/456")
+      allow(presenter).to receive(:member_of_collection_presenters).and_return(member_of_collection_presenters)
+      render 'hyrax/base/relationships', presenter: presenter
+    end
+    it "links to work and collection" do
+      expect(page).to have_text 'Relationships'
+      expect(page).to have_link 'Containing work'
+      expect(page).to have_link 'Containing collection'
+    end
   end
 end


### PR DESCRIPTION
Fixes #805 

- Hides the "Relationships" header if the collection/work doesn't have any parent, sub-collection, child-work. Displays the "Relationships" header if there are any parent/child.

- Specs written only for `show.html.erb_spec.rb`. Since `show.html.erb` file calls `_relationships.html.erb` partial which conditionally calls both `_relationships_parent_rows.html.erb` and `_parent_relationship_table.html.erb`
