### PR TITLE
Remove x-ray until test pass.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,6 +105,10 @@ Rails/TimeZone:
     - 'spec/services/collection_metadata_csv_factory_spec.rb'
     - 'config/initializers/hyrax.rb'
 
+Rails/HasManyOrHasOneDependent:
+  Exclude:
+    - 'app/models/hydra/access_controls/permission.rb'
+
 RSpec/AnyInstance:
   Exclude:
     - 'spec/support/shared/doi_request.rb'
@@ -195,6 +199,7 @@ RSpec/ExampleLength:
     - 'app/api/*'
     - 'app/api/**/*'
     - 'spec/api/*'
+    - 'spec/unit/permission_spec.rb'
 
 RSpec/ExpectActual:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'sidekiq-limit_fetch'
 gem 'willow_sword', github: 'notch8/willow_sword'
 
 # xray application monitoring through aws
-gem 'aws-xray-sdk', require: ['aws-xray-sdk/facets/rails/railtie']
+# gem 'aws-xray-sdk', require: ['aws-xray-sdk/facets/rails/railtie']
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,14 +166,8 @@ GEM
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-sdk-xray (1.4.0)
-      aws-sdk-core (~> 3)
-      aws-sigv4 (~> 1.0)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    aws-xray-sdk (0.11.5)
-      aws-sdk-xray (~> 1.4.0)
-      multi_json (~> 1)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -1120,7 +1114,6 @@ PLATFORMS
 DEPENDENCIES
   active-fedora (= 11.5.4)
   active_attr
-  aws-xray-sdk
   bixby (>= 1.0.0)
   bootstrap-sass (~> 3.4.1)
   browse-everything

--- a/app/models/hydra/access_controls/permission.rb
+++ b/app/models/hydra/access_controls/permission.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+module Hydra::AccessControls
+  AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/'
+  GROUP_AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/group'
+  PERSON_AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/person'
+  class Permission < AccessControlList
+    has_many :admin_policies, inverse_of: :default_permissions, class_name: 'Hydra::AdminPolicy'
+
+    # @param [Hash] args
+    # @option args [#to_s] :name name of agent
+    # @option args [#to_s] :type type of agent: group/person
+    # @option args [String] :access description of access: read/edit/discover
+    def initialize(args)
+      super()
+      build_agent(args[:name].to_s, args[:type].to_s)
+      build_access(args[:access])
+    end
+
+    def to_hash
+      { name: agent_name, type: type, access: access }
+    end
+
+    def inspect
+      agent_value = agent.first.rdf_subject.to_s.inspect if agent.first
+      mode_value = mode.first.rdf_subject.to_s.inspect if mode.first
+      "<#{self.class.name} id: #{id} agent: #{agent_value} mode: #{mode_value} access_to: #{access_to_id.inspect}>"
+    end
+
+    def ==(other)
+      other.is_a?(Permission) && id == other.id && access_to_id == other.access_to_id &&
+        agent.first.rdf_subject == other.agent.first.rdf_subject && mode.first.rdf_subject == other.mode.first.rdf_subject
+    end
+
+    def assign_attributes(attributes)
+      attrs = attributes.dup
+      name = attrs.delete(:name)
+      type = attrs.delete(:type)
+      build_agent(name, type) if name && type
+      access = attrs.delete(:access)
+      build_access(access) if access
+      super(attrs)
+    end
+
+    def agent_name
+      decode(parsed_agent.last)
+    end
+
+    def update(*)
+      super.tap { reset }
+    end
+
+    def reset
+      @access = nil
+      @parsed_agent = nil
+    end
+
+    def access
+      @access ||= mode.first.rdf_subject.to_s.split('#').last.downcase.sub('write', 'edit')
+    end
+
+    def type
+      parsed_agent.first
+    end
+
+    protected
+
+    def parsed_agent
+      @parsed_agent ||= agent.first.rdf_subject.to_s.sub(AGENT_URL_PREFIX, '').split('#')
+    end
+
+    def build_agent(name, type)
+      raise "Can't build agent #{inspect}" unless name && type
+      self.agent = case type
+                   when 'group'
+                     build_agent_resource(GROUP_AGENT_URL_PREFIX, name)
+                   when 'person'
+                     build_agent_resource(PERSON_AGENT_URL_PREFIX, name)
+                   else
+                     raise ArgumentError, "Unknown agent type #{type.inspect}"
+                   end
+    end
+
+    def build_agent_resource(prefix, name)
+      [Agent.new(::RDF::URI.new("#{prefix}##{encode(name)}"))]
+    end
+
+    def build_access(access)
+      raise "Can't build access #{inspect}" unless access
+      self.mode = case access
+                  when 'read'
+                    Mode.new(::ACL.Read)
+                  when 'edit'
+                    Mode.new(::ACL.Write)
+                  when 'discover'
+                    Mode.new(Hydra::ACL.Discover)
+                  else
+                    raise ArgumentError, "Unknown access #{access.inspect}"
+                  end
+    end
+
+    private
+
+    def encode(str)
+      URI::RFC2396_Parser.new.escape(str)
+    end
+
+    def decode(str)
+      URI::RFC2396_Parser.new.unescape(str)
+    end
+  end
+end

