### PR TITLE
Overwrites Hyrax Resource Synce Controller.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -200,6 +200,7 @@ RSpec/ExampleLength:
     - 'app/api/**/*'
     - 'spec/api/*'
     - 'spec/unit/permission_spec.rb'
+    - 'spec/controllers/hyrax/resource_sync_controller_spec.rb'
 
 RSpec/ExpectActual:
   Enabled: false

--- a/app/controllers/hyrax/resource_sync_controller.rb
+++ b/app/controllers/hyrax/resource_sync_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+class Hyrax::ResourceSyncController < ApplicationController
+  include ActionController::RequestForgeryProtection
+  protect_from_forgery with: :null_session
+
+  # We don't need locale here
+  def default_url_options
+    super.except(:locale)
+  end
+
+  def source_description
+    render_from_cache_as_xml(:source_description)
+  end
+
+  def capability_list
+    render_from_cache_as_xml(:capability_list)
+  end
+
+  def change_list
+    render_from_cache_as_xml(:change_list)
+  end
+
+  def resource_list
+    render_from_cache_as_xml(:resource_list)
+  end
+
+  private
+
+  def build_change_list
+    Hyrax::ResourceSync::ChangeListWriter.new(capability_list_url: hyrax.capability_list_url,
+                                              resource_host: request.host).write
+  end
+
+  def build_resource_list
+    Hyrax::ResourceSync::ResourceListWriter.new(capability_list_url: hyrax.capability_list_url,
+                                                resource_host: request.host).write
+  end
+
+  def build_capability_list
+    Hyrax::ResourceSync::CapabilityListWriter.new(resource_list_url: hyrax.resource_list_url,
+                                                  change_list_url: hyrax.change_list_url,
+                                                  description_url: hyrax.source_description_url).write
+  end
+
+  def build_source_description
+    Hyrax::ResourceSync::SourceDescriptionWriter.new(capability_list_url: hyrax.capability_list_url).write
+  end
+
+  def render_from_cache_as_xml(resource_sync_type)
+    # Caching based on host, for multi-tenancy support
+    body = Rails.cache.fetch("#{resource_sync_type}_#{request.host}", expires_in: 1.week) do
+      send("build_#{resource_sync_type}")
+    end
+    render body: body, content_type: 'application/xml'
+  end
+end

--- a/spec/controllers/hyrax/resource_sync_controller_spec.rb
+++ b/spec/controllers/hyrax/resource_sync_controller_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::ResourceSyncController do
+  routes { Hyrax::Engine.routes }
+  before do
+    Rails.cache.clear
+  end
+
+  describe "source_description" do
+    let(:writer) { double }
+    let(:document) { '<xml>' }
+    let(:capability_list) { Hyrax::Engine.routes.url_helpers.capability_list_url(host: 'test.host') }
+
+    it "is successful" do
+      allow(Hyrax::ResourceSync::SourceDescriptionWriter).to receive(:new).with(capability_list_url: capability_list).and_return(writer)
+      expect(writer).to receive(:write).and_return(document)
+      get :source_description
+      expect(response.content_type).to eq 'application/xml'
+      expect(response.body).to eq document
+    end
+  end
+
+  describe "capability_list" do
+    let(:writer) { double }
+    let(:document) { '<xml>' }
+    let(:capability_list) { Hyrax::Engine.routes.url_helpers.capability_list_url(host: 'test.host') }
+
+    it "is successful" do
+      allow(Hyrax::ResourceSync::CapabilityListWriter).to receive(:new).with(resource_list_url: "http://test.host/resourcelist", change_list_url: "http://test.host/changelist", description_url: "http://test.host/.well-known/resourcesync").and_return(writer)
+      expect(writer).to receive(:write).and_return(document)
+      get :capability_list
+      expect(response.content_type).to eq 'application/xml'
+      expect(response.body).to eq document
+    end
+  end
+
+  describe "resource_list" do
+    before do
+      Rails.cache.clear
+    end
+
+    let(:writer) { double }
+    let(:document) { '<xml>' }
+    let(:capability_list) { Hyrax::Engine.routes.url_helpers.capability_list_url(host: 'test.host') }
+
+    it "is successful" do
+      allow(Hyrax::ResourceSync::ResourceListWriter).to receive(:new).with(capability_list_url: capability_list, resource_host: "test.host").and_return(writer)
+      expect(writer).to receive(:write).and_return(document)
+      get :resource_list
+      expect(response.content_type).to eq 'application/xml'
+      expect(response.body).to eq document
+    end
+  end
+
+  describe "change_list" do
+    before do
+      Rails.cache.clear
+    end
+
+    let(:writer) { double }
+    let(:document) { '<xml>' }
+    let(:capability_list) { Hyrax::Engine.routes.url_helpers.capability_list_url(host: 'test.host') }
+
+    it "is successful" do
+      allow(Hyrax::ResourceSync::ChangeListWriter).to receive(:new).with(capability_list_url: capability_list, resource_host: "test.host").and_return(writer)
+      expect(writer).to receive(:write).and_return(document)
+      get :change_list
+      expect(response.content_type).to eq 'application/xml'
+      expect(response.body).to eq document
+    end
+  end
+end


### PR DESCRIPTION
Fixes #920 

Uses protect_from_forgery with: :null_session from the rails 5 options to reset the session_id when visiting any of the resource sync resources.
