### PR TITLE
Remove Solrizer call from base_attributes spec

### DIFF
--- a/spec/views/hyrax/base/_attributes.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attributes.html.erb_spec.rb
@@ -11,7 +11,7 @@ describe 'hyrax/base/_attributes.html.erb' do
   let(:solr_document) { SolrDocument.new(attributes) }
   let(:attributes) do
     {
-      Solrizer.solr_name('has_model', :symbol) => ["GenericWork"],
+      has_model_ssim: ["GenericWork"],
       college_tesim: college,
       department_tesim: department,
       related_url_tesim: related_url,


### PR DESCRIPTION
Fixes #1137 

Solrizer has been deprecated. Remove Solrizer call from spec copied from Hyrax gem.
Ex. https://github.com/samvera/hyrax/blob/f7a3fcde5cc08a72629a3a05ba27b3c214eff590/spec/views/hyrax/base/_attributes.html.erb_spec.rb

Changes proposed in this pull request:
* Remove Solrizer call from spec/views/hyrax/base/_attributes.html.erb_spec.rb
* Unrelated robucop indent fixes
