### PR TITLE
LIBSCHOLAR-42 Conditionalizes delete temp file script.

### DIFF
--- a/script/delete_old_temp_uploads.sh
+++ b/script/delete_old_temp_uploads.sh
@@ -3,4 +3,9 @@
 UPLOADS_DIRECTORY=/mnt/common/scholar-temp-uploads/hyrax/uploaded_file/file
 MAXIMUM_DAYS_TO_KEEP_FILES=30
 
-find $UPLOADS_DIRECTORY/* -maxdepth 0 -type d -ctime +$MAXIMUM_DAYS_TO_KEEP_FILES -exec rm -rf {} \;
+# Check if the directory exists and is not empty
+if [ -d "$UPLOADS_DIRECTORY" ] && [ "$(ls -A "$UPLOADS_DIRECTORY")" ]; then
+    find "$UPLOADS_DIRECTORY"/* -maxdepth 0 -type d -ctime +$MAXIMUM_DAYS_TO_KEEP_FILES -exec rm -rf {} \;
+else
+    echo "Directory $UPLOADS_DIRECTORY is either non-existent or empty. Skipping cleanup."
+fi


### PR DESCRIPTION
Fixes #LIBSCHOLAR-42
Present short summary (50 characters or less)

The delete temp file errors if the folder is empty.  I added a condition to check for existance before running the delete part.

