### PR TITLE
un-hide share tab

### DIFF
--- a/app/views/hyrax/base/_guts4form.html.erb
+++ b/app/views/hyrax/base/_guts4form.html.erb
@@ -32,7 +32,7 @@
             </li>
         <% end %>
 
-        <li role="presentation" id="tab-share" class="hidden">
+        <li role="presentation" id="tab-share">
           <a href="#share" aria-controls="share" role="tab" data-toggle="tab">
             <%= t("hyrax.works.form.tab.share") %>
           </a>

--- a/spec/features/create_article_spec.rb
+++ b/spec/features/create_article_spec.rb
@@ -108,6 +108,9 @@ RSpec.describe 'Create a Article', :feature, js: true do
       fill_in('Note', with: note)
       fill_in('External Link', with: external_link)
 
+      click_link('Sharing')
+      expect(page).to have_content("Regardless of the visibility settings for this work, you can also share it with other users and groups")
+
       choose('article_visibility_open')
       expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -102,6 +102,9 @@ RSpec.describe 'Create a Dataset', :feature, js: true do
       fill_in('External Link', with: external_link)
       expect(page).to have_css("label.control-label.string.optional", text: "Required Software")
 
+      click_link('Sharing')
+      expect(page).to have_content("Regardless of the visibility settings for this work, you can also share it with other users and groups")
+
       choose('dataset_visibility_open')
       expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')

--- a/spec/features/create_document_spec.rb
+++ b/spec/features/create_document_spec.rb
@@ -104,6 +104,9 @@ RSpec.describe 'Create a Document', :feature, js: true do
       fill_in('Note', with: note)
       fill_in('External Link', with: external_link)
 
+      click_link('Sharing')
+      expect(page).to have_content("Regardless of the visibility settings for this work, you can also share it with other users and groups")
+
       choose('document_visibility_open')
       expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -115,6 +115,9 @@ RSpec.describe 'Create a Etd', :feature, js: true do
       fill_in('Note', with: note)
       fill_in('External Link', with: external_link)
 
+      click_link('Sharing')
+      expect(page).to have_content("Regardless of the visibility settings for this work, you can also share it with other users and groups")
+
       choose('etd_visibility_open')
       expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')

--- a/spec/features/create_generic_work_spec.rb
+++ b/spec/features/create_generic_work_spec.rb
@@ -102,6 +102,9 @@ RSpec.describe 'Create a Generic Work', :feature, js: true do
       fill_in('Note', with: note)
       fill_in('External Link', with: external_link)
 
+      click_link('Sharing')
+      expect(page).to have_content("Regardless of the visibility settings for this work, you can also share it with other users and groups")
+
       choose('generic_work_visibility_open')
       expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -104,6 +104,9 @@ RSpec.describe 'Create a Image', :feature, js: true do
       fill_in('Note', with: note)
       fill_in('External Link', with: external_link)
 
+      click_link('Sharing')
+      expect(page).to have_content("Regardless of the visibility settings for this work, you can also share it with other users and groups")
+
       choose('image_visibility_open')
       expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')

--- a/spec/features/create_medium_spec.rb
+++ b/spec/features/create_medium_spec.rb
@@ -102,6 +102,9 @@ RSpec.describe 'Create a Medium', :feature, js: true do
       fill_in('Note', with: note)
       fill_in('External Link', with: external_link)
 
+      click_link('Sharing')
+      expect(page).to have_content("Regardless of the visibility settings for this work, you can also share it with other users and groups")
+
       choose('medium_visibility_open')
       expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')

--- a/spec/features/create_student_work_spec.rb
+++ b/spec/features/create_student_work_spec.rb
@@ -113,6 +113,9 @@ RSpec.describe 'Create a StudentWork', :feature, js: true do
       fill_in('Note', with: note)
       fill_in('External Link', with: external_link)
 
+      click_link('Sharing')
+      expect(page).to have_content("Regardless of the visibility settings for this work, you can also share it with other users and groups")
+
       choose('student_work_visibility_open')
       expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Open Access) may be viewed as publishing which could impact your ability to')
       check('agreement')


### PR DESCRIPTION
Fixes #957 

Changes proposed in this pull request:
* Remove hidden class from guts4form override
