### PR TITLE
Remove code for clamav gem

### DIFF
--- a/app/models/hyrax/virus_scanner.rb
+++ b/app/models/hyrax/virus_scanner.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 # The default virus scanner for Hydra::Works
-# If ClamAV is present, it will be used to check for the presence of a virus. If ClamAV is not
+# If Clamby is present, it will be used to check for the presence of a virus. If Clamby is not
 # installed or otherwise not available to your application, Hydra::Works does no virus checking
 # add assumes files have no viruses.
 #
-# To use a virus checker other than ClamAV:
+# To use a virus checker other than Clamby:
 #   class MyScanner < Hydra::Works::VirusScanner
 #     def infected?
 #       my_result = Scanner.check_for_viruses(file)
@@ -34,21 +34,9 @@ module Hyrax
     def infected?
       if defined?(Clamby)
         clamby_scanner
-      elsif defined?(ClamAV)
-        clam_av_scanner
       else
         null_scanner
       end
-    end
-
-    def clam_av_scanner
-      Deprecation.warn(self, "The ClamAV has been replaced by Clamby " \
-        "as the supported virus scanner for hydra-works. " \
-        "ClamAV support will be removed in hydra-works 2.0 ")
-      scan_result = ClamAV.instance.method(:scanfile).call(file)
-      return false if scan_result.zero?
-      warning "A virus was found in #{file}: #{scan_result}"
-      true
     end
 
     # @return [Boolean]

--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -10,6 +10,4 @@ if defined?(Clamby)
     output_level: 'medium',
     fdpass: true
   )
-elsif defined?(ClamAV)
-  ClamAV.instance.loaddb if defined? ClamAV
 end

--- a/spec/models/hyrax/virus_scanner_spec.rb
+++ b/spec/models/hyrax/virus_scanner_spec.rb
@@ -10,53 +10,6 @@ RSpec.describe Hyrax::VirusScanner do
 
   subject { described_class.new(file) }
 
-  context 'when ClamAV is defined' do
-    before do
-      hide_const('Clamby')
-
-      class ClamAV
-        def self.instance
-          @instance ||= ClamAV.new
-        end
-
-        def scanfile(path)
-          puts "scanfile: #{path}"
-        end
-      end
-    end
-
-    after do
-      Object.send(:remove_const, :ClamAV)
-    end
-
-    context 'with a clean file' do
-      before { allow(ClamAV.instance).to receive(:scanfile).with('/tmp/path').and_return(0) }
-      it 'returns false with no warning' do
-        expect(ActiveFedora::Base.logger).not_to receive(:warn)
-        is_expected.not_to be_infected
-      end
-    end
-
-    context 'with an infected file' do
-      before { allow(ClamAV.instance).to receive(:scanfile).with('/tmp/path').and_return(1) }
-      it 'returns true with a warning' do
-        expect(ActiveFedora::Base.logger).to receive(:warn).with(kind_of(String))
-        is_expected.to be_infected
-      end
-    end
-  end
-
-  context 'when ClamAV is not defined' do
-    before do
-      hide_const('Clamby')
-    end
-
-    it 'returns false with a warning' do
-      expect(ActiveFedora::Base.logger).to receive(:warn).with(kind_of(String))
-      is_expected.not_to be_infected
-    end
-  end
-
   context 'when Clamby is defined' do
     before do
       class Clamby


### PR DESCRIPTION
Fixes #1076 

Remove all references to ClamAV. Previously we have done work to replace ClamAV with Clammy, leaving behind some conditional code which throws deprecations as well as specs. This PR eliminates all references to ClamAV.

Changes proposed in this pull request:
* Remove clamav gem specific specs
* Remove conditional code to use clamav gem if it's defined
* Clean up comments to refer to clamby gem. 
