### PR TITLE
1075 - Fix unused parameters passed to Capybara warning

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -27,5 +27,5 @@
     </div>
   <% end %>
 <% else %>
-  <p>To request an account, <%= link_to 'use the contact page', contact_path %>.</p>
+  <p>To request an account, <%= link_to 'use the contact page', contact_path %></a>.</p>
 <% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -27,5 +27,5 @@
     </div>
   <% end %>
 <% else %>
-  <p>To request an account, <%= link_to 'use the contact page', contact_path %></a>.</p>
+  <p>To request an account, <%= link_to 'use the contact page', contact_path %>.</p>
 <% end %>

--- a/spec/features/uc_shibboleth_spec.rb
+++ b/spec/features/uc_shibboleth_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 describe 'UC account workflow', type: :feature do
   let(:user) { FactoryBot.create(:user) }
   let(:password) { FactoryBot.attributes_for(:user).fetch(:password) }
+  let(:locale) { 'en' }
 
   describe 'overridden devise password reset page' do
     context 'with a uc.edu email address' do
@@ -68,7 +69,7 @@ describe 'UC account workflow', type: :feature do
     it 'shows a request link of signups are disabled' do
       AUTH_CONFIG['signups_enabled'] = false
       visit new_user_registration_path
-      expect(page).to have_link('use the contact page', contact_path)
+      expect(page).to have_link('use the contact page', href: contact_path(locale: locale))
     end
   end
 
@@ -76,13 +77,13 @@ describe 'UC account workflow', type: :feature do
     it 'shows a shibboleth login link if shibboleth is enabled' do
       AUTH_CONFIG['shibboleth_enabled'] = true
       visit new_user_session_path
-      expect(page).to have_link('Central Login form', user_shibboleth_omniauth_authorize_path)
+      expect(page).to have_link('Central Login form', href: user_shibboleth_omniauth_authorize_path(locale: locale))
     end
 
     it 'does not show a shibboleth login link if shibboleth is disabled' do
       AUTH_CONFIG['shibboleth_enabled'] = false
       visit new_user_session_path
-      expect(page).not_to have_link('Central Login form', user_shibboleth_omniauth_authorize_path)
+      expect(page).not_to have_link('Central Login form', href: user_shibboleth_omniauth_authorize_path(locale: locale))
     end
 
     it 'shows a signup link if signups are enabled' do
@@ -107,7 +108,7 @@ describe 'UC account workflow', type: :feature do
 
       it 'shows a shibboleth login link and local login link' do
         expect(page).to have_link('UC Central Login username', href: 'https://www.uc.edu/distance/Student_Orientation/One_Stop_Student_Resources/central-log-in-.html')
-        expect(page).to have_link('log in using a local account', href: new_user_session_path + '?locale=en')
+        expect(page).to have_link('log in using a local account', href: new_user_session_path(locale: locale))
       end
     end
 
@@ -136,7 +137,7 @@ describe 'UC account workflow', type: :feature do
   describe 'home page login button' do
     it 'shows the correct login link' do
       visit root_path
-      expect(page).to have_link('Login', href: login_path + '?locale=en')
+      expect(page).to have_link('Login', href: login_path(locale: locale))
     end
   end
 


### PR DESCRIPTION
Fixes #1075 

Fix warning message for "Unused parameters passed to Capybara."

Capybara tests can have things like .have_link("some text", {optional parameters}).  The optional parameters need to be one of the following: 
`:count, :minimum, :maximum, :between, :text, :id, :class, :visible, :exact, :exact_text, :match, :wait, :filter_set, :href, :title, :alt`

We had tests that were looking like this: `expect(page).to have_link('use the contact page', contact_path)`, where we were not specifying what that second parameter was.  Not specifying meant that the second parameter wasn't being tested, and was raising that warning message "unused parameters passed to Capybara."

This PR is to fix that warning message by clarifying what the second parameter passed in several tests is supposed to be.

We have to pass in the `locale` as "en" because the actual url for the above example was not `/contact` but rather `/contact?locale=en`.  This PR factored out the locale into a let :variable at the start of the spec/features/uc_shibboleth_spec.rb file because it was needed in multiple locations in the tests.


