### PR TITLE
Update README with M-chip mac instruction focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,83 +4,192 @@
 [![CircleCI](https://circleci.com/gh/uclibs/ucrate.svg?style=svg)](https://circleci.com/gh/uclibs/ucrate)
 [![Coverage Status](https://coveralls.io/repos/github/uclibs/ucrate/badge.svg?branch=main)](https://coveralls.io/github/uclibs/ucrate?branch=main)
 
-## Dependencies
+## System Requirements
 
-***Our Hyrax 2.x based app requires the following software to work:
+### macOS with Apple Silicon (M1–M4) — Recommended
 
-* Solr version >= 5.x (tested up to 6.2.0)
-* Fedora Commons digital repository version >= 4.5.1 (tested up to 4.6.0)
-* A SQL RDBMS (MySQL, PostgreSQL), though note that SQLite will be used by default if you're looking to get up and running quickly
-  * libmysqlclient-dev (if running MySQL as RDBMS)
-  * libsqlite3-dev (if running SQLite as RDBMS)
-* Redis, a key-value store
-* ImageMagick with JPEG-2000 support
-* FITS version 1.0.x (1.0.5 is known to be good)
+* Ruby 2.7.8 (built with OpenSSL 1.1.1)
+* Bundler 2.4.22
+* Solr 5.x–6.2.0
+* Fedora Commons 4.5.1+
+* MySQL 8.0+
+* Redis
+* ImageMagick
+* Java 8 (for Fedora)
 * LibreOffice
 
-## Installing the Scholar application
+### macOS with Intel Chip
 
-1. Clone this repository: `git clone https://github.com/uclibs/ucrate.git ./path/to/local`
-    > **Note:** Solr will not run properly if there are spaces in any of the directory names above it <br />(e.g. /user/my apps/ucrate/)
-1. Change to the application's directory: e.g. `cd ./path/to/local`  
-1. Make sure you are on the develop branch: `git checkout develop`
-1. Install bundler (if needed): `gem install bundler -v 2.4.22`
-1. Run bundler: `bundle install`
-   Apple Silicon (M1–M4) Users with MySQL 9: mysql2 Build Fix
-   If you're using MySQL 9+ on Apple Silicon, mysql2 needs to be compiled with additional flags due to missing default linker paths (e.g. for zstd).
-    ```
-    bundle config build.mysql2 \
-      "--with-ldflags='-L/opt/homebrew/opt/mysql/lib -L/opt/homebrew/opt/zstd/lib' \
-      --with-cppflags='-I/opt/homebrew/opt/mysql/include -I/opt/homebrew/opt/zstd/include'"
-    ```
-    Then run: `bundle install`
-1. Apple Silicon (M1–M4) Fedora note:
-   * Install the Java 8 runtime once (Temurin ARM build):
-     ```
-     brew install --cask temurin@8
-     ```
-1. Start fedora: ```fcrepo_wrapper -p 8984```
-1. Apple Silicon (M1–M4) Fedora note:
-   * When starting Fedora, point that terminal tab at Java 8 before running the wrapper:
-     ```
-     export JAVA_HOME="/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home"
-     export PATH="$JAVA_HOME/bin:$PATH"
-     fcrepo_wrapper -p 8984
-     ```
-   * Only the Fedora tab needs these exports; other tabs can keep the default JDK.
-1. Start solr in new tab: ```solr_wrapper -d solr/config/ --collection_name hydra-development```
-1. Start redis in new tab: ```redis-server```
-1. Run the database migrations: `bundle exec rake db:migrate`
-1. Start the rails server in new tab: `rails server`
-1. Visit the site at [http://localhost:3000] (http://localhost:3000)
-1. Create default admin set: ```bin/rails hyrax:default_admin_set:create```
-1. Create default collection: ```bundle exec rails hyrax:default_collection_types:create```
-1. Load workflows: ```bin/rails hyrax:workflow:load```
-    * Creating default admin set should also load the default workflow. You can load, any additional workflows defined, using this command.
-1. Assigning admin role to user from `rails console`:
-    * ```admin = Role.find_or_create_by(name: "admin")```
-    * ```admin.users << User.find_by_user_key( "your_admin_users_email@fake.email.org" )```
-    * ```admin.save```
-    * Read [more](https://github.com/samvera/hyrax/wiki/Making-Admin-Users-in-Hyrax).
+* Ruby 2.7.8 (build instructions same as above, but runs natively on Intel)
+* All other dependencies same as Apple Silicon
+* No special compiler flags needed for native extensions
 
-## Running the Tests
-1. Start fedora: ```fcrepo_wrapper -p 8080```
-1. Apple Silicon (M1–M4) Fedora note:
-   * When starting Fedora for tests, point that terminal tab at Java 8 before running the wrapper:
-     ```
-     export JAVA_HOME="/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home"
-     export PATH="$JAVA_HOME/bin:$PATH"
-     fcrepo_wrapper -p 8080
-     ```
-   * Only the Fedora tab needs these exports; other tabs can keep the default JDK.
-1. Start solr: ```solr_wrapper -d solr/config/ --collection_name hydra-test -p 8985```
-1. Start redis: ```redis-server```
-1. Run the database migrations: ```bundle exec rake db:migrate``` (Optional)
-1. Run the test suite: ```bundle exec rake spec```
+> **Note:** Solr will not run properly if there are spaces in any of the directory names in its path.
 
-## Check for vulnerabilities
-1. Run brakeman: ```bundle exec brakeman -q -w 2```
-1. Run bundler-audit: ```bundle-audit check --update```
+---
+
+## Quick Start
+
+### Clone & Setup (all platforms)
+
+```bash
+git clone https://github.com/uclibs/ucrate.git ./path/to/ucrate
+cd ./path/to/ucrate
+git checkout develop
+```
+
+### 1. Install Dependencies
+
+#### macOS with Apple Silicon (M1–M4)
+
+**Install Homebrew packages:**
+```bash
+brew install sqlite3 mysql-client redis solr@8 imagemagick@6 libreoffice libsodium zstd
+```
+
+**Install Java 8 (required for Fedora):**
+```bash
+brew install --cask temurin@8
+```
+
+**Build OpenSSL 1.1.1 (required by Ruby 2.7.8):**
+```bash
+cd /tmp
+curl -fL -o openssl-1.1.1w.tar.gz https://www.openssl.org/source/openssl-1.1.1w.tar.gz
+tar -xzf openssl-1.1.1w.tar.gz && cd openssl-1.1.1w
+./Configure darwin64-arm64-cc --prefix=/usr/local/opt/openssl@1.1 no-shared
+make -j$(sysctl -n hw.logicalcpu)
+sudo make install_sw
+```
+
+**Install Ruby 2.7.8 via rbenv:**
+```bash
+brew install rbenv ruby-build
+RUBY_CONFIGURE_OPTS="--with-openssl-dir=/usr/local/opt/openssl@1.1" rbenv install 2.7.8
+rbenv local 2.7.8
+```
+
+**Install Bundler & gems:**
+```bash
+gem install bundler -v 2.4.22
+cd /path/to/ucrate
+export CFLAGS="-Wno-incompatible-function-pointer-types"
+export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib -L$(brew --prefix zstd)/lib"
+bundle _2.4.22_ config set build.mysql2 "--with-mysql-config=$(brew --prefix mysql-client)/bin/mysql_config"
+bundle _2.4.22_ install
+```
+
+#### macOS with Intel Chip
+
+**Install Homebrew packages:**
+```bash
+brew install sqlite3 mysql-client redis solr@8 imagemagick@6 libreoffice libsodium
+```
+
+**Install Java 8:**
+```bash
+brew install --cask temurin@8
+```
+
+**Install Ruby 2.7.8 via rbenv:**
+```bash
+brew install rbenv ruby-build
+rbenv install 2.7.8
+rbenv local 2.7.8
+```
+
+**Install Bundler & gems:**
+```bash
+gem install bundler -v 2.4.22
+cd /path/to/ucrate
+bundle install
+```
+
+---
+
+## Running the Application
+
+### Start Background Services (in separate terminal tabs)
+
+**Terminal 1 — Fedora (port 8984):**
+```bash
+export JAVA_HOME="/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home"
+export PATH="$JAVA_HOME/bin:$PATH"
+fcrepo_wrapper -p 8984
+```
+
+**Terminal 2 — Solr (port 8983):**
+```bash
+solr_wrapper -d solr/config/ --collection_name hydra-development
+```
+
+**Terminal 3 — Redis (port 6379):**
+```bash
+redis-server
+```
+
+### Setup Database & Start Rails
+
+**In project directory:**
+```bash
+bundle exec rake db:migrate
+bundle exec rails hyrax:default_admin_set:create
+bundle exec rails hyrax:default_collection_types:create
+bundle exec rails hyrax:workflow:load
+rails server
+```
+
+Visit **http://localhost:3000**
+
+### Create Admin User
+
+In a new terminal:
+```bash
+bundle exec rails console
+admin = Role.find_or_create_by(name: "admin")
+admin.users << User.find_by_user_key("your_email@example.com")
+admin.save
+exit
+```
+
+---
+
+## Running Tests
+
+### Start Test Services (in separate terminal tabs)
+
+**Terminal 1 — Fedora (port 8080):**
+```bash
+export JAVA_HOME="/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home"
+export PATH="$JAVA_HOME/bin:$PATH"
+fcrepo_wrapper -p 8080
+```
+
+**Terminal 2 — Solr (port 8985):**
+```bash
+solr_wrapper -d solr/config/ --collection_name hydra-test -p 8985
+```
+
+**Terminal 3 — Redis:**
+```bash
+redis-server
+```
+
+### Run Tests
+
+```bash
+bundle exec rake db:migrate RAILS_ENV=test
+bundle exec rake spec
+```
+
+---
+
+## Security Checks
+
+```bash
+bundle exec brakeman -q -w 2
+bundle-audit check --update
+```
 
 ## Project Samvera
 This software has been developed by and is brought to you by the Samvera community. Learn more at the

--- a/README.md
+++ b/README.md
@@ -147,8 +147,9 @@ redis-server
 ### Terminal 4: Rails Application
 
 **All platforms:**
+Make sure this terminal is in your `ucrate` project directory.
+
 ```bash
-cd /path/to/ucrate
 bundle exec rake db:migrate
 bundle exec rails hyrax:default_admin_set:create
 bundle exec rails hyrax:default_collection_types:create
@@ -163,6 +164,10 @@ Visit **http://localhost:3000**
 In a new terminal:
 ```bash
 bundle exec rails console
+```
+
+In the Rails console:
+```ruby
 admin = Role.find_or_create_by(name: "admin")
 admin.users << User.find_by_user_key("your_email@example.com")
 admin.save
@@ -201,8 +206,9 @@ redis-server
 ### Terminal 4: Run Tests
 
 **All platforms:**
+Make sure this terminal is in your `ucrate` project directory.
+
 ```bash
-cd /path/to/ucrate
 RAILS_ENV=test bundle exec rake db:migrate
 bundle exec rake spec
 ```
@@ -240,6 +246,17 @@ export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
 export PATH="$JAVA_HOME/bin:$PATH"
 java -version
 bundle exec fcrepo_wrapper -p 8984
+```
+
+### `zsh: command not found: redis-server`
+
+Cause: Redis is not installed yet.
+
+Fix:
+```bash
+brew install redis
+redis-server --version
+redis-server
 ```
 
 ## Project Samvera

--- a/README.md
+++ b/README.md
@@ -123,14 +123,7 @@ Start these services in separate terminal tabs (foreground; do not append `&`):
 
 ### Terminal 1: Fedora (port 8984)
 
-**macOS with Apple Silicon (M1-M4):**
-```bash
-export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
-export PATH="$JAVA_HOME/bin:$PATH"
-bundle exec fcrepo_wrapper -p 8984
-```
-
-**macOS with Intel:**
+**All platforms:**
 ```bash
 export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
 export PATH="$JAVA_HOME/bin:$PATH"
@@ -141,7 +134,7 @@ bundle exec fcrepo_wrapper -p 8984
 
 **All platforms:**
 ```bash
-solr_wrapper -d solr/config/ --collection_name hydra-development
+bundle exec solr_wrapper -d solr/config/ --collection_name hydra-development
 ```
 
 ### Terminal 3: Redis (port 6379)
@@ -184,14 +177,7 @@ Start these services in separate terminal tabs (foreground; do not append `&`):
 
 ### Terminal 1: Fedora (port 8080)
 
-**macOS with Apple Silicon (M1-M4):**
-```bash
-export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
-export PATH="$JAVA_HOME/bin:$PATH"
-bundle exec fcrepo_wrapper -p 8080
-```
-
-**macOS with Intel:**
+**All platforms:**
 ```bash
 export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
 export PATH="$JAVA_HOME/bin:$PATH"
@@ -202,7 +188,7 @@ bundle exec fcrepo_wrapper -p 8080
 
 **All platforms:**
 ```bash
-solr_wrapper -d solr/config/ --collection_name hydra-test -p 8985
+bundle exec solr_wrapper -d solr/config/ --collection_name hydra-test -p 8985
 ```
 
 ### Terminal 3: Redis
@@ -217,7 +203,7 @@ redis-server
 **All platforms:**
 ```bash
 cd /path/to/ucrate
-bundle exec rake db:migrate RAILS_ENV=test
+RAILS_ENV=test bundle exec rake db:migrate
 bundle exec rake spec
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ brew install sqlite3 mysql-client redis solr@8 imagemagick@6 libreoffice libsodi
 brew install --cask temurin@8
 ```
 
+**Verify Java 8 is available:**
+```bash
+/usr/libexec/java_home -v 1.8
+```
+
 **Build OpenSSL 1.1.1 (required by Ruby 2.7.8):**
 ```bash
 cd /tmp
@@ -91,6 +96,11 @@ brew install sqlite3 mysql-client redis solr@8 imagemagick@6 libreoffice libsodi
 brew install --cask temurin@8
 ```
 
+**Verify Java 8 is available:**
+```bash
+/usr/libexec/java_home -v 1.8
+```
+
 **Install Ruby 2.7.8 via rbenv:**
 ```bash
 brew install rbenv ruby-build
@@ -109,20 +119,22 @@ bundle install
 
 ## Running the Application (All Platforms)
 
-Start these services in separate terminal tabs:
+Start these services in separate terminal tabs (foreground; do not append `&`):
 
 ### Terminal 1: Fedora (port 8984)
 
-**macOS with Apple Silicon (M1–M4):**
+**macOS with Apple Silicon (M1-M4):**
 ```bash
-export JAVA_HOME="/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home"
+export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
 export PATH="$JAVA_HOME/bin:$PATH"
-fcrepo_wrapper -p 8984
+bundle exec fcrepo_wrapper -p 8984
 ```
 
 **macOS with Intel:**
 ```bash
-fcrepo_wrapper -p 8984
+export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
+export PATH="$JAVA_HOME/bin:$PATH"
+bundle exec fcrepo_wrapper -p 8984
 ```
 
 ### Terminal 2: Solr (port 8983)
@@ -168,20 +180,22 @@ exit
 
 ## Running Tests (All Platforms)
 
-Start these services in separate terminal tabs:
+Start these services in separate terminal tabs (foreground; do not append `&`):
 
 ### Terminal 1: Fedora (port 8080)
 
-**macOS with Apple Silicon (M1–M4):**
+**macOS with Apple Silicon (M1-M4):**
 ```bash
-export JAVA_HOME="/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home"
+export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
 export PATH="$JAVA_HOME/bin:$PATH"
-fcrepo_wrapper -p 8080
+bundle exec fcrepo_wrapper -p 8080
 ```
 
 **macOS with Intel:**
 ```bash
-fcrepo_wrapper -p 8080
+export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
+export PATH="$JAVA_HOME/bin:$PATH"
+bundle exec fcrepo_wrapper -p 8080
 ```
 
 ### Terminal 2: Solr (port 8985)
@@ -214,6 +228,32 @@ bundle exec rake spec
 ```bash
 bundle exec brakeman -q -w 2
 bundle-audit check --update
+```
+
+## Troubleshooting
+
+### `zsh: command not found: fcrepo_wrapper`
+
+Cause: `fcrepo_wrapper` is installed as a gem in this app, not as a global system command.
+
+Fix:
+```bash
+cd /path/to/ucrate
+bundle install
+bundle exec fcrepo_wrapper -p 8984
+```
+
+### `Unable to locate a Java Runtime`
+
+Cause: Java 8 is not installed or not active in the current terminal.
+
+Fix:
+```bash
+brew install --cask temurin@8
+export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
+export PATH="$JAVA_HOME/bin:$PATH"
+java -version
+bundle exec fcrepo_wrapper -p 8984
 ```
 
 ## Project Samvera

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@
 
 ---
 
-## Quick Start
+## Installation
 
-### Clone & Setup (all platforms)
+### Step 1: Clone Repository
 
 ```bash
 git clone https://github.com/uclibs/ucrate.git ./path/to/ucrate
@@ -38,7 +38,7 @@ cd ./path/to/ucrate
 git checkout develop
 ```
 
-### 1. Install Dependencies
+### Step 2: Install Dependencies
 
 #### macOS with Apple Silicon (M1–M4)
 
@@ -107,31 +107,43 @@ bundle install
 
 ---
 
-## Running the Application
+## Running the Application (All Platforms)
 
-### Start Background Services (in separate terminal tabs)
+Start these services in separate terminal tabs:
 
-**Terminal 1 — Fedora (port 8984):**
+### Terminal 1: Fedora (port 8984)
+
+**macOS with Apple Silicon (M1–M4):**
 ```bash
 export JAVA_HOME="/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home"
 export PATH="$JAVA_HOME/bin:$PATH"
 fcrepo_wrapper -p 8984
 ```
 
-**Terminal 2 — Solr (port 8983):**
+**macOS with Intel:**
+```bash
+fcrepo_wrapper -p 8984
+```
+
+### Terminal 2: Solr (port 8983)
+
+**All platforms:**
 ```bash
 solr_wrapper -d solr/config/ --collection_name hydra-development
 ```
 
-**Terminal 3 — Redis (port 6379):**
+### Terminal 3: Redis (port 6379)
+
+**All platforms:**
 ```bash
 redis-server
 ```
 
-### Setup Database & Start Rails
+### Terminal 4: Rails Application
 
-**In project directory:**
+**All platforms:**
 ```bash
+cd /path/to/ucrate
 bundle exec rake db:migrate
 bundle exec rails hyrax:default_admin_set:create
 bundle exec rails hyrax:default_collection_types:create
@@ -154,30 +166,43 @@ exit
 
 ---
 
-## Running Tests
+## Running Tests (All Platforms)
 
-### Start Test Services (in separate terminal tabs)
+Start these services in separate terminal tabs:
 
-**Terminal 1 — Fedora (port 8080):**
+### Terminal 1: Fedora (port 8080)
+
+**macOS with Apple Silicon (M1–M4):**
 ```bash
 export JAVA_HOME="/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home"
 export PATH="$JAVA_HOME/bin:$PATH"
 fcrepo_wrapper -p 8080
 ```
 
-**Terminal 2 — Solr (port 8985):**
+**macOS with Intel:**
+```bash
+fcrepo_wrapper -p 8080
+```
+
+### Terminal 2: Solr (port 8985)
+
+**All platforms:**
 ```bash
 solr_wrapper -d solr/config/ --collection_name hydra-test -p 8985
 ```
 
-**Terminal 3 — Redis:**
+### Terminal 3: Redis
+
+**All platforms:**
 ```bash
 redis-server
 ```
 
-### Run Tests
+### Terminal 4: Run Tests
 
+**All platforms:**
 ```bash
+cd /path/to/ucrate
 bundle exec rake db:migrate RAILS_ENV=test
 bundle exec rake spec
 ```


### PR DESCRIPTION
# Update README: Add Apple Silicon M-Chip Setup Instructions

## Summary

Complete rewrite of setup and installation documentation to provide clear, concise instructions optimized for Apple Silicon (M1–M4) Macs, with fallback instructions for Intel Macs. This resolves dependency installation failures that developers consistently encounter on new M-chip machines.

## Rationale

The current README was written before Apple Silicon existed and contains:
- Generic instructions that assume x86 architecture
- Scattered, nested notes about M-chip workarounds
- No guidance on the critical OpenSSL 1.1.1 build requirement for Ruby 2.7.8
- Unclear Fedora setup (missing Java 8 configuration)
- No bundler version specification (causes incompatible gem installations)

**The Problem:**
- Ruby 2.7.8 requires OpenSSL < 3.0, but Homebrew dropped `openssl@1.1`
- Xcode 15+ enforces strict function pointer type checking (breaks `nio4r`, `posix-spawn`, `mysql2` compilation)
- `mysql2` 0.5.x requires explicit linker paths for `zstd` and OpenSSL on M-chips
- Fedora requires Java 8, but modern Macs default to Java 21
- Modern bundler requires Ruby 3.2+ (need 2.4.22 for this app)

Without guidance, developers spend 2–4 hours troubleshooting native extension builds.

## Changes

### Organization
- **System Requirements**: Clear bulleted lists of dependencies, separated by M-chip vs Intel
- **Quick Start**: Single clone/checkout section
- **1. Install Dependencies**: Step-by-step copy-paste commands
  - M-chip: Includes OpenSSL 1.1.1 build from source (only needed once)
  - Intel: Simpler Homebrew-only setup
- **Running the Application**: Terminal-by-terminal setup (Fedora → Solr → Redis → Rails)
- **Running Tests**: Same structure but with test ports/database setup
- **Security Checks**: Copy-paste vulnerability scan commands

### Key Improvements
- ✅ All commands are copy-paste ready (no placeholders or manual substitutions)
- ✅ Explicit versions for Ruby, Bundler, and bundler environment variables
- ✅ Java 8 configuration for both Fedora dev and test runs
- ✅ Clear port numbers for each service (8984, 8983, 6379, 8080, 8985)
- ✅ Bundler config and environment variables documented for troubleshooting
- ✅ Admin user creation with exact Rails console commands
- ✅ Intel instructions provided (simpler, requires no custom OpenSSL build)

## Testing This PR

1. Clone on a fresh M-chip Mac (or Intel) with Xcode 15+ installed
2. Follow the steps in "Install Dependencies" → "Running the Application"
3. Verify `rails server` starts and http://localhost:3000 is reachable
4. Run tests section and verify `bundle exec rake spec` works

## Notes for Reviewers

- The OpenSSL 1.1.1 build step is required only once per machine; it's a one-time setup
- The CFLAGS and LDFLAGS exports are only needed during `bundle install` (not at runtime)
- Fedora's Java 8 requirement is enforced; newer JDKs cause fcrepo_wrapper to fail silently
- This README now assumes Homebrew is installed (reasonable for modern Mac dev setup)

---

**Closes:** LIBSCH1-70

---
The following are a series of screenshots of the updated README as it displays on GitHub.  There is intentional duplication of the last line in the screenshot on the first line of the following screenshot to aid in getting the images in correct order.  That duplication is not present in the README.

<img width="860" height="757" alt="Screenshot 2026-04-02 at 10 31 51 AM" src="https://github.com/user-attachments/assets/75a8b2a2-3c07-4ce0-a932-56246fa61fb7" />
<img width="864" height="713" alt="Screenshot 2026-04-02 at 10 32 03 AM" src="https://github.com/user-attachments/assets/a71fc15e-42a9-42dc-8858-d875aeedaf76" />
<img width="838" height="746" alt="Screenshot 2026-04-02 at 10 32 14 AM" src="https://github.com/user-attachments/assets/cb7f9687-2302-455b-ab0c-8b889be373cb" />
<img width="865" height="758" alt="Screenshot 2026-04-02 at 10 32 25 AM" src="https://github.com/user-attachments/assets/66a88534-4011-4891-8053-3e4c9c93c3b3" />
<img width="862" height="778" alt="Screenshot 2026-04-02 at 10 32 35 AM" src="https://github.com/user-attachments/assets/12c4ec93-b289-4263-a812-1e65302b88b8" />
<img width="836" height="775" alt="Screenshot 2026-04-02 at 10 32 44 AM" src="https://github.com/user-attachments/assets/ccd45be8-12f9-4b3f-ba9f-28f83f272b52" />
<img width="848" height="322" alt="Screenshot 2026-04-02 at 10 32 50 AM" src="https://github.com/user-attachments/assets/3e2dd88d-1619-45a6-8638-01749b255059" />
