### PR TITLE
LIBSCHOLAR-16 Bundle Update PR

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'hydra-remote_identifier', github: 'uclibs/hydra-remote_identifier', branch:
 gem 'kaltura', '0.1.1'
 gem 'rack', '2.2.3'
 gem 'sidekiq-limit_fetch'
-gem 'willow_sword', github: 'notch8/willow_sword'
 
 # Hyrax improvements
 gem "okcomputer", "~> 1.18.4"

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
+gem 'redis', '~> 5.4'
 # gem 'redis', '~> 3.0'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
@@ -76,7 +77,7 @@ gem 'orcid', git: 'https://github.com/uclibs/orcid', branch: 'rails-5.x'
 gem 'riiif', '~> 2.0'
 gem 'rsolr', '>= 1.0'
 gem 'sassc-rails', '>= 2.1.0'
-gem 'sidekiq', '~> 5.2.7'
+gem 'sidekiq', '>= 6.0'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/notch8/willow_sword.git
-  revision: 74f7684ff9ca96251f341e50a3afc34b5bd312cc
-  specs:
-    willow_sword (0.2.0)
-      bagit (~> 0.4.1)
-      rails (>= 5.1.6)
-      rubyzip (>= 1.0.0)
-
-GIT
   remote: https://github.com/uclibs/change_manager.git
   revision: d8e1b552740df00922a0a40796999c4e2a0cb8b6
   ref: d8e1b552740df00922a0a40796999c4e2a0cb8b6
@@ -1243,7 +1234,6 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webdrivers (~> 3.0)
   webmock
-  willow_sword!
 
 BUNDLED WITH
    2.4.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -806,8 +806,6 @@ GEM
     rack-openid (1.4.2)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
-    rack-protection (2.2.2)
-      rack
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (5.2.4.6)
@@ -903,7 +901,10 @@ GEM
       rexml (~> 3.2)
     redic (1.5.3)
       hiredis
-    redis (4.5.1)
+    redis (5.4.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.24.0)
+      connection_pool
     redis-namespace (1.9.0)
       redis (>= 4)
     redlock (1.3.0)
@@ -1027,11 +1028,10 @@ GEM
       activesupport (>= 4.0.0)
     show_me_the_cookies (6.0.0)
       capybara (>= 2, < 4)
-    sidekiq (5.2.10)
-      connection_pool (~> 2.2, >= 2.2.2)
+    sidekiq (6.5.5)
+      connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 1.5.0)
-      redis (~> 4.5, < 4.6.0)
+      redis (>= 4.5.0)
     sidekiq-limit_fetch (3.4.0)
       sidekiq (>= 4)
     signet (0.17.0)
@@ -1209,6 +1209,7 @@ DEPENDENCIES
   rack (= 2.2.3)
   rails (~> 5.2.4.6)
   rails-controller-testing
+  redis (~> 5.4)
   rest-client
   riiif (~> 2.0)
   rsolr (>= 1.0)
@@ -1222,7 +1223,7 @@ DEPENDENCIES
   selenium-webdriver (= 3.12.0)
   shoulda-matchers (~> 3.1)
   show_me_the_cookies
-  sidekiq (~> 5.2.7)
+  sidekiq (>= 6.0)
   sidekiq-limit_fetch
   simplecov-lcov
   solr_wrapper (>= 0.3)

--- a/config/initializers/redis_config.rb
+++ b/config/initializers/redis_config.rb
@@ -1,5 +1,13 @@
+# config/initializers/redis_config.rb
 # frozen_string_literal: true
 
 require 'redis'
+
+unless Redis.respond_to?(:current=)
+  class << Redis
+    attr_accessor :current
+  end
+end
+
 config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
-Redis.current = Redis.new(config.merge(thread_safe: true))
+Redis.current = Redis.new(url: config[:url])


### PR DESCRIPTION
Fixes LIBSCHOLAR-16.

Present short summary (50 characters or less)

Bundle updates high bundler audit vulnerabilities around redis, willow_sword, and sidekiq

Description can have multiple paragraphs and you can use code examples inside:

With the redis upgrade, there needed to be a monkey patch to handle the redis.current call that is no longer supported.
