### PR TITLE
LIBSCHOLAR-25 Run Brakeman on PRs

### DIFF
--- a/.github/actions/setup-ruby-deps/action.yml
+++ b/.github/actions/setup-ruby-deps/action.yml
@@ -1,0 +1,12 @@
+name: "Setup Ruby"
+description: "Sets up Ruby from .ruby-version with Bundler caching"
+
+inputs: {}
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Ruby from .ruby-version
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: .ruby-version
+        bundler-cache: true

--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -21,17 +21,28 @@ jobs:
           echo "Bundler version:    $(bundle -v)"
           echo "Brakeman version:   $(bundle exec brakeman --version || echo 'not installed')"
 
+      - name: Check if Brakeman is up-to-date (warn only)
+        run: |
+          set +e
+          bundle exec brakeman -q --no-progress --ensure-latest >/dev/null
+          CODE=$?
+          set -e
+          if [ "$CODE" -eq 5 ]; then
+            echo "::warning title=Brakeman::Installed version is not the latest. Run 'bundle update brakeman' to update."
+          elif [ "$CODE" -ne 0 ]; then
+            echo "::error title=Brakeman::Version check failed::Exit code $CODE"
+            exit $CODE
+          fi
+
       - name: Run Brakeman (JSON)
         run: |
           mkdir -p tmp
-          # --ensure-latest fails if the installed gem isn't the newest
-          # --no-exit-on-warn lets us control failure based on jq filtering
-          bundle exec brakeman -q --no-progress --ensure-latest --no-exit-on-warn \
+          bundle exec brakeman -q --no-progress --no-exit-on-warn \
             -f json -o tmp/brakeman-output.json
 
       - name: Run Brakeman (plain text for humans)
         run: |
-          bundle exec brakeman -q --no-progress --ensure-latest --no-exit-on-warn \
+          bundle exec brakeman -q --no-progress --no-exit-on-warn \
             -f plain -o tmp/brakeman-output.txt || true
 
       - name: Show Brakeman JSON summary
@@ -47,7 +58,6 @@ jobs:
             tmp/brakeman-output.json
             tmp/brakeman-output.txt
 
-      # Fail the job based on High-confidence findings
       - name: Fail on High-confidence warnings
         run: |
           HIGH_CONF_COUNT=$(jq '[.warnings[] | select(.confidence == "High")] | length' tmp/brakeman-output.json)

--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -11,36 +11,48 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Ruby, Gems, and Install Dependencies
+      - name: Set up Ruby & install gems (cached)
         uses: ./.github/actions/setup-ruby-deps
 
-      - name: Run Brakeman (Human-readable and JSON outputs)
+      - name: Print tool versions
+        run: |
+          echo "Ruby version:       $(ruby -v)"
+          echo "Gem version:        $(gem -v)"
+          echo "Bundler version:    $(bundle -v)"
+          echo "Brakeman version:   $(bundle exec brakeman --version || echo 'not installed')"
+
+      - name: Run Brakeman (JSON)
         run: |
           mkdir -p tmp
-          bundle exec brakeman --no-exit-on-warn -o tmp/brakeman-output.json
-        env:
-          BRAKEMAN_FORMAT: json
+          # --ensure-latest fails if the installed gem isn't the newest
+          # --no-exit-on-warn lets us control failure based on jq filtering
+          bundle exec brakeman -q --no-progress --ensure-latest --no-exit-on-warn \
+            -f json -o tmp/brakeman-output.json
 
-      - name: Display Brakeman Report
+      - name: Run Brakeman (plain text for humans)
         run: |
-          echo "Brakeman Report (JSON):"
-          cat tmp/brakeman-output.json || echo "Brakeman report is missing or empty."
-        shell: bash
+          bundle exec brakeman -q --no-progress --ensure-latest --no-exit-on-warn \
+            -f plain -o tmp/brakeman-output.txt || true
 
-      - name: Upload Brakeman Report
+      - name: Show Brakeman JSON summary
+        run: |
+          echo "Warnings count: $(jq '.warnings | length' tmp/brakeman-output.json)"
+          echo "High-confidence count: $(jq '[.warnings[] | select(.confidence == "High")] | length' tmp/brakeman-output.json)"
+
+      - name: Upload Brakeman Reports
         uses: actions/upload-artifact@v4
         with:
           name: brakeman-report
-          path: tmp/brakeman-output.json
+          path: |
+            tmp/brakeman-output.json
+            tmp/brakeman-output.txt
 
-      - name: Fail on High-Severity Issues
+      # Fail the job based on High-confidence findings
+      - name: Fail on High-confidence warnings
         run: |
-          HIGH_SEVERITY_COUNT=$(jq '.warnings | map(select(.confidence == "High")) | length' tmp/brakeman-output.json)
-          echo "High severity issues: $HIGH_SEVERITY_COUNT"
-          if [ "$HIGH_SEVERITY_COUNT" -gt 0 ]; then
-            echo "Brakeman detected high-severity issues. Failing the job."
+          HIGH_CONF_COUNT=$(jq '[.warnings[] | select(.confidence == "High")] | length' tmp/brakeman-output.json)
+          echo "High-confidence warnings: $HIGH_CONF_COUNT"
+          if [ "$HIGH_CONF_COUNT" -gt 0 ]; then
+            echo "Brakeman detected high-confidence warnings. Failing the job."
             exit 1
           fi
