### PR TITLE
Changes constants to variables in embargo rake task.

### DIFF
--- a/lib/tasks/embargo_notify.rake
+++ b/lib/tasks/embargo_notify.rake
@@ -3,10 +3,10 @@
 desc 'Starts EmbargoWorker to manage expired embargoes'
 task embargo_notify: :environment do
   # Controls when reminder emails are sent out for expiring embargoed works.
-  FOURTEEN_DAYS = 14
-  THIRTY_DAYS = 30
-  ONE_DAY = 1
-  ZERO_DAYS = 0
+  fourteen_days = 14
+  thirty_days = 30
+  one_day = 1
+  zero_days = 0
   results_cap = 1_000_000
   Time.zone = 'EST'
 
@@ -18,12 +18,12 @@ task embargo_notify: :environment do
     mail_contents = work['title_tesim'].first
 
     case days_until_release
-    when ONE_DAY # notify at end of day (~midnight), one day prior to release
-      EmbargoMailer.notify(receiver, mail_contents, ZERO_DAYS).deliver # still pass zero day count to mailer for notification message
-    when FOURTEEN_DAYS
-      EmbargoMailer.notify(receiver, mail_contents, FOURTEEN_DAYS).deliver
-    when THIRTY_DAYS
-      EmbargoMailer.notify(receiver, mail_contents, THIRTY_DAYS).deliver
+    when one_day # notify at end of day (~midnight), one day prior to release
+      EmbargoMailer.notify(receiver, mail_contents, zero_days).deliver # still pass zero day count to mailer for notification message
+    when fourteen_days
+      EmbargoMailer.notify(receiver, mail_contents, fourteen_days).deliver
+    when thirty_days
+      EmbargoMailer.notify(receiver, mail_contents, thirty_days).deliver
     end
   end
 end


### PR DESCRIPTION
Fixes #1077 

Present short summary (50 characters or less)

This task is used to notify users of their embargoed works.  This PR changes the use of CONSTANTS to remove change warnings in the spec test.  

Description can have multiple paragraphs and you can use code examples inside:

/Users/scherztc/Workspaces/ucrate/lib/tasks/embargo_notify.rake:6: warning: already initialized constant FOURTEEN_DAYS
/Users/scherztc/Workspaces/ucrate/lib/tasks/embargo_notify.rake:6: warning: previous definition of FOURTEEN_DAYS was here
/Users/scherztc/Workspaces/ucrate/lib/tasks/embargo_notify.rake:7: warning: already initialized constant THIRTY_DAYS
/Users/scherztc/Workspaces/ucrate/lib/tasks/embargo_notify.rake:7: warning: previous definition of THIRTY_DAYS was here
/Users/scherztc/Workspaces/ucrate/lib/tasks/embargo_notify.rake:8: warning: already initialized constant ONE_DAY
/Users/scherztc/Workspaces/ucrate/lib/tasks/embargo_notify.rake:8: warning: previous definition of ONE_DAY was here
/Users/scherztc/Workspaces/ucrate/lib/tasks/embargo_notify.rake:9: warning: already initialized constant ZERO_DAYS
/Users/scherztc/Workspaces/ucrate/lib/tasks/embargo_notify.rake:9: warning: previous definition of ZERO_DAYS was here
/Users/scherztc/Workspaces/ucrate/lib/tasks/embargo_notify.rake:6: warning: already initialized constant FOURTEEN_DAYS
/Users/scherztc/Workspaces/ucrate/lib/tasks/embargo_notify.rake:6: warning: previous definition of FOURTEEN_DAYS was here

Changes proposed in this pull request:
* 
* 
* 
