### PR TITLE
Log Format and Tracing Changes for Scholar

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -7,3 +7,4 @@ collection:
   dir: solr/config/
   name: hydra-development
 version: 7.6.0
+mirror_url: https://archive.apache.org/dist/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,8 @@ class ApplicationController < ActionController::Base
   with_themed_layout '1_column'
   protect_from_forgery with: :exception
 
+  around_action :add_tracing_and_logging_metadata
+
   private
 
   # override devise helper and route to CC.new when parameter is set
@@ -42,9 +44,8 @@ class ApplicationController < ActionController::Base
     redirect_to login_path unless user_signed_in?
   end
 
-  around_action :add_tracing_and_logging_metadata
-
   def add_tracing_and_logging_metadata
+    XRay.recorder.annotations[:user_id] = current_user.try(:id) || 0
     XRay.recorder.current_segment.user = current_user.try(:id) || 0
 
     logger.tagged("CU: #{current_user.try(:id) || 'UnauthenticatedUser'}") do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,6 +47,7 @@ class ApplicationController < ActionController::Base
   def add_tracing_and_logging_metadata
     XRay.recorder.annotations[:user_id] = current_user.try(:id) || 0
     XRay.recorder.current_segment.user = current_user.try(:id) || 0
+    XRay.recorder.metadata[:rails_request_id] = request.request_id || 0
 
     logger.tagged("CU: #{current_user.try(:id) || 'UnauthenticatedUser'}") do
       yield

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,11 +47,10 @@ class ApplicationController < ActionController::Base
   def add_tracing_and_logging_metadata
     XRay.recorder.annotations[:user_id] = current_user.try(:id) || 0
     XRay.recorder.current_segment.user = current_user.try(:id) || 0
-    XRay.recorder.metadata[:rails_request_id] = request.request_id || 0
+    XRay.recorder.annotations[:rails_request_id] = request.request_id || 0
 
     logger.tagged("CU: #{current_user.try(:id) || 'UnauthenticatedUser'}") do
       yield
     end
   end
-
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -4,20 +4,34 @@ require 'aws-xray-sdk'
 
 class ApplicationJob < ActiveJob::Base
 
-  after_enqueue do |job|
+  def serialize
+    super.merge('parent_trace_id' => @parent_trace_id || XRay.recorder.current_segment.trace_id)
+  end
+
+  def deserialize(job_data)
+    super(job_data)
+    @parent_trace_id = job_data['parent_trace_id']
+  end
+
+  around_enqueue do |job, block|
+    Rails.logger.info "#{Time.current}: Enqueuing job: #{self.class.name}: #{job.inspect}"
+    XRay.recorder.capture("job_enqueue::#{self.class.name}") do |subsegment|
+      subsegment.metadata.update job_info: job.inspect
+      subsegment.annotations.update job_id: job.job_id
+      subsegment.annotations.update provider_job_id: job.provider_job_id
+      block.call
+    end
     Rails.logger.info "#{Time.current}: Enqueued job: #{self.class.name}: #{job.inspect}"
   end
 
   around_perform do |job, block|
     Rails.logger.info "#{Time.current}: Beginning execution of the job: #{job.inspect}"
     # Create XRay Segment before perform
-    subsegment = XRay.recorder.begin_segment("sidekiq::#{self.class.name}")
+    # subsegment = XRay.recorder.begin_segment("sidekiq::#{self.class.name}")
+    subsegment = XRay.recorder.begin_segment("sidekiq::#{self.class.name}", parent_id: @parent_trace_id || nil )
     subsegment.annotations.update context: 'sidekiq'
     subsegment.annotations.update job_id: job.job_id
     subsegment.annotations.update provider_job_id: job.provider_job_id
-    job.attributes.each { |k,v|
-      subsegment.metadata.update "job_info_#{k}": v
-    }
     subsegment.metadata.update job_info: job.inspect
     # yield
     block.call

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,28 @@
 # frozen_string_literal: true
 
+require 'aws-xray-sdk'
+
 class ApplicationJob < ActiveJob::Base
