### PR TITLE
Adds Uglifier parser for Capistrano deploy fix.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,8 +21,11 @@ Rails.application.configure do
   config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
+
+  # Change the Uglifier parsing engine
+  config.assets.js_compressor = Uglifier.new(harmony: true)
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
This fix is needed to allow Capistrano to pre-compile assets through the uglifier parser.

This was discovered when testing the cap qa deploy. 