### PR TITLE
LIBSCHOLAR-43 : Removes the daemon and logging switch from Sidekiq 6+

### DIFF
--- a/script/restart_sidekiq.sh
+++ b/script/restart_sidekiq.sh
@@ -42,4 +42,4 @@ if [[ -z "${FITS_HOME}" ]]; then
   export PATH=$PATH:/opt/fits/fits
 fi
 cd $APP_DIRECTORY
-bundle exec sidekiq -d -c $THREADS -q ingest -q default -q event -q change -q import -q export -q fixity_check -L log/sidekiq.log -C config/sidekiq.yml -e $ENVIRONMENT
+bundle exec sidekiq -c $THREADS -q ingest -q default -q event -q change -q import -q export -q fixity_check -C config/sidekiq.yml -e $ENVIRONMENT


### PR DESCRIPTION
Fixes #LIBSCHOLAR-43

Present short summary (50 characters or less)

In Sidekiq version 6+ they are doing away with the -daemon and -logging options.  We need to remove them from our restart script.  Instead of -daemon and -l we need to set up a Process Supervisor in our DEV, QA, and PROD environments.

This will clean up the messaging in our monthly CRON task.

Transition to a Process Supervisor
To properly manage this new setup, use a process supervisor like systemd. Here’s how to integrate the fixed command:

1. Create a Systemd Service File
Create the service file:

bash
sudo nano /etc/systemd/system/sidekiq.service
Add the following configuration:

ini
[Unit]
Description=Sidekiq Background Worker
After=network.target

[Service]
Type=simple
WorkingDirectory=/path/to/your/app
ExecStart=/usr/bin/env bundle exec sidekiq -c $THREADS -q ingest -q default -q event -q change -q import -q export -q fixity_check -C config/sidekiq.yml -e $ENVIRONMENT
ExecReload=/bin/kill -TSTP $MAINPID
ExecStop=/bin/kill -TERM $MAINPID
User=your_app_user
Group=your_app_group
Restart=always
StandardOutput=syslog
StandardError=syslog
SyslogIdentifier=sidekiq

[Install]
WantedBy=multi-user.target
Replace:

/path/to/your/app with the path to your application directory.
your_app_user and your_app_group with the appropriate user and group.
$THREADS and $ENVIRONMENT with their respective values or hard-code them if necessary.
2. Reload and Start the Service
Reload the systemd daemon:

bash
sudo systemctl daemon-reload
Enable the service to start on boot:

bash
sudo systemctl enable sidekiq
Start the Sidekiq service:

bash
sudo systemctl start sidekiq
View logs:

bash
sudo journalctl -u sidekiq
Optional: Redirect Logs to a File
If you still want logs in a specific file, configure your system logger (e.g., rsyslog) to redirect logs from sidekiq to a file.

For example, add a custom rule in your rsyslog configuration:

Open the rsyslog config file:

bash
sudo nano /etc/rsyslog.d/sidekiq.conf
Add the following:

plaintext
if $programname == 'sidekiq' then /var/log/sidekiq.log
& stop
Restart rsyslog:

bash
sudo systemctl restart rsyslog
