### PR TITLE
Allow for env variable for fits in hyrax config

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@
 1. Run brakeman: ```bundle exec brakeman -q -w 2```
 1. Run bundler-audit: ```bundle-audit check --update```
 
+## Notes for local development
+1. If you installed fits on a mac via homebrew, you may be getting an error saying that there is no fits.sh file.  If this happens, add the following to your .env.development.local: `FITS_FILENAME=fits`
+
 ## Project Samvera
 This software has been developed by and is brought to you by the Samvera community. Learn more at the
 [Samvera website](http://projecthydra.org)

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -89,7 +89,9 @@ Hyrax.config do |config|
   # config.redis_namespace = "hyrax"
 
   # Path to the file characterization tool
-  # config.fits_path = "fits.sh"
+  # Developers using Brew to install fits should put "fits" as the filename in
+  # their .env.development.local file.  Default is "fits.sh".
+  config.fits_path = ENV.fetch("FITS_FILENAME", "fits.sh")
 
   # Path to the file derivatives creation tool
   config.libreoffice_path = ENV["SCHOLAR_SOFFICE_PATH"]


### PR DESCRIPTION
Adds an optional development environment variable "FITS_FILENAME" to hyrax.rb config file

Developers who have installed "fits" via homebrew have the fits file stored in their computer as "fits", while developers who have installed "fits" via Harvard have the fits file stored in their computer as "fits.sh".  The app defaults to "fits.sh", which causes it to crash when run locally from a "fits" machine.  The workaround to this has been to update the hyrax config file to indicate that the path should be "fits" instead of the default "fits.sh".

This PR adds an optional environment variable for "fits" developers, so that they can put `FITS_FILENAME` in their .env.development.local file to override the app's location of fits.  

Developers who had their app working correctly with the "fits.sh" default do not need to put in the new environment variable, and should notice no change in functionality.

Also adds note in README about the FITS_FILENAME variable.