### PR TITLE
Replace class calls with sym-link for factorybot

### DIFF
--- a/spec/support/shared/concern_calls.rb
+++ b/spec/support/shared/concern_calls.rb
@@ -2,7 +2,8 @@
 
 shared_examples 'concern calls' do |work_class|
   let!(:user) { create(:user) }
-  let(:work) { FactoryBot.build(work_class.classify.constantize, user: user, college: "ceas", department: "Test", creator: ["Test"], description: ["Test"], license: ["http://www.opendatacommons.org/licenses/by/1.0/"]) }
+  let(:work) { FactoryBot.build(work_class.singularize.to_sym, user: user, college: "ceas", department: "Test", creator: ["Test"], description: ["Test"], license: ["http://www.opendatacommons.org/licenses/by/1.0/"]) }
+
   let(:parameters) do
     {
       "access": "open",


### PR DESCRIPTION
Fixes #991 

Changes proposed in this pull request:
* Pass class name to symbol instead of constantizing for `spec/support/shared/concern_calls.rb`
