### PR TITLE
HOLD - 985 modify application.rb file to require 1/0 format for sqlite boolean

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,6 @@ module ScholarUc
     config.time_zone = "Eastern Time (US & Canada)"
     config.paths.add File.join('app', 'api'), glob: File.join('**', '*.rb')
     config.autoload_paths += Dir[Rails.root.join('app', 'api', '*')]
+    config.active_record.sqlite3.represent_boolean_as_integer = true
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,7 @@ module ScholarUc
     config.time_zone = "Eastern Time (US & Canada)"
     config.paths.add File.join('app', 'api'), glob: File.join('**', '*.rb')
     config.autoload_paths += Dir[Rails.root.join('app', 'api', '*')]
+    # This sqlite3 boolean_as_integer line can be removed upon migrating to Rails 6.0+
     config.active_record.sqlite3.represent_boolean_as_integer = true
   end
 end


### PR DESCRIPTION
Fixes #985 

## WARNING:  Every developer needs to run the rake tasks created in PR #1123 before this PR gets merged up.

In preparation for migrating to Rails 6.0, we need to stop saving boolean data fields in our sqlite databases in the old format of 't' and 'f'.  Instead, we need to save boolean values as 1 for true and 0 for false.  This is the format supported by Rails 6.0 and up.  When we upgrade to Rails 6.0, any data instances of booleans that have been saved in the older 't' and 'f' format will cause errors.

Luckily, our QA and production databases do not use sqlite, and so they do not save booleans as 't' and 'f' - that's a sqlite thing because sqlite has no native boolean class.  Because QA and production databases are in mysql, no rake migration is necessary for them.

I created a rake task to allow our developers to migrate the data held in their local testing and development environments (which DO use sqlite).  That rake task is created in PR #1123.  Instructions on how to run the rake tasks are on that PR and in the comments for the rake file.  **Every developer for scholar needs to run these rake tasks before we add the changes in this PR.**  

### This PR:
Adds a line to the application.rb that forces all boolean values saved in sqlite databases to be saved in the 1 / 0 format rather than the 't' / 'f' format.  The change to 1 / 0 is compatible with both the older and newer versions of Rails, while the older 't' / 'f' is incompatible with Rails 6.0+.  