--- a/config/initializers/aws_xray.rb
+++ b/config/initializers/aws_xray.rb
@@ -1,12 +1,12 @@
-# frozen_string_literal: true
-Rails.application.config.xray = {
-  name: "Scholar-#{Rails.env}@uc",
-  patch: %I[net_http aws_sdk],
-  # record db transactions as subsegments
-  active_record: true,
-  context_missing: 'LOG_ERROR',
-  # Makes sure the log file size does not go beyond a size, beyond which it is rotated.
-  # Only the latest rotated log will be retained. That is, the max possible size on disk of log files,
-  # if `SCHOLAR_XRAY_MAX_LOG_SIZE` is set to 10, would be 10MB(for the actual log) + 10MB(for the latest rotated log).
-  logger: Logger.new("log/#{Rails.env}-xray.log", 1, Integer(ENV.fetch("SCHOLAR_XRAY_MAX_LOG_SIZE", "10"), 10).megabytes)
-}
+# # frozen_string_literal: true
+# Rails.application.config.xray = {
+#   name: "Scholar-#{Rails.env}@uc",
+#   patch: %I[net_http aws_sdk],
+#   # record db transactions as subsegments
+#   active_record: true,
+#   context_missing: 'LOG_ERROR',
+#   # Makes sure the log file size does not go beyond a size, beyond which it is rotated.
+#   # Only the latest rotated log will be retained. That is, the max possible size on disk of log files,
+#   # if `SCHOLAR_XRAY_MAX_LOG_SIZE` is set to 10, would be 10MB(for the actual log) + 10MB(for the latest rotated log).
+#   logger: Logger.new("log/#{Rails.env}-xray.log", 1, Integer(ENV.fetch("SCHOLAR_XRAY_MAX_LOG_SIZE", "10"), 10).megabytes)
+# }

--- a/config/initializers/aws_xray.rb
+++ b/config/initializers/aws_xray.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # # frozen_string_literal: true
 # Rails.application.config.xray = {
 #   name: "Scholar-#{Rails.env}@uc",

--- a/spec/unit/permission_spec.rb
+++ b/spec/unit/permission_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Hydra::AccessControls::Permission do
+  describe "an initialized instance" do
+    let(:permission) { described_class.new(type: 'person', name: 'bob', access: 'read') }
+
+    it "sets predicates" do
+      expect(permission.agent.first.rdf_subject).to eq ::RDF::URI.new('http://projecthydra.org/ns/auth/person#bob')
+      expect(permission.mode.first.rdf_subject).to eq ACL.Read
+    end
+
+    describe "#to_hash" do
+      subject { permission.to_hash }
+      it { is_expected.to eq(type: 'person', name: 'bob', access: 'read') }
+    end
+
+    describe "#agent_name" do
+      subject { permission.agent_name }
+      it { is_expected.to eq 'bob' }
+    end
+
+    describe "#access" do
+      subject { permission.access }
+      it { is_expected.to eq 'read' }
+    end
+
+    describe "#type" do
+      subject { permission.type }
+      it { is_expected.to eq 'person' }
+    end
+  end
+
+  describe "equality comparison" do
+    let(:perm1) { described_class.new(type: 'person', name: 'bob', access: 'read') }
+    let(:perm2) { described_class.new(type: 'person', name: 'bob', access: 'read') }
+    let(:perm3) { described_class.new(type: 'person', name: 'jane', access: 'read') }
+
+    it "is equal if all values are equal" do
+      expect(perm1).to eq perm2
+    end
+
+    it "is unequal if some values are unequal" do
+      expect(perm1).not_to eq perm3
+      expect(perm2).not_to eq perm3
+    end
+  end
+
+  describe "URI escaping" do
+    let(:user_permission) { described_class.new(type: 'person', name: 'john doe', access: 'read') }
+    let(:user_permission2) { described_class.new(type: 'person', name: 'john%20doe', access: 'read') }
+    let(:user_permission3) { described_class.new(type: 'person', name: 'john+doe', access: 'read') }
+    let(:group_permission) { described_class.new(type: 'group', name: 'hydra devs', access: 'read') }
+    let(:group_permission2) { described_class.new(type: 'group', name: 'hydra%20devs', access: 'read') }
+    let(:group_permission3) { described_class.new(type: 'group', name: 'hydra+devs', access: 'read') }
+
+    it "escapes agent when building" do
+      expect(user_permission.agent.first.rdf_subject.to_s).to eq 'http://projecthydra.org/ns/auth/person#john%20doe'
+      expect(user_permission2.agent.first.rdf_subject.to_s).to eq 'http://projecthydra.org/ns/auth/person#john%2520doe'
+      expect(user_permission3.agent.first.rdf_subject.to_s).to eq 'http://projecthydra.org/ns/auth/person#john+doe'
+      expect(group_permission.agent.first.rdf_subject.to_s).to eq 'http://projecthydra.org/ns/auth/group#hydra%20devs'
+      expect(group_permission2.agent.first.rdf_subject.to_s).to eq 'http://projecthydra.org/ns/auth/group#hydra%2520devs'
+      expect(group_permission3.agent.first.rdf_subject.to_s).to eq 'http://projecthydra.org/ns/auth/group#hydra+devs'
+    end
+
+    it "unescapes agent when parsing" do
+      expect(user_permission.agent_name).to eq 'john doe'
+      expect(user_permission2.agent_name).to eq 'john%20doe'
+      expect(user_permission3.agent_name).to eq 'john+doe'
+      expect(group_permission.agent_name).to eq 'hydra devs'
+      expect(group_permission2.agent_name).to eq 'hydra%20devs'
+      expect(group_permission3.agent_name).to eq 'hydra+devs'
+    end
+  end
+end


### PR DESCRIPTION
Fixes #936 
Present short summary (50 characters or less)

The x-ray gem was causing weird results in the test on circleci and locally.  So we started by commenting out the gem and the initializer.  Then I implemented a URI parser to reduce the deprecation chatter in the log.  We used a hydra access controls overwrite of the permission.rb file.


``` ruby
class PostsController
  def index
    respond_with Post.limit(10)
  end
end
```

Changes proposed in this pull request:
* 
* 
* 
