### PR TITLE
1079 - Fix capybara warning for shibboleth

### DIFF
--- a/spec/features/uc_shibboleth_spec.rb
+++ b/spec/features/uc_shibboleth_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 describe 'UC account workflow', type: :feature do
   let(:user) { FactoryBot.create(:user) }
   let(:password) { FactoryBot.attributes_for(:user).fetch(:password) }
+  let(:locale) { 'en' }
 
   describe 'overridden devise password reset page' do
     context 'with a uc.edu email address' do
@@ -76,13 +77,13 @@ describe 'UC account workflow', type: :feature do
     it 'shows a shibboleth login link if shibboleth is enabled' do
       AUTH_CONFIG['shibboleth_enabled'] = true
       visit new_user_session_path
-      expect(page).to have_link('Central Login form', user_shibboleth_omniauth_authorize_path)
+      expect(page).to have_link('Central Login form', href: user_shibboleth_omniauth_authorize_path(locale: locale))
     end
 
     it 'does not show a shibboleth login link if shibboleth is disabled' do
       AUTH_CONFIG['shibboleth_enabled'] = false
       visit new_user_session_path
-      expect(page).not_to have_link('Central Login form', user_shibboleth_omniauth_authorize_path)
+      expect(page).not_to have_link('Central Login form', href: user_shibboleth_omniauth_authorize_path(locale: locale))
     end
 
     it 'shows a signup link if signups are enabled' do


### PR DESCRIPTION
Fixes #1079

See PR #1108 for background on this issue.

This PR fixes the Capybara warning for "shibboleth" which was caused by the syntax of tests in the file spec/features/uc_shibboleth_spec.rb.