### PR TITLE
Updates FAQ for max size.

### DIFF
--- a/app/views/static/faq.html.erb
+++ b/app/views/static/faq.html.erb
@@ -10,7 +10,7 @@
       <li><a href="#faq_4321">How can I share access to selected works with a group of collaborators?</a></li>
       <li><a href="#faq_8765">How do I upload an access file? </a></li>
       <li><a href="#faq_1346">How do I upload a preservation file? </a></li>
-      <li><a href="#faq_4679">I'm having trouble uploading a file over 200 MB; what should I do?</a></li>
+      <li><a href="#faq_4679">I'm having trouble uploading a file over 3.0 GB; what should I do?</a></li>
       <li><a href="#faq_7946">May I publish, contribute, or otherwise distribute my content elsewhere?</a></li>
       <li><a href="#faq_1379">What file formats should I use when uploading to <%=t('hyrax.product_name') %>?</a></li>
       <li><a href="#faq_7913">What happens to my works if I delete them?</a></li>
@@ -67,11 +67,11 @@
     </blockquote>
 
     <p><a name="faq_4679" id="faq_4679"></a>
-      I'm having trouble uploading a file over 200 MB; what should I do?
+      I'm having trouble uploading a file over 3.0 GB; what should I do?
     </p>
 
     <blockquote>
-      We recommend that you use the <%= link_to 'contact form', hyrax.contact_path %> for assistance with files larger than 200 MB, but if you have trouble uploading any file, please use the <%= link_to 'contact form', hyrax.contact_path %> for assistance.
+      We recommend that you use the <%= link_to 'contact form', hyrax.contact_path %> for assistance with files larger than 3.0 GB, but if you have trouble uploading any file, please use the <%= link_to 'contact form', hyrax.contact_path %> for assistance.
     </blockquote>
 
 


### PR DESCRIPTION
Fixes #884 

Set the maximum file size to 3.0 GB in the FAQ.  

There were 3 instances.