### PR TITLE
Hide Relationships if empty

### DIFF
--- a/app/views/hyrax/base/_parent_relationship_table.html.erb
+++ b/app/views/hyrax/base/_parent_relationship_table.html.erb
@@ -1,5 +1,5 @@
 <% parent_solr_docs = ParentQueryService.query_parents_for_id(child_id) %>
-
+<h2><%= t('hyrax.base.relationships.label') unless parent_solr_docs.blank? %></h2>
 <dt> <%= t('hyrax.relationships_parent_row.label') unless parent_solr_docs.blank? %> </dt>
   <dd>
     <ul class="tabular">
@@ -8,6 +8,6 @@
           <%= link_to item["title_tesim"].first, url_for_document(SolrDocument.find(item["id"])) %>
         </li>
       <% end %>
-     <% end %> 
-    </ul>
-  </dd>
+    <% end %> 
+  </ul>
+</dd>

--- a/app/views/hyrax/base/_relationships.html.erb
+++ b/app/views/hyrax/base/_relationships.html.erb
@@ -1,0 +1,3 @@
+<dl class="work-show">
+<%= render 'relationships_parent_rows', presenter: presenter %>
+</dl>

--- a/app/views/hyrax/base/_relationships.html.erb
+++ b/app/views/hyrax/base/_relationships.html.erb
@@ -1,3 +1,3 @@
 <dl class="work-show">
-<%= render 'relationships_parent_rows', presenter: presenter %>
+<%= render 'relationships_parent_rows', presenter: presenter, child_id: presenter.solr_document.id %>
 </dl>

--- a/app/views/hyrax/base/_relationships_parent_rows.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_rows.html.erb
@@ -1,3 +1,4 @@
+<% parent_solr_docs = ParentQueryService.query_parents_for_id(child_id) %>
 <%# Render presenters which aren't specified in the 'presenter_types' %>
 <% presenter.grouped_presenters(except: presenter.presenter_types).each_pair do |model_name, items| %>
   <%= render 'relationships_parent_row', type: model_name, items: items, presenter: presenter %>
@@ -7,7 +8,7 @@
 <%= render 'parent_relationship_table', child_id: presenter.solr_document.id %>
 
 <%# Render grouped presenters. Show rows if there are any items of that type %>
-<% if !(presenter.member_of_collection_presenters.empty?) %>
+<% if !(presenter.member_of_collection_presenters.empty?) && parent_solr_docs.blank? %>
 	<h2><%= t('hyrax.base.relationships.label') %></h2>
 <% end %>
 <% presenter.presenter_types.each do |type| %>

--- a/app/views/hyrax/base/_relationships_parent_rows.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_rows.html.erb
@@ -6,8 +6,10 @@
 <%# [scholar-override] Show parent relationships for child %>
 <%= render 'parent_relationship_table', child_id: presenter.solr_document.id %>
 
-
 <%# Render grouped presenters. Show rows if there are any items of that type %>
+<% if !(presenter.member_of_collection_presenters.empty?) %>
+	<h2><%= t('hyrax.base.relationships.label') %></h2>
+<% end %>
 <% presenter.presenter_types.each do |type| %>
   <% presenter.grouped_presenters(filtered_by: type).each_pair do |_, items| %>
     <%= render 'relationships_parent_row', type: type, items: items, presenter: presenter %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -77,6 +77,8 @@ en:
     relationships_parent_row:
       label: "In Parent Work:"
     base:
+      relationships:
+        label: "Relationships"
       relationships_parent_row:
         label: "In Collection:"
       form_progress:

--- a/spec/features/hyrax/batch_edit_spec.rb
+++ b/spec/features/hyrax/batch_edit_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
       # Set visibility to private
       within "#form_permissions_visibility" do
         batch_edit_expand('permissions_visibility')
+        find('#expand_link_permissions_visibility').click
         find('#generic_work_visibility_authenticated').click
         find('#permissions_visibility_save').click
         # This was `expect(page).to have_content 'Changes Saved'`, however in debugging,


### PR DESCRIPTION
Fixes #805  

- Hides the "Relationships" header if the collection/work doesn't have any parent, sub-collection, child-work. Displays the "Relationships" header if there are any parent/child.

- Specs written only for `show.html.erb_spec.rb`. Since `show.html.erb` file calls `_relationships.html.erb` partial which conditionally calls both `_relationships_parent_rows.html.erb` and `_parent_relationship_table.html.erb`