+
+  after_enqueue do |job|
+    Rails.logger.info "#{Time.current}: Enqueued job: #{self.class.name}: #{job.inspect}"
+  end
+
+  around_perform do |job, block|
+    Rails.logger.info "#{Time.current}: Beginning execution of the job: #{job.inspect}"
+    # Create XRay Segment before perform
+    subsegment = XRay.recorder.begin_segment("sidekiq::#{self.class.name}")
+    subsegment.annotations.update context: 'sidekiq'
+    subsegment.annotations.update job_id: job.job_id
+    subsegment.annotations.update provider_job_id: job.provider_job_id
+    job.attributes.each { |k,v|
+      subsegment.metadata.update "job_info_#{k}": v
+    }
+    subsegment.metadata.update job_info: job.inspect
+    # yield
+    block.call
+    # Destroy XRay Segment after perform
+    XRay.recorder.end_segment
+    Rails.logger.info "#{Time.current}: finished execution of the job: #{job.inspect}"
+  end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -29,7 +29,7 @@ class ApplicationJob < ActiveJob::Base
     seg_name = ENV.fetch("AWS_XRAY_TRACING_NAME", "")
     subsegment = XRay.recorder.begin_segment("#{seg_name}::sidekiq::#{self.class.name}")
     subsegment.annotations.update context: 'sidekiq'
-    subsegment.annotations.update job_class:"sidekiq::#{self.class.name}"
+    subsegment.annotations.update job_class: "sidekiq::#{self.class.name}"
     subsegment.annotations.update job_parent_id: @parent_trace_id.to_s
     subsegment.annotations.update job_id: job.job_id
     subsegment.annotations.update provider_job_id: job.provider_job_id

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module ScholarUc
 
     # Logging Configuration
     # Prepend all log lines with the following tags.
-    config.log_tags = [:request_id, :user_agent, :subdomain, :remote_ip, lambda { |request| request.headers["X-Forwarded-For"] || "No-X-Forwarded-For-Header" }]
+    config.log_tags = [:request_id, :user_agent, :subdomain, :remote_ip, lambda { |request| request.headers["X-Forwarded-For"] || "No-X-Forwarded-For-Header" }, lambda { |request| request.cookie_jar["_scholar_uc_session"] }]
     config.log_level = :debug
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'aws-xray-sdk'
 
 require_relative 'boot'
 
@@ -23,7 +24,7 @@ module ScholarUc
 
     # Logging Configuration
     # Prepend all log lines with the following tags.
-    config.log_tags = [:request_id, :user_agent, :subdomain, :remote_ip, lambda { |request| request.headers["X-Forwarded-For"] || "No-X-Forwarded-For-Header" }, lambda { |request| request.cookie_jar["_scholar_uc_session"] }]
+    config.log_tags = [:request_id, proc { XRay.recorder.current_segment.trace_id || "No-XRay-Trace-ID" }, :user_agent, :subdomain, :remote_ip, ->(request) { request.headers["X-Forwarded-For"] || "No-X-Forwarded-For-Header" }]
     config.log_level = :debug
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,10 @@ module ScholarUc
     config.time_zone = "Eastern Time (US & Canada)"
     config.paths.add File.join('app', 'api'), glob: File.join('**', '*.rb')
     config.autoload_paths += Dir[Rails.root.join('app', 'api', '*')]
+
+    # Logging Configuration
+    # Prepend all log lines with the following tags.
+    config.log_tags = [:request_id, :user_agent, :subdomain, :remote_ip, lambda { |request| request.headers["X-Forwarded-For"] || "No-X-Forwarded-For-Header" }]
+    config.log_level = :debug
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,9 +51,6 @@ Rails.application.configure do
   # when problems arise.
   config.log_level = :debug
 
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id, :user_agent, :subdomain, :remote_ip, lambda { |request| request.headers["X-Forwarded-For"] }]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
+  config.log_tags = [:request_id, :user_agent, :subdomain, :remote_ip, lambda { |request| request.headers["X-Forwarded-For"] }]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/initializers/aws_xray.rb
+++ b/config/initializers/aws_xray.rb
@@ -9,4 +9,5 @@ Rails.application.config.xray = {
   # Only the latest rotated log will be retained. That is, the max possible size on disk of log files,
   # if `SCHOLAR_XRAY_MAX_LOG_SIZE` is set to 10, would be 10MB(for the actual log) + 10MB(for the latest rotated log).
   logger: Logger.new("log/#{Rails.env}-xray.log", 1, Integer(ENV.fetch("SCHOLAR_XRAY_MAX_LOG_SIZE", "10"), 10).megabytes)
+  stream_threshold: 1,
 }

