### PR TITLE
removed extra </a> on views/devise/registrations/new

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -27,5 +27,5 @@
     </div>
   <% end %>
 <% else %>
-  <p>To request an account, <%= link_to 'use the contact page', contact_path %></a>.</p>
+  <p>To request an account, <%= link_to 'use the contact page', contact_path %>.</p>
 <% end %>


### PR DESCRIPTION
Minor HTML fix - there was an extra </a> present at views/devise/registrations/new that could potentially interfere with Javascript running correctly on the page.  Removed it.

There was no addition to the code, only a small removal, so test coverage remains unchanged.