### PR TITLE
Update collection policy and set 5GB file limit

### DIFF
--- a/app/views/static/coll_policy.html.erb
+++ b/app/views/static/coll_policy.html.erb
@@ -22,6 +22,10 @@ href="https://libraries.uc.edu/libraries/arb/records-management.html">Records Ma
     </p>
 
     <p>
+    Scholar@UC limits individual file uploads to 5GB, with a total of 100GB of storage available per account. More information about data management planning can be found here.  Individuals wishing to deposit larger files or data sets must <a href="/contact">contact Scholar@UC support</a>.
+    </p>
+
+    <p>
       <strong>Content classified as restricted by <a href="https://www.uc.edu/content/dam/uc/infosec/docs/policies/Data_Governance_and_Classification_Policy_9.1.1.pdf">University of Cincinnati Policy 9.1.1 (Data Protection Policy)</a> or by export control should never be deposited to <%=t('hyrax.product_name') %>.</strong>
     </p>
 

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -43,7 +43,7 @@ Hyrax.config do |config|
   # config.uploader = {
   #   limitConcurrentUploads: 6,
   #   maxNumberOfFiles: 100,
-  #   maxFileSize: 500.megabytes
+  #   maxFileSize: 500.megabytes NOTE: Don't set here.  Set in vendor/assets/javascripts/fileupload/jquery.fileupload-validate.js
   # }
 
   # Enable displaying usage statistics in the UI

--- a/vendor/assets/javascripts/fileupload/jquery.fileupload-validate.js
+++ b/vendor/assets/javascripts/fileupload/jquery.fileupload-validate.js
@@ -40,7 +40,7 @@
             always: true,
             // Options taken from the global options map:
             acceptFileTypes: '@',
-            maxFileSize: 3221225472, // Limit uploads to 3 GB per file
+            maxFileSize: 5368709120, // Limit uploads to 5 GB per file
             minFileSize: '@',
             maxNumberOfFiles: '@',
             disabled: '@disableValidation'


### PR DESCRIPTION
Fixes https://ucdts.atlassian.net/browse/LIBSCHOLAR-54

Updates the collection policy with details on user upload limits

Modifies the per-file upload size limit from 3GB to 5GB

After merging, create a change request to make these changes as a hot fix.