--- a/config/initializers/aws_xray.rb
+++ b/config/initializers/aws_xray.rb
@@ -8,6 +8,6 @@ Rails.application.config.xray = {
   # Makes sure the log file size does not go beyond a size, beyond which it is rotated.
   # Only the latest rotated log will be retained. That is, the max possible size on disk of log files,
   # if `SCHOLAR_XRAY_MAX_LOG_SIZE` is set to 10, would be 10MB(for the actual log) + 10MB(for the latest rotated log).
-  logger: Logger.new("log/#{Rails.env}-xray.log", 1, Integer(ENV.fetch("SCHOLAR_XRAY_MAX_LOG_SIZE", "10"), 10).megabytes)
-  stream_threshold: 1,
+  logger: Logger.new("log/#{Rails.env}-xray.log", 1, Integer(ENV.fetch("SCHOLAR_XRAY_MAX_LOG_SIZE", "10"), 10).megabytes),
+  stream_threshold: 1
 }


### PR DESCRIPTION
Fixes #issuenumber ; refs #issuenumber

Create a log format that is easy to parse(using CloudWatch expressions), these logs should also have the necessary context/metadata to categorise or group log lines based on HTTP request ID, on Client IP, on User ID, User Agent etc. This would give us more visibility into errors, for example gathering all lines of logs that originated from the same request or same Client IP address can give a us a greater understanding what went wrong.

Here is an example of method in `ApplicationController` which adds a the Current User's ID to the log as a tag and to the XRay Traces.
``` ruby
around_action :add_tracing_and_logging_metadata

  def add_tracing_and_logging_metadata
    XRay.recorder.current_segment.user = current_user.try(:id) || 0

    logger.tagged("CU: #{current_user.try(:id) || 'UnauthenticatedUser'}") do
      yield
    end
  end
```

Example Log snippets, when an user uses Scholar without logging in:
```
I, [2021-05-14T10:53:34.930424 #9076]  INFO -- : [787097bb-8069-4a86-9c29-325c583ad571] [Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15] [rails-scholar] [127.0.0.1] [192.168.33.1] [CU: UnauthenticatedUser]   Rendering hyrax/homepage/index.html.erb within layouts/homepage
I, [2021-05-14T10:53:34.941341 #9076]  INFO -- : [787097bb-8069-4a86-9c29-325c583ad571] [Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15] [rails-scholar] [127.0.0.1] [192.168.33.1] [CU: UnauthenticatedUser]   Rendered /home.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/hyrax-2.9.4/app/views/_flash_msg.html.erb (0.5ms)
I, [2021-05-14T10:53:34.947516 #9076]  INFO -- : [787097bb-8069-4a86-9c29-325c583ad571] [Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15] [rails-scholar] [127.0.0.1] [192.168.33.1] [CU: UnauthenticatedUser]   Rendered layouts/scholar/_scholar_headline.html.erb (0.8ms)
I, [2021-05-14T10:53:34.961606 #9076]  INFO -- : [787097bb-8069-4a86-9c29-325c583ad571] [Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15] [rails-scholar] [127.0.0.1] [192.168.33.1] [CU: UnauthenticatedUser]   Rendered hyrax/homepage/_featured_researcher.html.erb (0.5ms)
I, [2021-05-14T10:53:34.970927 #9076]  INFO -- : [787097bb-8069-4a86-9c29-325c583ad571] [Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15] [rails-scholar] [127.0.0.1] [192.168.33.1] [CU: UnauthenticatedUser]   Rendered hyrax/homepage/_featured_collections.html.erb (2.6ms)
I, [2021-05-14T10:53:34.981412 #9076]  INFO -- : [787097bb-8069-4a86-9c29-325c583ad571] [Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15] [rails-scholar] [127.0.0.1] [192.168.33.1] [CU: UnauthenticatedUser]   Rendered hyrax/homepage/_featured_works.html.erb (3.0ms)
I, [2021-05-14T10:53:34.981712 #9076]  INFO -- : [787097bb-8069-4a86-9c29-325c583ad571] [Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15] [rails-scholar] [127.0.0.1] [192.168.33.1] [CU: UnauthenticatedUser]   Rendered hyrax/homepage/_home_content.html.erb (27.2ms)
```

Changes proposed in this pull request:
* Added a new Log tags, which add some necessary context to each line of log.
  * These include things like a HTTP request ID, Client IP etc.
* Added Current User ID to XRay Traces.
* The default mirror url in the Solr Wrapper seems to be broken, replaced that with an alternate mirror url hosted by Apache Org.
