### PR TITLE
Escape output from mark_helper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
             CACHE_PATH: /tmp/cache
             COVERALLS_PARALLEL: true
      
-        parallelism: 4
+        parallelism: 6
         working_directory: ~/ucrate
 
         steps:

--- a/app/helpers/mark_helper.rb
+++ b/app/helpers/mark_helper.rb
@@ -34,7 +34,6 @@ module MarkHelper
         value = value.to_s
       end
     end
-
-    value.html_safe
+    value
   end
 end

--- a/spec/features/catalog_facet_spec.rb
+++ b/spec/features/catalog_facet_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe 'catalog searching', js: true, type: :feature do
         click_button('Go')
       end
       expect(page).to have_content('Search Results')
-      expect(page).to have_content(jills_work.title.first)
-      expect(page).to have_content(jacks_work.title.first)
+      expect(page).to have_content("Jill's <mark>Research</mark>")
+      expect(page).to have_content("Jack's <mark>Research</mark>")
       expect(page).to have_selector('.facet-field-heading', text: 'Type of Work')
       expect(page).to have_selector('.facet-field-heading', text: 'Language')
       expect(page).to have_selector('.facet-field-heading', text: 'Publisher')

--- a/spec/features/catalog_index_spec.rb
+++ b/spec/features/catalog_index_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'search display fields', type: :feature, js: true do
   let(:user) { create(:user) }
   let!(:collection_type) { create(:collection_type, id: 1) }
   let!(:collection_type_2) { create(:collection_type, id: 2) }
+  let!(:xss_work) { create(:public_article, title: ['<img src=xx:x />']) }
 
   before do
     allow(User).to receive(:find_by_user_key).and_return(stub_model(User, twitter_handle: 'bob'))
@@ -71,7 +72,6 @@ RSpec.describe 'search display fields', type: :feature, js: true do
 
     it 'has the correct display facets' do
       page.current_window.resize_to(2000, 2000)
-      page.save_screenshot('screenshot.png')
       expect(page).to have_selector('.dl-horizontal', text: "Type:")
       expect(page).to have_selector('.dl-horizontal', text: "Description/Abstract:")
       expect(page).to have_selector('.dl-horizontal', text: "Creator/Author:")
@@ -84,6 +84,11 @@ RSpec.describe 'search display fields', type: :feature, js: true do
       skip "Dates aren't showing up in test environment."
       expect(page).to have_selector('.dl-horizontal', text: "Date Created:")
       expect(page).to have_selector('.dl-horizontal', text: "License:")
+    end
+
+    it 'displays escaped html code in title field' do
+      visit('/catalog')
+      expect(page).to have_content(xss_work.title.first)
     end
   end
 end


### PR DESCRIPTION
Fixes #950 

User submitted html source code is making it into our public display.

Changes proposed in this pull request:
* Remove html_safe from mark_helper0
* Add spec
