### PR TITLE
1122 - Correct tests to account for locale in URL for Sign Up link

### DIFF
--- a/spec/features/uc_shibboleth_spec.rb
+++ b/spec/features/uc_shibboleth_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 describe 'UC account workflow', type: :feature do
   let(:user) { FactoryBot.create(:user) }
   let(:password) { FactoryBot.attributes_for(:user).fetch(:password) }
+  let(:locale) { 'en' }
 
   describe 'overridden devise password reset page' do
     context 'with a uc.edu email address' do
@@ -88,13 +89,13 @@ describe 'UC account workflow', type: :feature do
     it 'shows a signup link if signups are enabled' do
       AUTH_CONFIG['signups_enabled'] = true
       visit new_user_session_path
-      expect(page).to_not have_link('Sign up', href: new_user_registration_path)
+      expect(page).to have_link('Sign up', href: new_user_registration_path(locale: locale))
     end
 
     it 'does not show signup link if signups are disabled' do
       AUTH_CONFIG['signups_enabled'] = false
       visit new_user_session_path
-      expect(page).not_to have_link('Sign up', href: new_user_registration_path)
+      expect(page).not_to have_link('Sign up', href: new_user_registration_path(locale: locale))
     end
   end
 


### PR DESCRIPTION
Fixes #1122 

The tests for whether or not there was a sign-up link for uc_shibboleth were not correct.  The test that stated that the link should be present was actually checking (and passing) that it was absent because the url being checked did not include the locale.

What the test was checking: 
there is or isn't a link that goes to `/sign_up`

What the test needed to be checking:
there is or isn't a link that goes to `/sign_up?locale=en`

The changes in this PR add the locale to the check, and correct the test that states that the link should be present to actually check that the link is present.