### PR TITLE
Highlight search terms

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,7 @@ Metrics/MethodLength:
     - 'app/api/**/*'
     - 'spec/api/*'
     - 'app/helpers/api_helper.rb'
+    - 'app/helpers/mark_helper.rb'
 
 Metrics/ClassLength:
   Exclude:
@@ -305,6 +306,7 @@ Metrics/AbcSize:
     - 'app/api/**/*'
     - 'spec/api/*'
     - 'app/helpers/api_helper.rb'
+    - 'app/helpers/mark_helper.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -321,7 +321,12 @@ Lint/HandleExceptions:
     - 'spec/features/doi_validation_spec.rb'
 
 RSpec/SubjectStub:
-  Enabled: false    
+  Enabled: false
+
+RSpec/MessageChain:
+  Exclude:
+    - 'spec/views/catalog/_index_list_default.html.erb_spec.rb'
+    - 'spec/views/catalog/_index_header_list_default.html.erb_spec.rb'  
 
 Lint/RescueException:
   Exclude:
@@ -330,4 +335,5 @@ Lint/RescueException:
 Rails/OutputSafety:
   Exclude:
     - 'app/helpers/hyrax_helper.rb'
+    - 'app/helpers/mark_helper.rb'
     - 'app/renderers/hyrax/renderers/attribute_renderer.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -111,5 +111,5 @@ group :test do
 end
 
 group :production do
-  gem 'clamav'
+  # gem 'clamav'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -111,5 +111,5 @@ group :test do
 end
 
 group :production do
-  # gem 'clamav'
+  gem 'clamav'
 end

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -62,3 +62,7 @@
 .featured-work-fix {
   display: inline-block;
 }
+
+mark {
+  background-color: #ffff00;
+}

--- a/app/helpers/mark_helper.rb
+++ b/app/helpers/mark_helper.rb
@@ -3,14 +3,36 @@
 module MarkHelper
   def catalog(input_text)
     value = input_text.to_s
