### PR TITLE
Gem updates to fix Capistrano

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,10 @@ gem 'rsolr', '>= 1.0'
 gem 'sassc-rails', '>= 2.1.0'
 gem 'sidekiq', '>= 6.0'
 
+# Required for capistrano deploys
+gem 'bcrypt_pbkdf' # Password hashing library, required for ssh deployment
+gem 'ed25519' # Ed25519 elliptic curve public-key signature system
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'bixby', '>= 1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,7 @@ GEM
     bcp47 (0.3.3)
       i18n
     bcrypt (3.1.18)
+    bcrypt_pbkdf (1.1.1)
     bigdecimal (1.3.5)
     bindex (0.8.1)
     bixby (5.0.2)
@@ -378,6 +379,7 @@ GEM
       scanf (~> 1.0)
       sxp (~> 1.2)
       unicode-types (~> 1.7)
+    ed25519 (1.3.0)
     email_validator (2.2.3)
       activemodel
     equivalent-xml (0.6.0)
@@ -733,7 +735,7 @@ GEM
       connection_pool (~> 2.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (7.0.1)
+    net-ssh (7.3.0)
     netrc (0.11.0)
     nio4r (2.5.8)
     noid (0.9.0)
@@ -1164,6 +1166,7 @@ DEPENDENCIES
   active-fedora (~> 12.2.4)
   active_attr
   aws-xray-sdk
+  bcrypt_pbkdf
   bigdecimal (= 1.3.5)
   bixby (>= 1.0.0)
   bootstrap-sass (~> 3.4.1)
@@ -1188,6 +1191,7 @@ DEPENDENCIES
   devise-guests (~> 0.6)
   devise-multi_auth!
   dotenv-rails
+  ed25519
   equivalent-xml
   factory_bot_rails (~> 4.11.1)
   fcrepo_wrapper


### PR DESCRIPTION
Updates the net-ssh gem to resolve crypto compatibility with the servers

Adds the bcrypt_pbkdf and ed25519 gems required by the newer net-ssh gem

The deploy to dev completed successfully for me.  However, it complained about our newer sidekiq 6.0 version.  We still don't have a Linux service for starting and stopping the newer sidekiq.  Either need to do that or revert to < 6.0 version.