### PR TITLE
Modifies rails_helper to use required_version.

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,7 +61,7 @@ end
 
 # pin chromedriver version so capybara tests pass
 
-Webdrivers::Chromedriver.version = '72.0.3626.69'
+Webdrivers::Chromedriver.required_version = '72.0.3626.69'
 
 unless ENV['SKIP_MALEFICENT']
   # See https://github.com/jeremyf/capybara-maleficent


### PR DESCRIPTION
Fixes #1072 

Present short summary (50 characters or less)

Replaced the .version with .required_version for the Selenium Webdriver configuration in the rails_helper.rb

