### PR TITLE
Add descriptive alt text to Hyrax thumbnail render paths and overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,40 +4,41 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
-# Ignore bundler config.
+# Bundler config
 /.bundle
 
-# Ignore the default SQLite database.
+# SQLite database files
 /db/*.sqlite3
 /db/*.sqlite3-journal
 
-# Ignore all logfiles and tempfiles.
+# Logs and temp files
 /log/*
 /tmp/*
 !/log/.keep
 !/tmp/.keep
-dump.rdb
-vendor/*.csv
 
-# Ignore Byebug command history file.
+# Byebug history
 .byebug_history
 
+# Test coverage output
 coverage/*
 
-##Mac OS
+# macOS files
 .DS_Store
 
-# Cursor/VS Code settings
+# Editor and IDE settings
 .vscode/settings.json
+.idea/
 
-# Application files to ingore
+# Application files to ignore
 fits.log
+vendor/*.csv
+dump.rdb
 
-# Ignore dotenv config files
+# Local dotenv config files
 .env.development.local
 .env.test.local
 .env.production.local
 
-# Ignore compiled assets
+# Compiled assets
 public/**
-.idea/

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,14 +15,21 @@ module ApplicationHelper
   private
 
   def thumbnail_label_for(record)
-    return record.title_or_label.to_s.strip if record.respond_to?(:title_or_label) && record.title_or_label.present?
+    if record.respond_to?(:title_or_label) && record.title_or_label.present?
+      label = normalized_thumbnail_label(record.title_or_label)
+      return label if label.present?
+    end
 
     if record.respond_to?(:title) && record.title.present?
       value = record.title.is_a?(Array) ? record.title.first : record.title
-      return value.to_s.strip if value.present?
+      label = normalized_thumbnail_label(value)
+      return label if label.present?
     end
 
-    return record.to_s.strip if record.respond_to?(:to_s) && record.to_s.present?
+    if record.respond_to?(:to_s) && record.to_s.present?
+      label = normalized_thumbnail_label(record.to_s)
+      return label if label.present?
+    end
 
     nil
   end
@@ -31,5 +38,12 @@ module ApplicationHelper
     return record.human_readable_type.to_s.strip if record.respond_to?(:human_readable_type) && record.human_readable_type.present?
 
     nil
+  end
+
+  def normalized_thumbnail_label(value)
+    label = value.to_s.strip
+    return nil if label.blank? || label.casecmp('null').zero?
+
+    label
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,6 +27,7 @@ module ApplicationHelper
   end
 
   def normalized_thumbnail_label(value)
+    value = extract_first_label_value(value)
     label = value.to_s.strip
     return nil if label.blank? || label.casecmp('null').zero?
 
@@ -49,5 +50,11 @@ module ApplicationHelper
     return unless record.respond_to?(:to_s)
 
     record.to_s
+  end
+
+  def extract_first_label_value(value)
+    return value.first if value.respond_to?(:first) && !value.is_a?(String)
+
+    value
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,22 +14,22 @@ module ApplicationHelper
 
   private
 
-    def thumbnail_label_for(record)
-      return record.title_or_label.to_s.strip if record.respond_to?(:title_or_label) && record.title_or_label.present?
+  def thumbnail_label_for(record)
+    return record.title_or_label.to_s.strip if record.respond_to?(:title_or_label) && record.title_or_label.present?
 
-      if record.respond_to?(:title) && record.title.present?
-        value = record.title.is_a?(Array) ? record.title.first : record.title
-        return value.to_s.strip if value.present?
-      end
-
-      return record.to_s.strip if record.respond_to?(:to_s) && record.to_s.present?
-
-      nil
+    if record.respond_to?(:title) && record.title.present?
+      value = record.title.is_a?(Array) ? record.title.first : record.title
+      return value.to_s.strip if value.present?
     end
 
-    def thumbnail_type_for(record)
-      return record.human_readable_type.to_s.strip if record.respond_to?(:human_readable_type) && record.human_readable_type.present?
+    return record.to_s.strip if record.respond_to?(:to_s) && record.to_s.present?
 
-      nil
-    end
+    nil
+  end
+
+  def thumbnail_type_for(record)
+    return record.human_readable_type.to_s.strip if record.respond_to?(:human_readable_type) && record.human_readable_type.present?
+
+    nil
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,35 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def thumbnail_alt_text_for(record)
+    label = thumbnail_label_for(record)
+    type = thumbnail_type_for(record)
+
+    return "#{type} thumbnail: #{label}" if type.present? && label.present?
+    return "Thumbnail for #{label}" if label.present?
+    return "#{type} thumbnail" if type.present?
+
+    'Thumbnail'
+  end
+
+  private
+
+    def thumbnail_label_for(record)
+      return record.title_or_label.to_s.strip if record.respond_to?(:title_or_label) && record.title_or_label.present?
+
+      if record.respond_to?(:title) && record.title.present?
+        value = record.title.is_a?(Array) ? record.title.first : record.title
+        return value.to_s.strip if value.present?
+      end
+
+      return record.to_s.strip if record.respond_to?(:to_s) && record.to_s.present?
+
+      nil
+    end
+
+    def thumbnail_type_for(record)
+      return record.human_readable_type.to_s.strip if record.respond_to?(:human_readable_type) && record.human_readable_type.present?
+
+      nil
+    end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,23 +15,9 @@ module ApplicationHelper
   private
 
   def thumbnail_label_for(record)
-    if record.respond_to?(:title_or_label) && record.title_or_label.present?
-      label = normalized_thumbnail_label(record.title_or_label)
-      return label if label.present?
-    end
-
-    if record.respond_to?(:title) && record.title.present?
-      value = record.title.is_a?(Array) ? record.title.first : record.title
-      label = normalized_thumbnail_label(value)
-      return label if label.present?
-    end
-
-    if record.respond_to?(:to_s) && record.to_s.present?
-      label = normalized_thumbnail_label(record.to_s)
-      return label if label.present?
-    end
-
-    nil
+    [title_or_label_value(record), title_value(record), to_s_value(record)]
+      .map { |value| normalized_thumbnail_label(value) }
+      .find(&:present?)
   end
 
   def thumbnail_type_for(record)
@@ -45,5 +31,23 @@ module ApplicationHelper
     return nil if label.blank? || label.casecmp('null').zero?
 
     label
+  end
+
+  def title_or_label_value(record)
+    return unless record.respond_to?(:title_or_label)
+
+    record.title_or_label
+  end
+
+  def title_value(record)
+    return unless record.respond_to?(:title) && record.title.present?
+
+    record.title.is_a?(Array) ? record.title.first : record.title
+  end
+
+  def to_s_value(record)
+    return unless record.respond_to?(:to_s)
+
+    record.to_s
   end
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module CatalogHelper
+  include Blacklight::CatalogHelperBehavior
+
   def render_thumbnail_tag(document, image_options = {}, url_options = {})
     options = image_options.to_h.symbolize_keys
     options[:alt] = thumbnail_alt_text_for(document) if options[:alt].blank?

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module CatalogHelper
+  def render_thumbnail_tag(document, image_options = {}, url_options = {})
+    options = image_options.to_h.symbolize_keys
+    options[:alt] = thumbnail_alt_text_for(document) if options[:alt].blank?
+
+    super(document, options, url_options)
+  end
+end

--- a/app/views/catalog/_thumbnail_default.html.erb
+++ b/app/views/catalog/_thumbnail_default.html.erb
@@ -1,0 +1,5 @@
+<%- if has_thumbnail?(document) && tn = render_thumbnail_tag(document, {}, tabindex: -1, counter: document_counter_with_offset(document_counter)) %>
+<div class="document-thumbnail">
+  <%= tn %>
+</div>
+<%- end %>

--- a/app/views/hyrax/collections/_media_display.html.erb
+++ b/app/views/hyrax/collections/_media_display.html.erb
@@ -1,0 +1,7 @@
+<% if presenter.thumbnail_path %>
+  <%= image_tag presenter.thumbnail_path,
+                class: "representative-media",
+                alt: thumbnail_alt_text_for(presenter) %>
+<% else %>
+  <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-search" aria-hidden="true"></span>
+<% end %>

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -1,0 +1,73 @@
+<% # used by All and Managed Collections tabs %>
+<% id = collection_presenter.id %>
+<tr id="document_<%= id %>"
+  data-id="<%= id %>"
+  data-colls-hash="<%= collection_presenter.available_parent_collections(scope: controller) %>"
+  data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
+  data-post-delete-url="<%= is_admin_set ? hyrax.admin_admin_set_path(id) : hyrax.dashboard_collection_path(id) %>">
+
+  <td>
+    <% if collection_presenter.allow_batch? %>
+    <input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector"
+      data-hasaccess="<%= (can?(:edit, collection_presenter.solr_document)) %>" />
+    <% else %>
+    <input type="checkbox" class="disabled" disabled=true />
+    <% end %>
+  </td>
+  <td>
+    <div class="thumbnail-title-wrapper">
+      <div class="thumbnail-wrapper">
+        <% if (collection_presenter.thumbnail_path == nil) %>
+          <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-small"></span>
+        <% else %>
+          <%= image_tag(collection_presenter.thumbnail_path, alt: thumbnail_alt_text_for(collection_presenter)) %>
+        <% end %>
+      </div>
+      <%= link_to collection_presenter.show_path do %>
+          <span class="sr-only"><%= t("hyrax.dashboard.my.sr.show_label") %> </span>
+          <%= collection_presenter.title_or_label %>
+      <% end %>
+
+      <%# Expand arrow %>
+      <a href="#" class="small show-more" title="Click for more details">
+        <i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></i>
+        <span class="sr-only"> <%= "#{t("hyrax.dashboard.my.sr.detail_label")} #{collection_presenter.title_or_label}" %></span>
+      </a>
+    </div>
+
+    <%# Collection details %>
+    <div id="detail_<%= id %>">
+      <div class="expanded-details">
+        <p>
+          <strong><%= t("hyrax.dashboard.my.collection_list.description") %></strong>
+          <br /><%= collection_presenter.description&.first %>
+        </p>
+        <p>
+          <strong><%= t("hyrax.dashboard.my.collection_list.edit_access") %></strong>
+          <br />
+          <% if collection_presenter.edit_groups.present? %>
+            <%= t("hyrax.dashboard.my.collection_list.groups") %> <%= collection_presenter.edit_groups.join(', ') %>
+            <br />
+          <% end %>
+          <%= t("hyrax.dashboard.my.collection_list.users") %> <%= collection_presenter.edit_people.join(', ') %>
+        </p>
+      </div>
+    </div>
+  </td>
+  <% if !current_ability.admin? %>
+    <td><%= collection_presenter.managed_access %></td>
+  <% end %>
+  <td class="collection_type">
+    <%= collection_presenter.collection_type_badge %>
+  </td>
+  <td><%= collection_presenter.permission_badge %>  </td>
+  <td><%= collection_presenter.total_viewable_items %></td>
+  <td class="date"><%= collection_presenter.modified_date.try(:to_formatted_s, :standard) %> </td>
+  <td>
+    <% if collection_presenter.solr_document.admin_set? %>
+      <%= render '/hyrax/my/admin_set_action_menu', admin_set_presenter: collection_presenter %>
+    <% else %>
+      <%= render '/hyrax/my/collection_action_menu', collection_presenter: collection_presenter %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/hyrax/homepage/_featured_collections.html.erb
+++ b/app/views/hyrax/homepage/_featured_collections.html.erb
@@ -7,8 +7,7 @@
   <div class="center-block main row featured-thumb featured-collection">
     <%= link_to collection_path(featured_collection.collection_id) do %>
     <%= image_tag collection.to_solr["thumbnail_path_ss"], 
-                alt: "Thumbnail for featured collection: #{collection.title.first}",
-                role: "presentation" %>
+                alt: thumbnail_alt_text_for(collection) %>
     <% end %>
   </div>
     <% end %>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -1,0 +1,72 @@
+<% # used by Your Collections tab %>
+<% id = collection_presenter.id %>
+<%# Data attributes referenced by the javascript for submitting nested forms. %>
+<tr id="document_<%= id %>"
+  data-source="my"
+  data-id="<%= id %>"
+  data-colls-hash="<%= collection_presenter.available_parent_collections(scope: controller) %>"
+  data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
+  data-post-delete-url="<%= is_admin_set ? hyrax.admin_admin_set_path(id) : hyrax.dashboard_collection_path(id) %>">
+
+  <td>
+    <% if collection_presenter.allow_batch? %>
+        <input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector"
+               data-hasaccess="<%= (can?(:edit, collection_presenter.solr_document)) %>" />
+    <% else %>
+        <input type="checkbox" class="disabled" disabled=true />
+    <% end %>
+  </td>
+  <td>
+    <div class="thumbnail-title-wrapper">
+      <div class="thumbnail-wrapper">
+        <% if (collection_presenter.thumbnail_path == nil) %>
+          <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-small"></span>
+        <% else %>
+          <%= image_tag(collection_presenter.thumbnail_path, alt: thumbnail_alt_text_for(collection_presenter)) %>
+        <% end %>
+      </div>
+      <%= link_to collection_presenter.show_path, id: "src_copy_link#{id}" do %>
+        <span class="sr-only"><%= t("hyrax.dashboard.my.sr.show_label") %></span>
+        <%= collection_presenter.title_or_label %>
+      <% end %>
+
+      <%# Expand arrow %>
+      <a href="#" class="small show-more" title="Click for more details">
+        <i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></i>
+        <span class="sr-only"> <%= "#{t("hyrax.dashboard.my.sr.detail_label")} #{collection_presenter.title_or_label}" %></span>
+      </a>
+    </div>
+
+    <%# Collection details %>
+    <div id="detail_<%= id %>">
+      <div class="expanded-details">
+        <p>
+          <strong><%= t("hyrax.dashboard.my.collection_list.description") %></strong>
+          <br /><%= collection_presenter.description&.first %>
+        </p>
+        <p>
+          <strong><%= t("hyrax.dashboard.my.collection_list.edit_access") %></strong>
+          <br />
+          <% if collection_presenter.edit_groups.present? %>
+            <%= t("hyrax.dashboard.my.collection_list.groups") %> <%= collection_presenter.edit_groups.join(', ') %>
+            <br />
+          <% end %>
+          <%= t("hyrax.dashboard.my.collection_list.users") %> <%= collection_presenter.edit_people.join(', ') %>
+        </p>
+      </div>
+    </div>
+  </td>
+  <td class="collection_type">
+    <%= collection_presenter.collection_type_badge %>
+  </td>
+  <td><%= collection_presenter.permission_badge %></td>
+  <td><%= collection_presenter.total_viewable_items %></td>
+  <td class="date"><%= collection_presenter.modified_date.try(:to_formatted_s, :standard) %> </td>
+  <td>
+    <% if collection_presenter.solr_document.admin_set? %>
+      <%= render '/hyrax/my/admin_set_action_menu', admin_set_presenter: collection_presenter %>
+    <% else %>
+      <%= render 'hyrax/my/collection_action_menu', collection_presenter: collection_presenter %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/hyrax/users/_contributions.html.erb
+++ b/app/views/hyrax/users/_contributions.html.erb
@@ -1,0 +1,25 @@
+<div class="tab-pane active" id="contributions">
+  <% if presenter.trophies.count > 0 %>
+    <table>
+      <% presenter.trophies.each do |t| %>
+        <tr id="trophyrow_<%= t.id %>" class='highlighted-works'>
+          <td>
+            <%= link_to [main_app, t] do %>
+              <%= image_tag t.thumbnail_path, width: 90, alt: thumbnail_alt_text_for(t) %>
+            <% end %>
+          </td>
+          <td>
+            <%= link_to t.to_s, [main_app, t] %>
+            <% if presenter.current_user? %>
+              <%= display_trophy_link current_user, t.id, class: 'glyphicon glyphicon-star', data: { removerow: true } do %>
+                <i class='trophy-on glyphicon glyphicon-remove'></i>
+              <% end %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  <% else %>
+    <%= presenter.name %> has no highlighted works.
+  <% end %>
+</div>

--- a/spec/features/featured_collection_spec.rb
+++ b/spec/features/featured_collection_spec.rb
@@ -44,7 +44,8 @@ describe 'collection', type: :feature, js: true do
       visit hyrax.dashboard_collection_path(collection)
       click_link("Feature")
       visit '/'
-      expect(page).to have_css("img[alt='Thumbnail for featured collection: #{collection.title.first}")
+      expected_alt = ApplicationController.helpers.thumbnail_alt_text_for(collection)
+      expect(page).to have_css("img[alt='#{expected_alt}']")
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -4,6 +4,22 @@ require 'rails_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
   describe '#thumbnail_alt_text_for' do
+    it 'uses the first value when title_or_label is relation-like' do
+      relation_like_label = double('ActiveTriples::Relation', first: 'Collection Title 2')
+      record = instance_double(
+        'Record',
+        title_or_label: relation_like_label,
+        title: ['Collection Title 2'],
+        human_readable_type: 'Collection',
+        to_s: relation_like_label.to_s
+      )
+
+      alt_text = helper.thumbnail_alt_text_for(record)
+
+      expect(alt_text).to eq('Collection thumbnail: Collection Title 2')
+      expect(alt_text).not_to include('ActiveTriples::Relation')
+    end
+
     it 'returns a non-nil alt text when title is missing' do
       record = instance_double(
         'Record',

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#thumbnail_alt_text_for' do
+    it 'returns a non-nil alt text when title is missing' do
+      record = instance_double(
+        'Record',
+        title_or_label: nil,
+        title: nil,
+        human_readable_type: 'Collection',
+        to_s: ''
+      )
+
+      alt_text = helper.thumbnail_alt_text_for(record)
+
+      expect(alt_text).to be_present
+      expect(alt_text).to eq('Collection thumbnail')
+    end
+
+    it 'does not render a null label in alt text' do
+      record = instance_double(
+        'Record',
+        title_or_label: 'null',
+        title: ['null'],
+        human_readable_type: 'Collection',
+        to_s: 'null'
+      )
+
+      alt_text = helper.thumbnail_alt_text_for(record)
+
+      expect(alt_text).to eq('Collection thumbnail')
+      expect(alt_text.downcase).not_to include('null')
+    end
+  end
+end

--- a/spec/views/catalog/_thumbnail_default.html.erb_spec.rb
+++ b/spec/views/catalog/_thumbnail_default.html.erb_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'catalog/_thumbnail_default.html.erb', type: :view do
+  it 'renders a thumbnail image with non-null alt text' do
+    document = double('SolrDocument')
+
+    allow(view).to receive(:has_thumbnail?).with(document).and_return(true)
+    allow(view).to receive(:document_counter_with_offset).with(1).and_return(1)
+    allow(view).to receive(:render_thumbnail_tag)
+      .with(document, {}, hash_including(tabindex: -1, counter: 1))
+      .and_return('<img src="/downloads/thumb.png" alt="Collection thumbnail">'.html_safe)
+
+    render partial: 'catalog/thumbnail_default', locals: { document: document, document_counter: 1 }
+
+    expect(rendered).to include('alt="Collection thumbnail"')
+    expect(rendered.downcase).not_to include('thumbnail: null')
+  end
+end

--- a/spec/views/hyrax/collections/_media_display.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_media_display.html.erb_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/collections/_media_display.html.erb', type: :view do
+  it 'renders thumbnail alt text that is present and does not include null' do
+    presenter = instance_double(
+      'Hyrax::CollectionPresenter',
+      thumbnail_path: '/downloads/thumb.png',
+      title_or_label: 'null',
+      title: ['null'],
+      human_readable_type: 'Collection',
+      to_s: 'null'
+    )
+
+    render partial: 'hyrax/collections/media_display', locals: { presenter: presenter }
+
+    expect(rendered).to include('alt="Collection thumbnail"')
+    expect(rendered.downcase).not_to include('thumbnail: null')
+  end
+end

--- a/spec/views/hyrax/homepage/_featured_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/homepage/_featured_collections.html.erb_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/homepage/_featured_collections.html.erb', type: :view do
+  it 'renders a featured collection thumbnail with non-null alt text' do
+    featured_collection = instance_double('FeaturedCollection', collection_id: 'col-123')
+    collection = double(
+      'Collection',
+      to_solr: { 'thumbnail_path_ss' => '/downloads/featured-thumb.png' },
+      title_or_label: 'null',
+      title: ['null'],
+      human_readable_type: 'Collection',
+      to_s: 'null'
+    )
+
+    allow(FeaturedCollection).to receive(:count).and_return(1)
+    allow(FeaturedCollection).to receive(:first).and_return(featured_collection)
+    allow(Collection).to receive(:find).with('col-123').and_return(collection)
+    allow(view).to receive(:collection_path).with('col-123').and_return('/collections/col-123')
+
+    render partial: 'hyrax/homepage/featured_collections'
+
+    expect(rendered).to include('alt="Collection thumbnail"')
+    expect(rendered.downcase).not_to include('thumbnail: null')
+  end
+end

--- a/spec/views/hyrax/users/_contributions.html.erb_spec.rb
+++ b/spec/views/hyrax/users/_contributions.html.erb_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/users/_contributions.html.erb', type: :view do
+  it 'renders trophy thumbnail alt text that is present and not null' do
+    trophy = double(
+      'SolrDocument',
+      id: 'work-1',
+      thumbnail_path: '/downloads/trophy-thumb.png',
+      title_or_label: 'null',
+      title: ['null'],
+      human_readable_type: 'Generic Work',
+      to_s: 'null'
+    )
+    presenter = double('Presenter', trophies: [trophy], current_user?: false, name: 'User')
+
+    allow(view).to receive(:presenter).and_return(presenter)
+    allow(view).to receive(:main_app).and_return(main_app)
+    allow(view).to receive(:link_to) do |*_args, &block|
+      block ? block.call : ''
+    end
+
+    render partial: 'hyrax/users/contributions', locals: { presenter: presenter }
+
+    expect(rendered).to include('alt="Generic Work thumbnail"')
+    expect(rendered.downcase).not_to include('thumbnail: null')
+  end
+end


### PR DESCRIPTION
## Summary
This PR improves thumbnail accessibility by ensuring thumbnail images have meaningful `alt` text across Hyrax/Blacklight render paths, including fallback and featured collection thumbnails.

## Why
Some thumbnail images were rendered with weak/missing descriptions (or marked as presentational), which reduced the usefulness of those images for screen reader users.

## What Changed
- Added a shared alt-text helper in `ApplicationHelper`:
  - `thumbnail_alt_text_for(record)`
  - Builds alt text from record type + label when available.
  - Falls back safely when data is incomplete.
  - Treats null-like labels (for example `"null"`) as missing to avoid output like `Collection thumbnail: null`.
- Ensured default Blacklight thumbnail rendering gets alt text when none is explicitly provided via `CatalogHelper#render_thumbnail_tag`.
- Added/overrode Hyrax/Blacklight thumbnail partials to pass descriptive alt text where thumbnails are rendered with `image_tag`.
- Updated featured collections homepage rendering to use helper-generated alt text and removed presentational treatment.
- Updated featured collection feature spec to assert helper-derived alt text (resilient to text wording changes).

## Accessibility Impact
- Thumbnail images now expose meaningful alt text in key UI surfaces.
- Prevents null placeholder labels from leaking into assistive text.
- Removes presentational treatment where thumbnails carry content meaning.

## Risk / Notes
- This PR includes local Hyrax/Blacklight view overrides; future gem upgrades should re-validate override compatibility.
- No DB/schema changes.
- No API contract changes.

## Rollback
Revert this PR to restore prior thumbnail alt text behavior.

---
Affects thumbnails on the index pages only:
<img width="2551" height="1366" alt="Screenshot 2026-04-10 at 11 22 49 AM" src="https://github.com/user-attachments/assets/089781e8-1de1-41d2-8995-cf5b565b839f" />
<img width="514" height="1126" alt="Screenshot 2026-04-10 at 11 23 09 AM" src="https://github.com/user-attachments/assets/80ba550d-1e4d-442d-bba7-ecb681b574b8" />

Uses the alt text "Collection Thumbnail: {name of collection}" or "Work Thumbnail: {name of work}" on index pages only.
<img width="318" height="842" alt="Screenshot 2026-04-10 at 11 27 25 AM" src="https://github.com/user-attachments/assets/1314d2d2-ea08-46b9-96c9-a86c10f297de" />

Does include index page of works inside a collection:
<img width="2006" height="1368" alt="Screenshot 2026-04-10 at 11 53 44 AM" src="https://github.com/user-attachments/assets/dca5f921-448d-46b3-8ae4-56bcc7c566fc" />

Does not affect images inside individual collections:
<img width="2489" height="1319" alt="Screenshot 2026-04-10 at 11 23 35 AM" src="https://github.com/user-attachments/assets/64de9bfb-d771-4c49-a8cd-57ef32e3ef3e" />