-        env:
-          BRAKEMAN_FORMAT: json
-        shell: bash

--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -1,0 +1,46 @@
+name: Ensure Brakeman Passes
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  brakeman:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Ruby, Gems, and Install Dependencies
+        uses: ./.github/actions/setup-ruby-deps
+
+      - name: Run Brakeman (Human-readable and JSON outputs)
+        run: |
+          mkdir -p tmp
+          bundle exec brakeman --no-exit-on-warn -o tmp/brakeman-output.json
+        env:
+          BRAKEMAN_FORMAT: json
+
+      - name: Display Brakeman Report
+        run: |
+          echo "Brakeman Report (JSON):"
+          cat tmp/brakeman-output.json || echo "Brakeman report is missing or empty."
+        shell: bash
+
+      - name: Upload Brakeman Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: brakeman-report
+          path: tmp/brakeman-output.json
+
+      - name: Fail on High-Severity Issues
+        run: |
+          HIGH_SEVERITY_COUNT=$(jq '.warnings | map(select(.confidence == "High")) | length' tmp/brakeman-output.json)
+          echo "High severity issues: $HIGH_SEVERITY_COUNT"
+          if [ "$HIGH_SEVERITY_COUNT" -gt 0 ]; then
+            echo "Brakeman detected high-severity issues. Failing the job."
+            exit 1
+          fi
+        env:
+          BRAKEMAN_FORMAT: json
+        shell: bash

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,7 @@ GEM
     bootstrap_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
-    brakeman (5.3.1)
+    brakeman (5.4.1)
     breadcrumbs_on_rails (3.0.1)
     browse-everything (1.1.0)
       addressable (~> 2.5)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -16,6 +16,24 @@
       "confidence": "High",
       "cwe_id": [1104],
       "note": "Temporarily ignoring until Ruby upgrade is complete"
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 120,
+      "fingerprint": "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 5.2.4.6 ended on 2022-06-01",
+      "file": "Gemfile.lock",
+      "line": 811,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "High",
+      "cwe_id": [
+        1104
+      ]
     }
   ],
   "updated": "2025-08-20 20:35:33 +0000",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,33 +1,13 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Mass Assignment",
-      "warning_code": 70,
-      "fingerprint": "c58372ffa9750e7506995301196bc155ae5e14f7b5f01d301b8232036c8b2ca3",
-      "check_name": "MassAssignment",
-      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
-      "file": "app/controllers/hyrax/batch_uploads_controller.rb",
-      "line": 16,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params[:title].permit!",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Hyrax::BatchUploadsController",
-        "method": "create_update_job"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
       "warning_type": "Unmaintained Dependency",
       "warning_code": 121,
-      "fingerprint": "9a3951031616a07c8e02c86652f537e92c08685da97f5ec2b12d5d3602b55bb8",
+      "fingerprint": "edf687f759ec9765bd5db185dbc615c80af77d6e7e19386fc42934e7a80307af",
       "check_name": "EOLRuby",
       "message": "Support for Ruby 2.7.8 ended on 2023-03-31",
-      "file": "Gemfile.lock",
-      "line": 821,
+      "file": ".ruby-version",
+      "line": 1,
       "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
       "code": null,
       "render_path": null,
@@ -35,26 +15,9 @@
       "user_input": null,
       "confidence": "High",
       "cwe_id": [1104],
-      "note": "Ruby EOL ignored due to pending upgrade of Ruby version along with upgrade of Hyrax in year-end 2023 sprint"
-    },
-    {
-      "warning_type": "Unmaintained Dependency",
-      "warning_code": 120,
-      "fingerprint": "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
-      "check_name": "EOLRails",
-      "message": "Support for Rails 5.2.4.6 ended on 2022-06-01",
-      "file": "Gemfile.lock",
-      "line": 821,
-      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "High",
-      "cwe_id": [1104],
-      "note": "Rails EOL ignored due to pending upgrade of Rails version along with upgrade of Hyrax in year-end 2023 sprint"
+      "note": "Temporarily ignoring until Ruby upgrade is complete"
     }
   ],
-  "updated": "2023-11-03 14:42:01 -0400",
-  "brakeman_version": "5.3.1"
+  "updated": "2025-08-20 20:35:33 +0000",
+  "brakeman_version": "5.4.1"
 }


### PR DESCRIPTION
Jira Issue: [#25](https://ucdts.atlassian.net/browse/LIBSCHOLAR-25)

## Run Brakeman on PRs
This PR adds an automated security scan with Brakeman on every pull request.

### What’s included
- GitHub Actions workflow to run Brakeman and upload reports
- Composite action to set up Ruby from .ruby-version with Bundler caching (duplicated in Jira Issue # )
- config/brakeman.ignore updated to ignore High-confidence warnings related to our current Ruby (2.7.8) and Rails (5.2.4.6) versions
- Brakeman gem bumped to 5.4.1 (latest supported with Ruby 2.7) within Gemfile.lock

### Behavior
- Prints tool versions for traceability
- Warns (non-blocking) if Brakeman is not the latest release (Latest release not supported with our dependencies)
- Runs Brakeman twice: JSON (for automation) and plain text (for readability)
- Uploads both reports as workflow artifacts
- Fails the job if any High-confidence warnings are detected that are not on the ignore list

### Local usage
`bundle exec brakeman -q --no-progress --no-exit-on-warn -f plain`


