### PR TITLE
1139/ HUT : welcome_email

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -177,6 +177,11 @@ RSpec.configure do |config|
                                                  end
   end
 
+  # Configure Capybara to use Selenium with Chrome in headless mode for JS-enabled feature tests
+  config.before(:each, type: :feature, js: true) do
+    Capybara.javascript_driver = :selenium_chrome_headless
+  end
+
   config.after do
     DatabaseCleaner.clean
   end


### PR DESCRIPTION
Fixes #1139

Fix welcome_email_spec.rb

We had been getting this error:
```
   586.2) Failure/Error: User.find_by_email(user_email).delete
          
          NoMethodError:
            undefined method `delete' for nil:NilClass
          # ./spec/features/welcome_mailer_spec.rb:21:in `block (2 levels) in <top (required)>'
```

This was being caused because the test was attempting to delete a user in an `after` block, when that user had never been created.  It had never been created because the test that was supposed to create it was failing due to an error in the scss:
```
RSpec::Core::MultipleExceptionError: Error: "calc(100vh - 110px)" is not a number for `min'
        on line 1:30625 of stdin, in function `min`
        from line 1:30625 of stdin
>> x;flex:1;flex-direction:column;max-height:min(650px,calc(100vh - 110px));ove
```

This error was occurring in multiple places and multiple files.  It was showing up because the failing feature tests were trying to look at pages that were requiring some javascript-enhanced scss (`min(650px,calc(100vh - 110px))`) that was failing.

Adding the following to the rails_helper allows the scss values to be appropriately calculated in feature tests:
```
  config.before(:each, type: :feature, js: true) do
    Capybara.javascript_driver = :selenium_chrome_headless
  end
```


