### PR TITLE
Updates embargo scripts.

### DIFF
--- a/script/embargo_notify.sh
+++ b/script/embargo_notify.sh
@@ -1,3 +1,29 @@
-cd /srv/apps/curate_uc
-export PATH=$PATH:/srv/apps/.gem/ruby/2.7.0/bin
-RAILS_ENV=production bundle exec rake embargo_notify
+#!/bin/sh
+
+# Notify editors that a work has been released
+# script/embargo_notify.sh [production|development]
+
+ENVIRONMENT=$1
+
+APP_DIRECTORY="$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )"
+
+
+if [ $# -eq 0 ]; then
+    echo -e "ERROR: no environment argument [production|development] provided"
+    exit 1
+fi
+
+if [ $ENVIRONMENT != "production" ] && [ $ENVIRONMENT != "development" ]; then
+    echo -e "ERROR: environment argument must be either [production|development] most likely this will be development for local machines and production otherwise"
+    exit 1
+fi
+
+if [[ $ENVIRONMENT == "production" ]]; then
+    export PATH=$PATH:/srv/apps/.gem/ruby/2.7.0/bin
+fi
+
+banner "Notify Embargoe Editors"
+
+cd $APP_DIRECTORY
+
+RAILS_ENV=$ENVIRONMENT bundle exec rake embargo_notify

--- a/script/embargo_notify.sh
+++ b/script/embargo_notify.sh
@@ -1,0 +1,3 @@
+cd /srv/apps/curate_uc
+export PATH=$PATH:/srv/apps/.gem/ruby/2.7.0/bin
+RAILS_ENV=production bundle exec rake embargo_notify

--- a/script/release_embargo.sh
+++ b/script/release_embargo.sh
@@ -1,9 +1,27 @@
-#!/bin/bash
+#!/bin/sh
 
 # Change and expired embargoed objects to open access
 # Runs as a cron job daily just after midnight
+# script/release_embargo.sh [production|development]
 
-cd /srv/apps/curate_uc
-export PATH=$PATH:/srv/apps/.gem/ruby/2.7.0/bin
+ENVIRONMENT=$1
+
+APP_DIRECTORY="$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )"
+
+if [ $# -eq 0 ]; then
+    echo -e "ERROR: no environment argument [production|development] provided"
+    exit 1
+fi
+
+if [ $ENVIRONMENT != "production" ] && [ $ENVIRONMENT != "development" ]; then
+    echo -e "ERROR: environment argument must be either [production|development] most likely this will be development for local machines and production otherwise"
+    exit 1
+fi
+
+if [[ $ENVIRONMENT == "production" ]]; then
+    export PATH=$PATH:/srv/apps/.gem/ruby/2.7.0/bin
+fi
+
+cd $APP_DIRECTORY
 export RELEASE_DATE=`date +\%Y-\%m-\%d -d "+1 day"`
-RAILS_ENV=production bundle exec rake embargo_release["$RELEASE_DATE"]
+RAILS_ENV=$ENVIRONMENT bundle exec rake embargo_release["$RELEASE_DATE"]

--- a/script/release_embargo.sh
+++ b/script/release_embargo.sh
@@ -3,6 +3,7 @@
 # Change and expired embargoed objects to open access
 # Runs as a cron job daily just after midnight
 
-cd "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )"
-export RELEASE_DATE=`date -v +1d "+%Y-\%m-\%d"`
-bundle exec rake embargo_release["$RELEASE_DATE"]
+cd /srv/apps/curate_uc
+export PATH=$PATH:/srv/apps/.gem/ruby/2.7.0/bin
+export RELEASE_DATE=`date +\%Y-\%m-\%d -d "+1 day"`
+RAILS_ENV=production bundle exec rake embargo_release["$RELEASE_DATE"]


### PR DESCRIPTION
Fixes #1165 

The embargo scripts are not being used in cron since the date -v function is crashing.  We need to clean up these scripts and then set them in crontab.  

We have also separated the notification and releasing into their own scripts instead of doing it crontab.

