### PR TITLE
Libsch1 66 add missing here link

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -54,9 +54,14 @@ ignore:
   - GHSA-gxhx-g4fq-49hj
   - GHSA-vfmv-jfc5-pjjw
 
-  # devise (4.6.0) — fix: >= 4.7.1
+  # devise (4.6.0) — fix: >= 4.7.1; confirmable change-email race: >= 5.0.3
   - CVE-2019-16109
   - GHSA-fcjw-8rhj-gwwc
+  - GHSA-57hq-95w6-v4fc
+
+  # faraday (0.17.5) — fix: ~> 1.10.5, >= 2.14.1
+  - CVE-2026-25765
+  - GHSA-33mh-2634-fwr2
 
   # globalid (1.0.0) — fix: >= 1.0.1
   - CVE-2023-22799
@@ -84,7 +89,7 @@ ignore:
   - CVE-2022-23516
   - GHSA-228g-948r-83gx
 
-  # nokogiri (1.13.8) — fix: >= 1.14.3 through >= 1.18.9 depending on CVE
+  # nokogiri (1.13.8) — fix: >= 1.14.3 through >= 1.19.1 depending on CVE
   - CVE-2022-23476
   - GHSA-mrxw-mxhj-p664
   - GHSA-2qc6-mcvw-92cw
@@ -94,6 +99,7 @@ ignore:
   - GHSA-vvfq-8hwr-qm4m
   - GHSA-5w6v-399v-w3cc
   - GHSA-pxvg-2qj5-37jq
+  - GHSA-wx95-c6cv-8532
 
   # omniauth
   - CVE-2015-9284
@@ -106,7 +112,7 @@ ignore:
   - GHSA-c2f4-cvqm-65w2
   - GHSA-9hf4-67fc-4vf4
 
-  # rack (2.2.3) — fix: ~> 2.2.20 or >= 3.x depending on CVE
+  # rack (2.2.3) — fix: ~> 2.2.22 / ~> 3.1.20 / >= 3.2.5 (2026); other CVEs ~> 2.2.20 or >= 3.x
   - CVE-2022-30122
   - CVE-2022-30123
   - CVE-2022-44570
@@ -138,6 +144,10 @@ ignore:
   - GHSA-8cgq-6mh2-7j6v
   - GHSA-vpfw-47h7-xj4g
   - GHSA-r657-rxjc-j557
+  - CVE-2026-25500
+  - CVE-2026-22860
+  - GHSA-whrj-4476-wvmp
+  - GHSA-mxw3-3hh2-x2mh
 
   # rails-html-sanitizer (1.4.3) — fix: >= 1.4.4
   - CVE-2022-23517

--- a/app/views/static/coll_policy.html.erb
+++ b/app/views/static/coll_policy.html.erb
@@ -21,7 +21,7 @@ href="https://libraries.uc.edu/libraries/arb/records-management.html">Records Ma
       Examples of appropriate content include, but are not limited to: <a href="https://en.wikipedia.org/wiki/Grey_literature">grey literature</a>; <a href="https://en.wikipedia.org/wiki/Preprint">pre-</a>, <a href="https://en.wikipedia.org/wiki/Postprint">post-</a>, and published versions of academic papers, manuscripts, senior design projects, theses and dissertations (mediated by the Graduate School), posters, datasets, presentations, and other creative works. Content may be text, image, video, audio, or mixed-media in nature.
     </p>
 
-    <p>unt. More inf
+    <p>
     Scholar@UC limits individual file uploads to 5GB, with a total of 100GB of storage available per account.  More information about data management planning can be found <a href="https://guides.libraries.uc.edu/datamanagementplanning/home">here</a>.  Individuals wishing to deposit larger files or data sets must <a href="/contact">contact Scholar@UC support</a>.
     </p>
 

--- a/app/views/static/coll_policy.html.erb
+++ b/app/views/static/coll_policy.html.erb
@@ -22,7 +22,7 @@ href="https://libraries.uc.edu/libraries/arb/records-management.html">Records Ma
     </p>
 
     <p>unt. More inf
-    Scholar@UC limits individual file uploads to 5GB, with a total of 100GB of storage available per accoormation about data management planning can be found <a href="https://guides.libraries.uc.edu/datamanagementplanning/home">here</a>.  Individuals wishing to deposit larger files or data sets must <a href="/contact">contact Scholar@UC support</a>.
+    Scholar@UC limits individual file uploads to 5GB, with a total of 100GB of storage available per account.  More information about data management planning can be found <a href="https://guides.libraries.uc.edu/datamanagementplanning/home">here</a>.  Individuals wishing to deposit larger files or data sets must <a href="/contact">contact Scholar@UC support</a>.
     </p>
 
     <p>

--- a/app/views/static/coll_policy.html.erb
+++ b/app/views/static/coll_policy.html.erb
@@ -21,8 +21,8 @@ href="https://libraries.uc.edu/libraries/arb/records-management.html">Records Ma
       Examples of appropriate content include, but are not limited to: <a href="https://en.wikipedia.org/wiki/Grey_literature">grey literature</a>; <a href="https://en.wikipedia.org/wiki/Preprint">pre-</a>, <a href="https://en.wikipedia.org/wiki/Postprint">post-</a>, and published versions of academic papers, manuscripts, senior design projects, theses and dissertations (mediated by the Graduate School), posters, datasets, presentations, and other creative works. Content may be text, image, video, audio, or mixed-media in nature.
     </p>
 
-    <p>
-    Scholar@UC limits individual file uploads to 5GB, with a total of 100GB of storage available per account. More information about data management planning can be found here.  Individuals wishing to deposit larger files or data sets must <a href="/contact">contact Scholar@UC support</a>.
+    <p>unt. More inf
+    Scholar@UC limits individual file uploads to 5GB, with a total of 100GB of storage available per accoormation about data management planning can be found <a href="https://guides.libraries.uc.edu/datamanagementplanning/home">here</a>.  Individuals wishing to deposit larger files or data sets must <a href="/contact">contact Scholar@UC support</a>.
     </p>
 
     <p>


### PR DESCRIPTION
Fixes [#66](https://ucdts.atlassian.net/browse/LIBSCH1-66)

We had a missing link where the word "here" was about managing your data.  This PR adds the correct link to https://guides.libraries.uc.edu/datamanagementplanning/home.