### PR TITLE
Updates sidekiq restart script.

### DIFF
--- a/script/restart_sidekiq.sh
+++ b/script/restart_sidekiq.sh
@@ -42,4 +42,4 @@ if [[ -z "${FITS_HOME}" ]]; then
   export PATH=$PATH:/opt/fits/fits
 fi
 cd $APP_DIRECTORY
-bundle exec sidekiq -d -c $THREADS -q ingest -q default -q event -q change -q fixity_check -L log/sidekiq.log -C config/sidekiq.yml -e $ENVIRONMENT
+bundle exec sidekiq -d -c $THREADS -q ingest -q default -q event -q change -q import -q export -q fixity_check -L log/sidekiq.log -C config/sidekiq.yml -e $ENVIRONMENT


### PR DESCRIPTION
Present short summary (50 characters or less)

This is part of the BulkRAX installation.  Even though we have these queues in the config file, we did not designate them in the restart script that Capistrano uses.  This PR will add them to the restart script.
