### PR TITLE
Add log out screen markup to /public

### DIFF
--- a/public/LogOut.html
+++ b/public/LogOut.html
@@ -1,0 +1,61 @@
+<html>
+  <head>
+    <title>Shibboleth Authentication Request</title>
+  </head>
+
+  <body>
+    <header>
+      <nav id="masthead" class="navbar navbar-inverse navbar-static-top" role="navigation">
+        <div class="container-fluid">
+	  <!-- Brand and toggle get grouped for better mobile display -->
+	  <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+              <span class="sr-only">Toggle navigation</span>
+	      <span class="icon-bar"></span>
+	      <span class="icon-bar"></span>
+	      <span class="icon-bar"></span>
+            </button>
+	    <a id="logo" class="navbar-brand" href="http://www.uc.edu" target="_blank" data-no-turbolink="true">
+	      <span><img class="header-uc-logo" src="/assets/uc-logo-white-2d355501b79b1390afcd9bc3c564f576b479eeea6b38a874b8b171332cb21df7.png" /></span>
+	    </a>
+	  </div>
+	</div>
+      </nav>
+    </header>
+
+    <div style="margin: 1em;">
+      <h3>You have been logged out of Scholar@UC</h3>
+      <p style="margin-top: 2em;">If you wish to also log out of UC's Login Service, click the Log Out button below.</p>
+	
+      <form method="POST" action="<shibmlp action/>">
+        <shibmlpif TARGET>
+          <input type="hidden" name="TARGET" value="<shibmlp TARGET/>"/>
+        </shibmlpif>
+        <shibmlpif RelayState>
+          <input type="hidden" name="RelayState" value="<shibmlp RelayState/>"/>
+        </shibmlpif>
+        <shibmlpif SAMLRequest>
+          <input type="hidden" name="SAMLRequest" value="<shibmlp SAMLRequest/>"/>
+        </shibmlpif>
+        <shibmlpif SAMLResponse>
+          <input type="hidden" name="SAMLResponse" value="<shibmlp SAMLResponse/>"/>
+        </shibmlpif>
+        <shibmlpif SAMLart>
+          <input type="hidden" name="SAMLart" value="<shibmlp SAMLart/>"/>
+        </shibmlpif>
+        <shibmlpif SigAlg>
+          <input type="hidden" name="SigAlg" value="<shibmlp SigAlg/>"/>
+        </shibmlpif>
+        <shibmlpif Signature>
+          <input type="hidden" name="Signature" value="<shibmlp Signature/>"/>
+        </shibmlpif>
+        <shibmlpif KeyInfo>
+          <input type="hidden" name="KeyInfo" value="<shibmlp KeyInfo/>"/>
+        </shibmlpif>
+	<input type="submit" value="Log Out"/>
+      </form>
+
+      <p style="margin-top: 2em;"><a href="/">Return to Scholar@UC</a></p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #1098

Puts the new Scholar log out page in /public for safekeeping and tracking changes.  The file will actually live on the servers at `/etc/shibboleth/bindingTemplate.html`.  

The original page was not submitting the hidden SSO logout form on page load.  This revamped page notifies the user they have logged out of Scholar and gives them the option to log out of SSO as well.  Also provides a return link to Scholar.

This page is currently up on scholar-qa.uc.edu and can be viewed/tested by logging into scholar-qa with SSO and then logging out.

After merging, @hortongn will copy the file to the remaining servers and submit an emergency change request.