-    filter_chars = params[:q].to_s.split(' ')
-    if !filter_chars.empty?
-      filter_chars.each do |char|
-        value = value.gsub!(/#{char}/i, '<mark>' + char + '</mark>').to_s
-        value = input_text.to_s if value.empty?
+
+    # Ignore if the value is a hyperlink
+    unless value.include? "a href"
+      # Split the search params
+      search_params = params[:q].to_s.split(' ')
+      # Split each catalog item/text
+      all_text = input_text.to_s.split(' ')
+      count = -1
+      if !search_params.empty?
+        all_text.each do |each_text|
+          count += 1
+          text_downcase = each_text.to_s.downcase
+          search_params.each do |char|
+            search_param = char.to_s.downcase
+            # Check if the catalog item/text has the search param
+            next unless text_downcase.include?(search_param)
+            # Replace the catalog item/text with <mark> tag
+            text_downcase = each_text.gsub!(each_text, '<mark>' + each_text + '</mark>').to_s
+            all_text[count] = if text_downcase.empty?
+                                each_text.to_s
+                              else
+                                text_downcase
+                              end
+          end
+        end
+        # join the splitted catalog item/text with space
+        value = all_text.join(" ")
+      else
+        value = value.to_s
       end
-    else
-      value = value.to_s
     end
 
     value.html_safe

--- a/app/helpers/mark_helper.rb
+++ b/app/helpers/mark_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module MarkHelper
+  def catalog(input_text)
+    value = input_text.to_s
+    filter_chars = params[:q].to_s.split(' ')
+    if !filter_chars.empty?
+      filter_chars.each do |char|
+        value = value.gsub!(/#{char}/i, '<mark>' + char + '</mark>').to_s
+        value = input_text.to_s if value.empty?
+      end
+    else
+      value = value.to_s
+    end
+
+    value.html_safe
+  end
+end

--- a/app/views/catalog/_index_header_list_collection.html.erb
+++ b/app/views/catalog/_index_header_list_collection.html.erb
@@ -1,0 +1,4 @@
+<div class="search-results-title-row">
+  <h4 class="search-result-title"><%= link_to catalog(document.title_or_label), [hyrax, document] %></h4>
+  <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
+</div>

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,0 +1,3 @@
+<div class="search-results-title-row">
+  <h4><%= link_to catalog(document.title_or_label), document %></h4>
+</div>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -2,10 +2,10 @@
   <div class="metadata">
     <dl class="dl-horizontal">
     <% doc_presenter = index_presenter(document) %>
-    <% index_fields(document).each do |field_name, field| -%>
+    <% index_fields(document).each do |field_name, field| %>
       <% if should_render_index_field? document, field %>
-          <dt class="field-label <%= field_name %>"><%= render_index_field_label document, field: field_name %></dt>
-          <dd class="field-text <%= field_name %>"><%= doc_presenter.field_value field %></dd>
+        <dt class="field-label <%= field_name %>"><%= render_index_field_label document, field: field_name %></dt>
+        <dd class="field-text <%= field_name %>"><%= catalog(doc_presenter.field_value field) %></dd>
       <% end %>
     <% end %>
     </dl>

--- a/spec/helpers/mark_helper_spec.rb
+++ b/spec/helpers/mark_helper_spec.rb
@@ -3,17 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe MarkHelper, type: :helper do
-  let(:filter_chars) { ["Make", "test"] }
+  let(:search_params) { ["Make", "test"] }
   let(:input_text) { "Make Collections Great Again" }
-  before do
-    controller.params[:q] = 'Make'
-    allow(filter_chars).to receive(:length) { 2 }
-    ActionController::Parameters.new(q: 'Make test')
+
+  describe '#catalog' do
+    before do
+      controller.params[:q] = 'make'
+      allow(search_params).to receive(:length) { 2 }
+      ActionController::Parameters.new(q: 'Make test')
+    end
+    it "returns expected output" do
+      expect(catalog(input_text.dup)).to include('<mark>Make</mark>')
+    end
   end
 
   describe '#catalog' do
+    before do
+      controller.params[:q] = 'testit'
+      allow(search_params).to receive(:length) { 2 }
+      ActionController::Parameters.new(q: 'Make test')
+    end
     it "returns expected output" do
-      expect(catalog(input_text.dup)).to include('<mark>Make</mark>')
+      expect(catalog(input_text.dup)).not_to include('<mark>')
     end
   end
 end

--- a/spec/helpers/mark_helper_spec.rb
+++ b/spec/helpers/mark_helper_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MarkHelper, type: :helper do
+  let(:filter_chars) { ["Make", "test"] }
+  let(:input_text) { "Make Collections Great Again" }
+  before do
+    controller.params[:q] = 'Make'
+    allow(filter_chars).to receive(:length) { 2 }
+    ActionController::Parameters.new(q: 'Make test')
+  end
+
+  describe '#catalog' do
+    it "returns expected output" do
+      expect(catalog(input_text.dup)).to include('<mark>Make</mark>')
+    end
+  end
+end

--- a/spec/views/catalog/_index_header_list_collection.html.erb_spec.rb
+++ b/spec/views/catalog/_index_header_list_collection.html.erb_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+RSpec.describe 'catalog/_index_header_list_collection', type: :view do
+  let(:id) { '123' }
+  let(:collection) { create(:collection, id: id) }
+  let(:collection_doc) { SolrDocument.new(id: id, has_model_ssim: 'Collection', collection_type_gid_ssim: collection.collection_type_gid) }
+  let(:collection_type) { create(:collection_type) }
+  let(:user_collection_type) { create(:user_collection_type) }
+
+  let(:blacklight_config) { CatalogController.blacklight_config }
+  let(:user) { create(:user, groups: 'admin') }
+  let(:ability) { Ability.new(user) }
+  let(:presenter) { Hyrax::CollectionPresenter.new(collection_doc, ability) }
+  let(:current_ability) { Ability.new(user) }
+
+  let(:blacklight_configuration_context) do
+    Blacklight::Configuration::Context.new(controller)
+  end
+
+  let(:depositor) do
+    stub_model(User,
+               user_key: 'bob',
+               twitter_handle: 'bot4lib')
+  end
+
+  let(:hyrax) { Hyrax::Engine.routes.url_helpers }
+
+  describe 'catalog helper finds the text' do
+    before do
+      allow(view).to receive(:catalog).and_return('<mark>Test</mark>'.html_safe)
+      allow(view).to receive(:current_ability).and_return(ability)
+      allow(view).to receive(:document).and_return(collection_doc)
+      allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
+      allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+      allow(User).to receive(:find_by_user_key).and_return(depositor.user_key)
+      allow(view).to receive(:can?).with(:edit, collection_doc).and_return(true)
+      allow(view).to receive(:can?).with(:destroy, collection_doc).and_return(true)
+      render 'catalog/index_header_list_collection', document: collection_doc
+    end
+    it "displays mark tag" do
+      include MarkHelper
+      expect(rendered).to include('<mark>Test</mark>')
+    end
+  end
+
+  describe 'catalog helper doesnt finds the text' do
+    before do
+      allow(view).to receive(:catalog).and_return('Test'.html_safe)
+      allow(view).to receive(:current_ability).and_return(ability)
+      allow(view).to receive(:document).and_return(collection_doc)
+      allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
+      allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+      allow(User).to receive(:find_by_user_key).and_return(depositor.user_key)
+      allow(view).to receive(:can?).with(:edit, collection_doc).and_return(true)
+      allow(view).to receive(:can?).with(:destroy, collection_doc).and_return(true)
+      render 'catalog/index_header_list_collection', document: collection_doc
+    end
+    it "doesnt displays mark tag" do
+      include MarkHelper
+      expect(rendered).not_to include('<mark>Test</mark>')
+    end
+  end
+end

--- a/spec/views/catalog/_index_header_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_header_list_default.html.erb_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+RSpec.describe 'catalog/_index_header_list_default', type: :view do
+  let(:attributes) do
+    { 'id' => '123',
+      'title_tesim' => 'Test Work',
+      'creator_tesim' => ['Justin', 'Joe'],
+      'depositor_tesim' => ['jcoyne@justincoyne.com'],
+      'proxy_depositor_ssim' => ['atz@stanford.edu'],
+      'description_tesim' => ['This links to http://example.com/ What about that?'],
+      'date_uploaded_dtsi' => '2013-03-14T00:00:00Z',
+      'license_tesim' => ["http://creativecommons.org/publicdomain/zero/1.0/",
+                          "http://creativecommons.org/publicdomain/mark/1.0/",
+                          "http://www.europeana.eu/portal/rights/rr-r.html"],
+      'rights_statement_tesim' => ['http://rightsstatements.org/vocab/InC/1.0/'],
+      'identifier_tesim' => ['65434567654345654'],
+      'keyword_tesim' => ['taco', 'mustache'],
+      'subject_tesim' => ['Awesome'],
+      'contributor_tesim' => ['Bird, Big'],
+      'publisher_tesim' => ['Penguin Random House'],
+      'based_near_label_tesim' => ['Pennsylvania'],
+      'language_tesim' => ['English'],
+      'resource_type_tesim' => ['Capstone Project'],
+      'has_model_ssim' => ['GenericWork'] }
+  end
+
+  let(:document) { SolrDocument.new(attributes) }
+  let(:blacklight_config) { CatalogController.blacklight_config }
+  let(:user) { create(:user, groups: 'admin') }
+  let(:ability) { Ability.new(user) }
+  let(:presenter) { Hyrax::CollectionPresenter.new(document, ability) }
+  let(:current_ability) { Ability.new(user) }
+
+  let(:blacklight_configuration_context) do
+    Blacklight::Configuration::Context.new(controller)
+  end
+
+  let(:depositor) do
+    stub_model(User,
+               user_key: 'bob',
+               twitter_handle: 'bot4lib')
+  end
+
+  describe 'catalog helper finds the text' do
+    before do
+      allow(view).to receive(:catalog).and_return('<mark>Test</mark>'.html_safe)
+      allow(view).to receive(:current_ability).and_return(ability)
+      allow(view).to receive(:document).and_return(document)
+      allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
+      allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+      allow(User).to receive(:find_by_user_key).and_return(depositor.user_key)
+      allow(presenter).to receive(:field_value) { |field| "Test #{field}" }
+      allow(view).to receive(:can?).with(:edit, document).and_return(true)
+      allow(view).to receive(:can?).with(:destroy, document).and_return(true)
+      render 'catalog/index_header_list_default', document: document
+    end
+    it "displays mark tag" do
+      include MarkHelper
+      expect(rendered).to include('<mark>Test</mark>')
+    end
+  end
+
+  describe 'catalog helper doesnt finds the text' do
+    before do
+      allow(view).to receive(:catalog).and_return('Test'.html_safe)
+      allow(view).to receive(:current_ability).and_return(ability)
+      allow(view).to receive(:document).and_return(document)
+      allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
+      allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+      allow(User).to receive(:find_by_user_key).and_return(depositor.user_key)
+      allow(presenter).to receive(:field_value) { |field| "Test #{field}" }
+      allow(view).to receive(:can?).with(:edit, document).and_return(true)
+      allow(view).to receive(:can?).with(:destroy, document).and_return(true)
+      render 'catalog/index_header_list_default', document: document
+    end
+    it "doesnt displays mark tag" do
+      include MarkHelper
+      expect(rendered).not_to include('<mark>Test</mark>')
+    end
+  end
+end

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+RSpec.describe 'catalog/_index_list_default', type: :view do
+  let(:attributes) do
+    { 'id' => '123',
+      'creator_tesim' => ['Justin', 'Joe'],
+      'depositor_tesim' => ['jcoyne@justincoyne.com'],
+      'proxy_depositor_ssim' => ['atz@stanford.edu'],
+      'description_tesim' => ['This links to http://example.com/ What about that?'],
+      'date_uploaded_dtsi' => '2013-03-14T00:00:00Z',
+      'license_tesim' => ["http://creativecommons.org/publicdomain/zero/1.0/",
+                          "http://creativecommons.org/publicdomain/mark/1.0/",
+                          "http://www.europeana.eu/portal/rights/rr-r.html"],
+      'rights_statement_tesim' => ['http://rightsstatements.org/vocab/InC/1.0/'],
+      'identifier_tesim' => ['65434567654345654'],
+      'keyword_tesim' => ['taco', 'mustache'],
+      'subject_tesim' => ['Awesome'],
+      'contributor_tesim' => ['Bird, Big'],
+      'publisher_tesim' => ['Penguin Random House'],
+      'based_near_label_tesim' => ['Pennsylvania'],
+      'language_tesim' => ['English'],
+      'resource_type_tesim' => ['Capstone Project'] }
+  end
+
+  let(:document) { SolrDocument.new(attributes) }
+  let(:blacklight_config) { CatalogController.blacklight_config }
+  let(:user) { create(:user, groups: 'admin') }
+  let(:ability) { Ability.new(user) }
+  let(:presenter) { Hyrax::CollectionPresenter.new(document, ability) }
+  let(:current_ability) { Ability.new(user) }
+
+  let(:blacklight_configuration_context) do
+    Blacklight::Configuration::Context.new(controller)
+  end
+
+  let(:depositor) do
+    stub_model(User,
+               user_key: 'bob',
+               twitter_handle: 'bot4lib')
+  end
+
+  describe 'catalog helper finds the text' do
+    before do
+      view.stub_chain(:can_create_any_work?, :should_render_index_field?).and_return(true)
+      allow(view).to receive(:current_ability).and_return(ability)
+      allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
+      allow(view).to receive(:evaluate_if_unless_configuration).and_return(true)
+      allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+      allow(User).to receive(:find_by_user_key).and_return(depositor.user_key)
+      allow(view).to receive(:index_presenter).and_return(presenter)
+      allow(presenter).to receive(:field_value) { |field| "Test #{field}" }
+      allow(document).to receive(:collection?).and_return(true)
+      allow(view).to receive(:index_fields).and_return(blacklight_config.index_fields)
+      allow(view).to receive(:collection_presenter).and_return(presenter)
+      allow(view).to receive(:can?).with(:edit, document).and_return(true)
+      allow(view).to receive(:catalog).and_return('<mark>Test</mark>'.html_safe)
+      allow(view).to receive(:should_render_index_field?).and_return(true)
+      allow(view).to receive(:can?).with(:destroy, document).and_return(true)
+      render 'catalog/index_list_default', document: document
+    end
+    it "displays mark tag" do
+      include MarkHelper
+      expect(rendered).to include('<mark>Test</mark>')
+    end
+  end
+
+  describe 'catalog helper doesnt finds the text' do
+    before do
+      view.stub_chain(:can_create_any_work?, :should_render_index_field?).and_return(true)
+      allow(view).to receive(:current_ability).and_return(ability)
+      allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
+      allow(view).to receive(:evaluate_if_unless_configuration).and_return(true)
+      allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+      allow(User).to receive(:find_by_user_key).and_return(depositor.user_key)
+      allow(view).to receive(:index_presenter).and_return(presenter)
+      allow(presenter).to receive(:field_value) { |field| "Test #{field}" }
+      allow(document).to receive(:collection?).and_return(true)
+      allow(view).to receive(:index_fields).and_return(blacklight_config.index_fields)
+      allow(view).to receive(:collection_presenter).and_return(presenter)
+      allow(view).to receive(:can?).with(:edit, document).and_return(true)
+      allow(view).to receive(:catalog).and_return('Test'.html_safe)
+      allow(view).to receive(:should_render_index_field?).and_return(true)
+      allow(view).to receive(:can?).with(:destroy, document).and_return(true)
+      render 'catalog/index_list_default', document: document
+    end
+    it "doesnt displays mark tag" do
+      include MarkHelper
+      expect(rendered).not_to include('<mark>Test</mark>')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #705

- Includes a `<mark></mark>` tag around the search params.
