### PR TITLE
Add interactive verification check to deploy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -349,6 +349,16 @@ Lint/RescueException:
   Exclude:
     - 'app/services/hyrax/custom_stat_importer.rb'
     
+Rails/Exit:
+  Exclude:
+    - 'config/deploy.rb'
+    - 'config/deploy/production.rb'
+
+Rails/Output:
+  Exclude:
+    - 'config/deploy.rb'
+    - 'config/deploy/production.rb'
+
 Rails/OutputSafety:
   Exclude:
     - 'app/helpers/hyrax_helper.rb'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -65,3 +65,26 @@ task :start_prod do
     execute "cd #{fetch(:deploy_to)}/current/script && chmod a+x * && source start_prod.sh"
   end
 end
+
+namespace :deploy do
+  task :confirmation do
+    stage = fetch(:stage).upcase
+    branch = fetch(:branch)
+    puts <<-WARN
+     ========================================================================
+       *** Deploying branch `#{branch}` to #{stage} server ***
+       WARNING: You're about to perform actions on #{stage} server(s)
+       Please confirm that all your intentions are kind and friendly
+     ========================================================================
+     WARN
+    ask :value, "Sure you want to continue deploying `#{branch}` on #{stage}? (Y)"
+    unless fetch(:value).match?(/\A(?i:yes|y)\z/)
+      puts "\nNo confirmation - deploy cancelled!"
+      exit
+    end
+  end
+end
+
+Capistrano::DSL.stages.each do |stage|
+  after stage, 'deploy:confirmation'
+end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -11,6 +11,11 @@ set :bundle_path, -> { shared_path.join('vendor/bundle') }
 append :linked_dirs, "tmp", "public"
 ask(:username, nil)
 ask(:password, nil, echo: false)
+ask(:value, 'Have you submitted and received an approved Change Management Request? (Y)')
+unless fetch(:value).match?(/\A(?i:yes|y)\z/)
+  puts "\nNo confirmation - deploy cancelled!"
+  exit
+end
 # NOTE: Removing :db from one of the servers makes the migrations run only once between thems
 server "localhost", user: fetch(:username), password: fetch(:password), port: 2222, roles: [:web, :app, :db]
 server "localhost", user: fetch(:username), password: fetch(:password), port: 2223, roles: [:web, :app]


### PR DESCRIPTION
Fixes #1065 

Add interactive confirmation to deployment scripts. Prompt user to confirm branch, target server, and confirm change request for production deploys.

Changes proposed in this pull request:
* Interactive confirmation for branch and target server on all modes, set in `config/deploy.rb`
* Interactive confirmation for change request submission for production deploy set in 'config/deploy/production.rb`
