### PR TITLE
LIBSCHOLAR-56 Add bundler-audit Github workflow

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -17,7 +17,7 @@ ignore:
   - CVE-2022-23516
 
   # nokogiri
-  - GHSA-mrxw-mxhj-p664   # no CVE listed in your output
+  - GHSA-mrxw-mxhj-p664
   - CVE-2022-23476
 
   # omniauth

--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,0 +1,41 @@
+ignore:
+  # actionpack
+  - CVE-2022-23633
+
+  # actionview
+  - CVE-2023-23913
+
+  # activerecord
+  - CVE-2022-44566
+  - CVE-2022-32224
+
+  # activestorage
+  - CVE-2022-21831
+
+  # loofah
+  - CVE-2022-23514
+  - CVE-2022-23516
+
+  # nokogiri
+  - GHSA-mrxw-mxhj-p664   # no CVE listed in your output
+  - CVE-2022-23476
+
+  # omniauth
+  - CVE-2015-9284
+
+  # rack
+  - CVE-2025-27610
+  - CVE-2022-44570
+  - CVE-2025-46727
+  - CVE-2022-30122
+  - CVE-2023-27530
+  - CVE-2022-30123
+
+  # rails-html-sanitizer
+  - CVE-2022-23517
+
+  # rexml
+  - CVE-2024-49761
+
+  # webrick
+  - CVE-2024-47220

--- a/.github/actions/setup-ruby-deps/action.yml
+++ b/.github/actions/setup-ruby-deps/action.yml
@@ -8,5 +8,5 @@ runs:
     - name: Set up Ruby from .ruby-version
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 'file:.ruby-version'
+        ruby-version: .ruby-version
         bundler-cache: true

--- a/.github/actions/setup-ruby-deps/action.yml
+++ b/.github/actions/setup-ruby-deps/action.yml
@@ -1,5 +1,5 @@
-name: "Setup Ruby & Node"
-description: "Sets up Ruby from .ruby-version with Bundler caching, and Node.js from .nvmrc with Yarn caching."
+name: "Setup Ruby"
+description: "Sets up Ruby from .ruby-version with Bundler caching"
 
 inputs: {}
 runs:
@@ -8,28 +8,5 @@ runs:
     - name: Set up Ruby from .ruby-version
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: .ruby-version
+        ruby-version: 'file:.ruby-version'
         bundler-cache: true
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version-file: '.nvmrc'
-        cache: 'yarn'
-
-    - name: Restore node_modules cache
-      uses: actions/cache@v3
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-node-modules-
-    - name: Install Dependencies
-      run: yarn install --frozen-lockfile
-      shell: bash
-
-    - name: Save node_modules cache
-      uses: actions/cache@v3
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}

--- a/.github/actions/setup-ruby-deps/action.yml
+++ b/.github/actions/setup-ruby-deps/action.yml
@@ -1,0 +1,35 @@
+name: "Setup Ruby & Node"
+description: "Sets up Ruby from .ruby-version with Bundler caching, and Node.js from .nvmrc with Yarn caching."
+
+inputs: {}
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Ruby from .ruby-version
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: .ruby-version
+        bundler-cache: true
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'yarn'
+
+    - name: Restore node_modules cache
+      uses: actions/cache@v3
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-node-modules-
+    - name: Install Dependencies
+      run: yarn install --frozen-lockfile
+      shell: bash
+
+    - name: Save node_modules cache
+      uses: actions/cache@v3
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -14,16 +14,23 @@ jobs:
       - name: Set up Ruby and install gems
         uses: ./.github/actions/setup-ruby-deps
 
+      - name: Print tool versions
+        run: |
+          echo "Ruby version:       $(ruby -v)"
+          echo "Gem version:        $(gem -v)"
+          echo "Bundler version:    $(bundle -v)"
+          echo "Bundler-Audit version: $(bundle exec bundler-audit version || echo 'not installed')"
+
       - name: Run Bundler-Audit
         run: |
           mkdir -p tmp
-          # Allow bundler-audit to return 1 (vulnerabilities found) without failing the step
+          # Allow 'vulnerabilities found' (exit 1) without failing the step
           set +e
-          bundle exec bundler-audit check --update > tmp/bundler-audit-output.txt
+          bundle exec bundle audit check --update > tmp/bundler-audit-output.txt
           AUDIT_EXIT=$?
           set -e
           if [ $AUDIT_EXIT -ne 0 ] && [ $AUDIT_EXIT -ne 1 ]; then
-            echo "bundler-audit failed unexpectedly (exit code $AUDIT_EXIT)"
+            echo "bundle audit failed unexpectedly (exit code $AUDIT_EXIT)"
             exit $AUDIT_EXIT
           fi
         shell: bash

--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -1,0 +1,46 @@
+name: Ensure Bundler-Audit Passes
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  bundler-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Ruby and install gems
+        uses: ./.github/actions/setup-ruby-deps
+
+      - name: Run Bundler-Audit
+        run: |
+          mkdir -p tmp
+          # Allow bundler-audit to return 1 (vulnerabilities found) without failing the step
+          set +e
+          bundle exec bundler-audit check --update > tmp/bundler-audit-output.txt
+          AUDIT_EXIT=$?
+          set -e
+          if [ $AUDIT_EXIT -ne 0 ] && [ $AUDIT_EXIT -ne 1 ]; then
+            echo "bundler-audit failed unexpectedly (exit code $AUDIT_EXIT)"
+            exit $AUDIT_EXIT
+          fi
+        shell: bash
+
+      - name: Analyze Bundler-Audit Output
+        run: |
+          if grep -Eq '^Criticality:\s*(Critical|High)' tmp/bundler-audit-output.txt; then
+            echo "High or Critical vulnerabilities detected!"
+            cat tmp/bundler-audit-output.txt
+            exit 1
+          else
+            echo "No High or Critical vulnerabilities detected."
+          fi
+        shell: bash
+
+      - name: Upload Bundler-Audit Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundler-audit-report
+          path: tmp/bundler-audit-output.txt


### PR DESCRIPTION
Jira Issue: [#56](https://ucdts.atlassian.net/browse/LIBSCHOLAR-56)

## Run bundler‑audit on PRs
This PR adds an automated security check for Ruby gems on every pull request.

### What’s included
- GitHub Actions workflow to run `bundle exec bundle audit check --update`
- Composite action to set up Ruby from `.ruby-version` with Bundler caching
- .bundler-audit.yml to temporarily ignore currently known High/Critical advisories from our scan (kept in VCS for auditability)

### Behavior
- Saves output to tmp/bundler-audit-output.txt
- Fails if bundler-audit exits unexpectedly (e.g., network or tool errors)
- Fails the job if any High/Critical vulnerabilities are detected and not ignored
- Uploads the full audit report as a workflow artifact

### Local usage
`bundle exec bundle audit check --update`
