### PR TITLE
XRay log continues to grow.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -76,3 +76,6 @@ SCHOLAR_DOI_URL=https://api.test.datacite.org/dois
 
 # API
 API_KEY={ :development => 'scholarDEV' }
+
+# XRay max log size in MB, must be an integer value
+SCHOLAR_XRAY_MAX_LOG_SIZE=10

--- a/.env.test
+++ b/.env.test
@@ -75,3 +75,6 @@ SCHOLAR_DOI_URL=https://api.test.datacite.org/dois
 
 # API
 API_KEY={ :development => 'testKey'}
+
+# XRay max log size in MB, must be an integer value
+SCHOLAR_XRAY_MAX_LOG_SIZE=10

--- a/config/initializers/aws_xray.rb
+++ b/config/initializers/aws_xray.rb
@@ -8,5 +8,5 @@ Rails.application.config.xray = {
   # Makes sure the log file size does not go beyond 10MB, beyond which it is rotated.
   # Only the latest rotated log will be retained. That is, the max possible size on disk of log files
   # in this case would be 10MB(for actual log) + 10MB(for the latest rotated log)
-  logger: Logger.new("log/#{Rails.env}-xray.log", 1, 10 * 1024 * 1024),
+  logger: Logger.new("log/#{Rails.env}-xray.log", 1, 10 * 1024 * 1024)
 }

--- a/config/initializers/aws_xray.rb
+++ b/config/initializers/aws_xray.rb
@@ -8,5 +8,5 @@ Rails.application.config.xray = {
   # Makes sure the log file size does not go beyond a size, beyond which it is rotated.
   # Only the latest rotated log will be retained. That is, the max possible size on disk of log files
   # if `SCHOLAR_XRAY_MAX_LOG_SIZE` is set to 10 would be 10MB(for actual log) + 10MB(for the latest rotated log).
-  logger: Logger.new("log/#{Rails.env}-xray.log", 1, Integer(ENV.fetch("SCHOLAR_XRAY_MAX_LOG_SIZE", "10"), 10) * 1024 * 1024)
+  logger: Logger.new("log/#{Rails.env}-xray.log", 1, Integer(ENV.fetch("SCHOLAR_XRAY_MAX_LOG_SIZE", "10"), 10).megabytes)
 }

--- a/config/initializers/aws_xray.rb
+++ b/config/initializers/aws_xray.rb
@@ -6,7 +6,7 @@ Rails.application.config.xray = {
   active_record: true,
   context_missing: 'LOG_ERROR',
   # Makes sure the log file size does not go beyond a size, beyond which it is rotated.
-  # Only the latest rotated log will be retained. That is, the max possible size on disk of log files
-  # if `SCHOLAR_XRAY_MAX_LOG_SIZE` is set to 10 would be 10MB(for actual log) + 10MB(for the latest rotated log).
+  # Only the latest rotated log will be retained. That is, the max possible size on disk of log files,
+  # if `SCHOLAR_XRAY_MAX_LOG_SIZE` is set to 10, would be 10MB(for the actual log) + 10MB(for the latest rotated log).
   logger: Logger.new("log/#{Rails.env}-xray.log", 1, Integer(ENV.fetch("SCHOLAR_XRAY_MAX_LOG_SIZE", "10"), 10).megabytes)
 }

--- a/config/initializers/aws_xray.rb
+++ b/config/initializers/aws_xray.rb
@@ -5,5 +5,8 @@ Rails.application.config.xray = {
   # record db transactions as subsegments
   active_record: true,
   context_missing: 'LOG_ERROR',
-  logger: Logger.new("log/#{Rails.env}-xray.log")
+  # Makes sure the log file size does not go beyond 10MB, beyond which it is rotated.
+  # Only the latest rotated log will be retained. That is, the max possible size on disk of log files
+  # in this case would be 10MB(for actual log) + 10MB(for the latest rotated log)
+  logger: Logger.new("log/#{Rails.env}-xray.log", 1, 10 * 1024 * 1024),
 }

--- a/config/initializers/aws_xray.rb
+++ b/config/initializers/aws_xray.rb
@@ -5,8 +5,8 @@ Rails.application.config.xray = {
   # record db transactions as subsegments
   active_record: true,
   context_missing: 'LOG_ERROR',
-  # Makes sure the log file size does not go beyond 10MB, beyond which it is rotated.
+  # Makes sure the log file size does not go beyond a size, beyond which it is rotated.
   # Only the latest rotated log will be retained. That is, the max possible size on disk of log files
-  # in this case would be 10MB(for actual log) + 10MB(for the latest rotated log)
-  logger: Logger.new("log/#{Rails.env}-xray.log", 1, 10 * 1024 * 1024)
+  # if `SCHOLAR_XRAY_MAX_LOG_SIZE` is set to 10 would be 10MB(for actual log) + 10MB(for the latest rotated log).
+  logger: Logger.new("log/#{Rails.env}-xray.log", 1, Integer(ENV.fetch("SCHOLAR_XRAY_MAX_LOG_SIZE", "10"), 10) * 1024 * 1024)
 }


### PR DESCRIPTION
# Fixes XRay log continues to grow.
* Makes sure the log file size does not go beyond 10MB, beyond which it is rotated.
* Only the latest rotated log will be retained.
* That is, the max possible size on disk of log files in this case would be 10MB(for actual log) + 10MB(for the latest rotated log).

Fixes #928 