### PR TITLE
1075 Fix Capybara warning for "Files", discover failing test

### DIFF
--- a/spec/features/form_tab_nav_js_spec.rb
+++ b/spec/features/form_tab_nav_js_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe 'Navigating between tabs in create work form', :js, :workflow do
   end
 
   it 'matches active tab to form content' do
+    skip 'Clicking on the link "Attaching a file" does not change the active tab.'
     click_link "Attaching a file"
     expect(page).to have_content('You can add one or more files ')
-    expect(page).to have_selector("ul li.active a", 'Files')
+    expect(page).to have_selector("ul li.active a", text: 'Files')
   end
 end


### PR DESCRIPTION
Fixes #1075

See PR #1108 for more information about the Capybara warnings.

There was a Capybara warning for `Unused parameters passed to Capybara::Queries::SelectorQuery : ["Files"]`.  This came from the test at **spec/features/form_tab_nav_js_spec.rb:30** that had a parameter "Files" in the have_selector() call.  The lack of keyword "text:" caused this parameter to not be used, so the test was only looking for the first item in the query, an active list item.

Adding in the keyword "text:" causes the test to fail because the desired behavior is not happening.

I skipped the test because it will not pass without fixing the bug, and have created an issue for the bug, Ref #1121  