### PR TITLE
1132/ HUT multi value input type not loading correctly

### DIFF
--- a/app/indexers/hyrax/collection_indexer.rb
+++ b/app/indexers/hyrax/collection_indexer.rb
@@ -16,7 +16,7 @@ module Hyrax
         solr_doc['bytes'] = object.bytes
         solr_doc['thumbnail_path_ss'] = thumbnail_path
         solr_doc['visibility_ssi'] = object.visibility
-        solr_doc['sort_title'] = sortable_title(object.title.first)  if object.title.present?
+        solr_doc['sort_title'] = sortable_title(object.title.first) if object.title.present?
 
         object.in_collections.each do |col|
           (solr_doc['member_of_collection_ids_ssim'] ||= []) << col.id

--- a/config/initializers/hydra_editor.rb
+++ b/config/initializers/hydra_editor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Adds hydra-editor inputs to the load path
 hydra_editor_inputs_path = Gem.loaded_specs['hydra-editor'].full_gem_path + '/app/inputs'
 $LOAD_PATH.unshift(hydra_editor_inputs_path) unless $LOAD_PATH.include?(hydra_editor_inputs_path)

--- a/config/initializers/hydra_editor.rb
+++ b/config/initializers/hydra_editor.rb
@@ -1,0 +1,8 @@
+# Adds hydra-editor inputs to the load path
+hydra_editor_inputs_path = Gem.loaded_specs['hydra-editor'].full_gem_path + '/app/inputs'
+$LOAD_PATH.unshift(hydra_editor_inputs_path) unless $LOAD_PATH.include?(hydra_editor_inputs_path)
+
+# Require the multi_value_input file from hydra-editor
+# This is needed because multi_value_input is not a basic SimpleForm input
+# and it is used in multiple places both in hyrax and in hydra-editor.
+require 'multi_value_input'


### PR DESCRIPTION
Fixes #1132 

We were having problems with Scholar not recognizing the input type "as: :multi_value".  Any time we were attempting to take an input with the "multi_value" format, the app would crash.  

"MultiValueInput" is a custom input class created by hydra-editor and present in the version of hydra-editor we are using, 5.0.5.  SimpleForm should have been using that class to handle anything with the "as: :multi_value" tags, but it wasn't.

It turns out that Scholar was not loading the input classes from hydra-editor.  This PR adds the input classes of hydra-editor to the load path for Scholar, and then specifically requires the "multi_value_input" file.  With this addition to the initializers, all of our work types can now successfully use the multi_value format.

(Note:  change to app/indexers/hyrax/collection_indexer.rb is simply a Rubocop fix)