### PR TITLE
Restore ORCID attribute on hyrax user object

### DIFF
--- a/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
@@ -108,6 +108,13 @@
   </div>
 
   <div class="form-group">
+    <%= f.label :orcid, 'Orcid'.html_safe, class: 'col-xs-4 control-label' %>
+    <div class="col-xs-8">
+       <%= f.text_field :orcid, class: "form-control" %>
+    </div>
+  </div>
+
+  <div class="form-group">
     <%= f.label :website, class: 'col-xs-4 control-label' do %>
       <%= t('hyrax.user_profile.website') %>
     <% end %>
@@ -143,28 +150,16 @@
     </div>
   </div><!-- .form-group -->
 
-  <div class="form-group">
+
+<div class="form-group">
     <%= f.label :googleplus_handle, '<i class="fa fa-google-plus"></i> Google+ Handle'.html_safe, class: 'col-xs-4 control-label' %>
     <div class="col-xs-8">
        <%= f.text_field :googleplus_handle, class: "form-control" %>
     </div>
   </div><!-- .form-group -->
 
+
   <%= render 'trophy_edit', trophies: @trophies %>
 
   <%= f.button '<i class="glyphicon glyphicon-save"></i> Save Profile'.html_safe, type: 'submit', class: "btn btn-primary" %>
 <% end %>
-
-<div class="orcid-section">
-  <div class="well">
-    <% defined?(status_processor) || status_processor = Orcid::ProfileStatus.method(:for) %>
-      <% status_processor.call(current_user) do |on| %>
-          <% on.authenticated_connection do |profile| %>
-          <% end %>
-    <% end %>
-    <%= render partial: 'orcid/profile_connections/orcid_connector', locals: {default_search_text: current_user.name } %>
-		<p>
-		   <%= link_to 'What is ORCID?', main_app.orcid_about_path %>
- 	  </p>
-  </div>
-</div>

--- a/app/views/hyrax/users/_user_info.html.erb
+++ b/app/views/hyrax/users/_user_info.html.erb
@@ -1,11 +1,8 @@
 <dl id="user_info">
 
-<% defined?(status_processor) || status_processor = Orcid::ProfileStatus.method(:for)
-                                   status_processor.call(current_user) do |on|
-                                   on.authenticated_connection do |profile| %>
-                                   <dt><%= orcid_label('profile') %></dt>
-                                   <dd><%= link_to profile.orcid_profile_id, Orcid.url_for_orcid_id(profile.orcid_profile_id), { target: '_blank' } %></dd>
-<% end %>
+<% if user.orcid.present? %>
+  <dt><%= orcid_label('profile') %></dt>
+  <dd><%= link_to user.orcid, user.orcid, { target: '_blank' } %></dd>
 <% end %>
 
 <% if Hyrax.config.arkivo_api? && user.zotero_userid.present? %>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     website { 'Personal webpage' }
     rd_page { 'https://researchdirectory.uc.edu/p/user' }
     blog { 'Blog' }
+    orcid { '0000-0000-0000-0000' }
 
     transient do
       # Allow for custom groups when a user is instantiated.

--- a/spec/features/hyrax/users_spec.rb
+++ b/spec/features/hyrax/users_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "User Spec", type: :feature do
       it 'renders identity and contact fields' do
         visit profile_path
         click_link('Edit Profile', match: :first)
+
         expect(page).to have_field('First Name', with: user.first_name)
         expect(page).to have_field('Last Name', with: user.last_name)
         expect(page).to have_field('Job title', with: user.title)
@@ -51,8 +52,16 @@ RSpec.describe "User Spec", type: :feature do
         expect(page).to have_field('Research Directory webpage', with: user.rd_page)
         expect(page).to have_field('Personal webpage', with: user.website)
         expect(page).to have_field('Blog', with: user.blog)
-        expect(page).to have_content('Create or Connect your ORCID iD')
-        expect(page).to have_link('What is ORCID?')
+        expect(page).to have_field('Orcid', with: user.orcid)
+      end
+
+      it 'persists orcid id after editing' do
+        visit profile_path
+        click_link('Edit Profile', match: :first)
+        expect(page).to have_field('Orcid', with: user.orcid)
+        fill_in('Orcid', with: '1234-1234-1234-1234')
+        click_on('Save Profile')
+        expect(page).to have_content('https://orcid.org/1234-1234-1234-1234')
       end
 
       it 'shows permalinks after editing' do

--- a/spec/views/hyrax/dashboard/profiles/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/profiles/edit.html.erb_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe 'hyrax/dashboard/profiles/edit.html.erb', type: :view do
     expect(rendered).to match(/Blog/)
   end
 
-  it "does not show hyrax orcid field" do
+  it "shows hyrax orcid field" do
     render
-    expect(rendered).not_to match(/ORCID Profile/)
+    expect(rendered).to match(/Orcid/)
   end
 end


### PR DESCRIPTION
Fixes #982 

Restore user profile edit form fields and display for ORCID attribute on user object. 

Changes proposed in this pull request:
* Remove ORCID profile connector widget from profile edit view
* Remove ORCID profile connector widget from profile show view
* Restore hyrax user orcid attribute form and display fields
* Adjust specs
