### PR TITLE
Remove Solrizer call from base_attributes spec

### DIFF
--- a/app/indexers/hyrax/collection_indexer.rb
+++ b/app/indexers/hyrax/collection_indexer.rb
@@ -2,9 +2,9 @@
 module Hyrax
   class CollectionIndexer < Hydra::PCDM::CollectionIndexer
     include Hyrax::IndexesThumbnails
-#    include SortableTitleIndexer
+    #    include SortableTitleIndexer
 
-#    STORED_LONG = Solrizer::Descriptor.new(:long, :stored)
+    #    STORED_LONG = Solrizer::Descriptor.new(:long, :stored)
     STORED_LONG = ActiveFedora::Indexing::Descriptor.new(:long, :stored)
     self.thumbnail_path_service = Hyrax::CollectionThumbnailPathService
 
@@ -14,7 +14,7 @@ module Hyrax
         solr_doc['generic_type_sim'] = ["Collection"]
         solr_doc['visibility_ssi'] = object.visibility
         solr_doc['thumbnail_path_ss'] = thumbnail_path
- 
+
         # Solrizer.set_field(solr_doc, 'generic_type', 'Collection', :facetable)
         # Index the size of the collection in bytes
         solr_doc[Solrizer.solr_name(:bytes, STORED_LONG)] = object.bytes

--- a/spec/views/hyrax/base/_attributes.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attributes.html.erb_spec.rb
@@ -11,7 +11,7 @@ describe 'hyrax/base/_attributes.html.erb' do
   let(:solr_document) { SolrDocument.new(attributes) }
   let(:attributes) do
     {
-      Solrizer.solr_name('has_model', :symbol) => ["GenericWork"],
+      has_model_ssim: ["GenericWork"],
       college_tesim: college,
       department_tesim: department,
       related_url_tesim: related_url,


### PR DESCRIPTION
Fixes #1137 

Solrizer has been deprecated. Remove Solrizer call from spec copied from Hyrax gem.
Ex. https://github.com/samvera/hyrax/blob/f7a3fcde5cc08a72629a3a05ba27b3c214eff590/spec/views/hyrax/base/_attributes.html.erb_spec.rb

Changes proposed in this pull request:
* Remove Solrizer call from spec/views/hyrax/base/_attributes.html.erb_spec.rb
* Unrelated robucop indent fixes
