### PR TITLE
LIBSCHOLAR-16 Removes Willow Sword from Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'hydra-remote_identifier', github: 'uclibs/hydra-remote_identifier', branch:
 gem 'kaltura', '0.1.1'
 gem 'rack', '2.2.3'
 gem 'sidekiq-limit_fetch'
-gem 'willow_sword', github: 'notch8/willow_sword'
 
 # Hyrax improvements
 gem "okcomputer", "~> 1.18.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/notch8/willow_sword.git
-  revision: 74f7684ff9ca96251f341e50a3afc34b5bd312cc
-  specs:
-    willow_sword (0.2.0)
-      bagit (~> 0.4.1)
-      rails (>= 5.1.6)
-      rubyzip (>= 1.0.0)
-
-GIT
   remote: https://github.com/uclibs/change_manager.git
   revision: d8e1b552740df00922a0a40796999c4e2a0cb8b6
   ref: d8e1b552740df00922a0a40796999c4e2a0cb8b6
@@ -1243,7 +1234,6 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webdrivers (~> 3.0)
   webmock
-  willow_sword!
 
 BUNDLED WITH
    2.4.22


### PR DESCRIPTION
I am doing this in steps since the CircleCI has been funny.  I removed the Willow Sword gem from the Gemfile.

When reviewing, make sure the BATCH functions work from the Dashboard.
