### PR TITLE
Fixes attach_file_to_work deprecation.

### DIFF
--- a/app/services/work_loader.rb
+++ b/app/services/work_loader.rb
@@ -64,7 +64,7 @@ class WorkLoader
       actor = Hyrax::Actors::FileSetActor.new(file_set, user)
       actor.create_metadata(visibility: visibility)
       actor.create_content(file[:uploaded_file].file.file.to_file)
-      actor.attach_file_to_work(curation_concern)
+      actor.attach_to_work(curation_concern)
       actor.file_set.permissions_attributes = curation_concern.permissions.map(&:to_hash)
 
       file.update(file_set_uri: file_set.uri)


### PR DESCRIPTION
Fixes #1073 

Present short summary (50 characters or less)

This fixes the attach_file_to_work deprecation in our app/services/work_loader.rb with attach_to_work.rb

Description can have multiple paragraphs and you can use code examples inside:

To review this PR run test suite and there should be no deprecation warnings.
Test our work_loader using our Batch Loader : https://github.com/uclibs/ucrate/wiki/Bulk-Upload


Changes proposed in this pull request:
* app/services/work_loader.rb 
