### PR TITLE
add clamby functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,5 +115,5 @@ group :test do
 end
 
 group :production do
-  #  gem 'clamav'
+  #  gem 'clamby'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -115,5 +115,5 @@ group :test do
 end
 
 group :production do
-  #  gem 'clamby'
+  gem 'clamby'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,6 +252,7 @@ GEM
       mime-types (>= 1.16)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    clamby (1.6.6)
     clipboard-rails (1.7.1)
     coderay (1.1.3)
     coercible (1.0.0)
@@ -1066,6 +1067,7 @@ DEPENDENCIES
   capybara (~> 2.4, < 2.18.0)
   capybara-maleficent (~> 0.2)
   change_manager!
+  clamby
   coffee-rails (~> 4.2)
   coveralls (~> 0.8.22)
   database_cleaner

--- a/app/models/hyrax/virus_scanner.rb
+++ b/app/models/hyrax/virus_scanner.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# The default virus scanner for Hydra::Works
+# If ClamAV is present, it will be used to check for the presence of a virus. If ClamAV is not
+# installed or otherwise not available to your application, Hydra::Works does no virus checking
+# add assumes files have no viruses.
+#
+# To use a virus checker other than ClamAV:
+#   class MyScanner < Hydra::Works::VirusScanner
+#     def infected?
+#       my_result = Scanner.check_for_viruses(file)
+#       [return true or false]
+#     end
+#   end
+#
+# Then set Hydra::Works to use your scanner either in a config file or initializer:
+#   Hydra::Works.default_system_virus_scanner = MyScanner
+module Hyrax
+  class VirusScanner < Hydra::Works::VirusScanner
+    attr_reader :file
+
+    # @api public
+    # @param file [String]
+    def self.infected?(file)
+      new(file).infected?
+    end
+
+    def initialize(file)
+      @file = file
+    end
+
+    # Override this method to use your own virus checking software
+    # @return [Boolean]
+    def infected?
+      if defined?(Clamby)
+        clamby_scanner
+      elsif defined?(ClamAV)
+        clam_av_scanner
+      else
+        null_scanner
+      end
+    end
+
+    def clam_av_scanner
+      Deprecation.warn(self, "The ClamAV has been replaced by Clamby " \
+        "as the supported virus scanner for hydra-works. " \
+        "ClamAV support will be removed in hydra-works 2.0 ")
+      scan_result = ClamAV.instance.method(:scanfile).call(file)
+      return false if scan_result.zero?
+      warning "A virus was found in #{file}: #{scan_result}"
+      true
+    end
+
+    # @return [Boolean]
+    def clamby_scanner
+      scan_result = Clamby.virus?(file)
+      warning("A virus was found in #{file}") if scan_result
+      scan_result
+    end
+
+    # Always return zero if there's nothing available to check for viruses. This means that
+    # we assume all files have no viruses because we can't conclusively say if they have or not.
+    def null_scanner
+      warning "Unable to check #{file} for viruses because no virus scanner is defined"
+      false
+    end
+
+    private
+
+      def warning(msg)
+        ActiveFedora::Base.logger&.warn(msg)
+      end
+  end
+end

--- a/config/initializers/clamav.rb
+++ b/config/initializers/clamav.rb
@@ -1,3 +1,15 @@
 # frozen_string_literal: true
 
-ClamAV.instance.loaddb if defined? ClamAV
+# Set local VirusScanner
+Hydra::Works.default_system_virus_scanner = Hyrax::VirusScanner
+
+if defined?(Clamby)
+  Clamby.configure(
+    check: false,
+    # daemonize: true,
+    output_level: 'medium',
+    fdpass: true
+  )
+elsif defined?(ClamAV)
+  ClamAV.instance.loaddb if defined? ClamAV
+end

--- a/spec/models/hyrax/virus_scanner_spec.rb
+++ b/spec/models/hyrax/virus_scanner_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::VirusScanner do
+  let(:file)   { '/tmp/path' }
+  let(:logger) { Logger.new(nil) }
+
+  before { allow(Hyrax).to receive(:logger).and_return(logger) }
+
+  subject { described_class.new(file) }
+
+  context 'when ClamAV is defined' do
+    before do
+      hide_const('Clamby')
+
+      class ClamAV
+        def self.instance
+          @instance ||= ClamAV.new
+        end
+
+        def scanfile(path)
+          puts "scanfile: #{path}"
+        end
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :ClamAV)
+    end
+
+    context 'with a clean file' do
+      before { allow(ClamAV.instance).to receive(:scanfile).with('/tmp/path').and_return(0) }
+      it 'returns false with no warning' do
+        expect(ActiveFedora::Base.logger).not_to receive(:warn)
+        is_expected.not_to be_infected
+      end
+    end
+
+    context 'with an infected file' do
+      before { allow(ClamAV.instance).to receive(:scanfile).with('/tmp/path').and_return(1) }
+      it 'returns true with a warning' do
+        expect(ActiveFedora::Base.logger).to receive(:warn).with(kind_of(String))
+        is_expected.to be_infected
+      end
+    end
+  end
+
+  context 'when ClamAV is not defined' do
+    before do
+      hide_const('Clamby')
+    end
+
+    it 'returns false with a warning' do
+      expect(ActiveFedora::Base.logger).to receive(:warn).with(kind_of(String))
+      is_expected.not_to be_infected
+    end
+  end
+
+  context 'when Clamby is defined' do
+    before do
+      class Clamby
+        def self.virus?(path)
+          puts "scanfile: #{path}"
+        end
+      end
+    end
+    after do
+      Object.send(:remove_const, :Clamby)
+    end
+    context 'with a clean file' do
+      before { allow(Clamby).to receive(:virus?).with('/tmp/path').and_return(false) }
+      it 'returns false' do
+        expect(ActiveFedora::Base.logger).not_to receive(:warn)
+        is_expected.not_to be_infected
+      end
+    end
+    context 'with an infected file' do
+      before { allow(Clamby).to receive(:virus?).with('/tmp/path').and_return(true) }
+      it 'returns true' do
+        expect(ActiveFedora::Base.logger).to receive(:warn).with(kind_of(String))
+        is_expected.to be_infected
+      end
+    end
+  end
+
+  context 'when Clamby is not defined' do
+    before { Object.send(:remove_const, :Clamby) if defined?(Clamby) }
+
+    it 'returns false' do
+      expect(ActiveFedora::Base.logger).to receive(:warn).with(kind_of(String))
+      is_expected.not_to be_infected
+    end
+  end
+end


### PR DESCRIPTION
Fixes #901 

Abandoned [clamav gem](https://github.com/eagleas/clamav) is now failing to bundle with current version of clamav. Add `virus_scanner` override to use [clamby](https://github.com/kobaltz/clamby)

Changes proposed in this pull request:
* Add Hyrax::VirusScanner with support for either clamav or clamby scanners
* Add config to set local virus_scanner as virus scanner service 
