### PR TITLE
1141/HUT : Collection Indexer Key Not Found

### DIFF
--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -62,7 +62,7 @@ module Hyrax
     end
 
     def size
-      number_to_human_size(@solr_document['bytes_lts'])
+      number_to_human_size(@solr_document['bytes'])
     end
 
     def total_items

--- a/spec/indexers/hyrax/collection_indexer_spec.rb
+++ b/spec/indexers/hyrax/collection_indexer_spec.rb
@@ -27,7 +27,7 @@ describe Hyrax::CollectionIndexer do
 
     it "has required fields" do
       expect(subject.fetch('generic_type_sim')).to eq ["Collection"]
-      expect(subject.fetch('bytes_lts')).to eq(1000)
+      expect(subject.fetch('bytes')).to eq(1000)
       expect(subject.fetch('thumbnail_path_ss')).to eq "/downloads/1234?file=thumbnail"
       expect(subject.fetch('member_of_collection_ids_ssim')).to eq [col1id, col2id]
       expect(subject.fetch('member_of_collections_ssim')).to eq [col1title, col2title]
@@ -35,32 +35,32 @@ describe Hyrax::CollectionIndexer do
 
     it "removes leading spaces" do
       collection.stub(:title).and_return ["  I start with a space"]
-      expect(subject.fetch('sort_title_ssi')).to eq("I START WITH A SPACE")
+      expect(subject.fetch('sort_title')).to eq("I START WITH A SPACE")
     end
 
     it "removes leading articles" do
       collection.stub(:title).and_return(["The the is first"])
-      expect(subject.fetch('sort_title_ssi')).to eq("THE IS FIRST")
+      expect(subject.fetch('sort_title')).to eq("THE IS FIRST")
     end
 
     it "removes non alphanumeric characters" do
       collection.stub(:title).and_return(["Title* 30! Sure& $has$ a &lot& of ^^^punctuation!!!!"])
-      expect(subject.fetch('sort_title_ssi')).to eq("TITLE 30 SURE HAS A LOT OF PUNCTUATION")
+      expect(subject.fetch('sort_title')).to eq("TITLE 30 SURE HAS A LOT OF PUNCTUATION")
     end
 
     it "removes double spaces" do
       collection.stub(:title).and_return(["This  title has      extra   spaces"])
-      expect(subject.fetch('sort_title_ssi')).to eq("THIS TITLE HAS EXTRA SPACES")
+      expect(subject.fetch('sort_title')).to eq("THIS TITLE HAS EXTRA SPACES")
     end
 
     it "upcases everything" do
       collection.stub(:title).and_return(["i should be uppercase"])
-      expect(subject.fetch('sort_title_ssi')).to eq("I SHOULD BE UPPERCASE")
+      expect(subject.fetch('sort_title')).to eq("I SHOULD BE UPPERCASE")
     end
 
     it "adds leading 0s as needed" do
       collection.stub(:title).and_return(["1) Is the first title"])
-      expect(subject.fetch('sort_title_ssi')).to eq("00000000000000000001 IS THE FIRST TITLE")
+      expect(subject.fetch('sort_title')).to eq("00000000000000000001 IS THE FIRST TITLE")
     end
   end
 end


### PR DESCRIPTION
Fixes #1141 

Updates two keys in file spec/indexers/hyrax/collection_indexer_spec.rb and use of one of the keys in file app/presenters/hyrax/collection_presenter.rb. 

We were working with the following 2 errors when running the tests in spec/indexers/hyrax/collection_indexer_spec.rb:
```
Hyrax::CollectionIndexer#generate_solr_document removes leading articles
Failure/Error: expect(subject.fetch('sort_title_ssi')).to eq("THE IS FIRST")

KeyError:
key not found: "sort_title_ssi"
```
and
```
Hyrax::CollectionIndexer#generate_solr_document has required fields
Failure/Error: expect(subject.fetch('bytes_lts')).to eq(1000)

KeyError:
key not found: "bytes_lts"
```

"sort_title_ssi", "sort_title", "bytes_lts", and "bytes" are not values we store in our database.  Instead, they are being generated dynamically by Solr.  We need to update the naming of these values to align with the updates in Hyrax.  `sort_title_ssi` becomes `sort_title`, and `bytes_lts` becomes `bytes`.  

In file app/presenters/hyrax/collection_presenter.rb, we are defining "size" using the old `bytes_lts` name.  This is also updated to `bytes`.  "Size" is an overwrite function, and in Hyrax 4.0 it is not being supported at all.  In Hyrax 3.0, the definitionof "size" is a hard-coded `null`, and we are overwriting this to calculate the size based off bytes.  We will need to examine this more closely when we move to Hyrax 4.0.