### PR TITLE
Add fixity_check queue to sidekiq

### DIFF
--- a/script/restart_sidekiq.sh
+++ b/script/restart_sidekiq.sh
@@ -42,4 +42,4 @@ if [[ -z "${FITS_HOME}" ]]; then
   export PATH=$PATH:/opt/fits/fits
 fi
 cd $APP_DIRECTORY
-bundle exec sidekiq -d -c $THREADS -q ingest -q default -q event -q change -L log/sidekiq.log -C config/sidekiq.yml -e $ENVIRONMENT
+bundle exec sidekiq -d -c $THREADS -q ingest -q default -q event -q change -q fixity_check -L log/sidekiq.log -C config/sidekiq.yml -e $ENVIRONMENT


### PR DESCRIPTION
Fixes #859 

Adds the fixity_check queue to the sidekiq startup script.  This change is already running on production, but has to be committed to our repo.