### PR TITLE
1135/ HUT Include Devise::Test::ControllerHelpers for all types in rails_helper

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -145,8 +145,7 @@ RSpec.configure do |config|
   config.include OptionalExample
 
   config.include Devise::Test::IntegrationHelpers, type: :feature
-  config.include Devise::Test::ControllerHelpers, type: :controller
-  config.include Devise::Test::ControllerHelpers, type: :helper
+  config.include Devise::Test::ControllerHelpers
 
   config.before :suite do
     DatabaseCleaner.clean_with(:truncation)


### PR DESCRIPTION
Fixes #1135 

Include Devise::Test::ControllerHelpers for all types in rails_helper.

The following testing error:
```
Failure/Error: <%= media_display https://github.com/presenter %>

ActionView::Template::Error:
```
came from not correctly loading the testing helpers from Devise.  We had 
```
  config.include Devise::Test::ControllerHelpers, type: :controller
  config.include Devise::Test::ControllerHelpers, type: :helper
```
in our rails_helper file, but we also needed:
```
  config.include Devise::Test::ControllerHelpers, type: :view
```
This PR combines the three types and loads all types by simplifying the loading to:
```
  config.include Devise::Test::ControllerHelpers
```