### PR TITLE
Add descriptive alt text on work and file-set representative media accessibility

### DIFF
--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -137,9 +137,16 @@ module HyraxHelper
         concat tag.span('', class: 'fa fa-bell')
         concat tag.span('&nbsp;Notifications'.html_safe, class: 'visible-xs-inline-block')
         concat "\n"
-        concat tag.span(unread_notifications,
-                           class: count_classes_for(unread_notifications))
+        concat notification_count_badge(unread_notifications)
       end
     end
+  end
+
+  private
+
+  def notification_count_badge(unread_count)
+    attrs = { class: count_classes_for(unread_count) }
+    attrs[:aria] = { hidden: true } if unread_count.zero?
+    unread_count.zero? ? tag.span('', attrs) : tag.span(unread_count, attrs)
   end
 end

--- a/app/views/_toolbar.html.erb
+++ b/app/views/_toolbar.html.erb
@@ -8,7 +8,7 @@
 
 <% if current_ability.can_create_any_work? %>
       <li class="dropdown">
-        <%= link_to hyrax.my_works_path, role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false } do %>
+        <%= link_to '#', role: 'button', class: 'dropdown-toggle', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false } do %>
           <span class="fa fa-cube"></span> <span>&nbsp;<%= t("hyrax.toolbar.works.menu") %></span> <span class="caret"></span>
         <% end %>
         <ul class="dropdown-menu">
@@ -51,7 +51,7 @@
 
     <% if can?(:create_any, Collection) && Hyrax::SelectCollectionTypeListPresenter.new(current_user).any? %>
       <li class="dropdown">
-        <%= link_to hyrax.my_collections_path, role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false } do %>
+        <%= link_to '#', role: 'button', class: 'dropdown-toggle', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false } do %>
           <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %>"></span> <span>&nbsp;<%= t("hyrax.toolbar.collections.menu") %></span> <span class="caret"></span>
         <% end %>
         <ul class="dropdown-menu">

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -6,23 +6,31 @@
       <%= render_notifications(user: current_user) %>
     </li>
     <li class="dropdown">
-      <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false}, controls: 'user-util-links' do %>
+      <%= link_to hyrax.dashboard_profile_path(current_user),
+                  id: 'user-util-dropdown-toggle',
+                  class: 'dropdown-toggle',
+                  role: 'button',
+                  data: { toggle: 'dropdown' },
+                  aria: { haspopup: 'menu', expanded: false, controls: 'user-util-links' } do %>
         <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
         <span class="fa fa-user" aria-hidden="true"></span>
         <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
         <span>&nbsp;<%= current_user.name %></span>
-        <span class="caret"></span>
+        <span class="caret" aria-hidden="true"></span>
       <% end %>
-      <ul id="user-util-links" class="dropdown-menu dropdown-menu-right" role="menu">
-        <li><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path %></li>
-        <li class="divider"></li>
-        <li><%= link_to t("hyrax.toolbar.profile.view"), hyrax.dashboard_profile_path(current_user) %></li>
-        <li><%= link_to t("hyrax.toolbar.profile.edit"), hyrax.edit_dashboard_profile_path(current_user) %></li>
-        <li class="divider"></li>
+      <ul id="user-util-links"
+          class="dropdown-menu dropdown-menu-right"
+          role="menu"
+          aria-labelledby="user-util-dropdown-toggle">
+        <li role="none"><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path, role: 'menuitem', tabindex: -1 %></li>
+        <li class="divider" role="separator"></li>
+        <li role="none"><%= link_to t("hyrax.toolbar.profile.view"), hyrax.dashboard_profile_path(current_user), role: 'menuitem', tabindex: -1 %></li>
+        <li role="none"><%= link_to t("hyrax.toolbar.profile.edit"), hyrax.edit_dashboard_profile_path(current_user), role: 'menuitem', tabindex: -1 %></li>
+        <li class="divider" role="separator"></li>
         <% unless current_user.provider == "shibboleth" %>
-          <li><%= link_to t("hyku.toolbar.profile.edit_registration"), main_app.edit_user_registration_path %></li>
+          <li role="none"><%= link_to t("hyku.toolbar.profile.edit_registration"), main_app.edit_user_registration_path, role: 'menuitem', tabindex: -1 %></li>
         <% end %>
-        <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path %></li>
+        <li role="none"><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path, role: 'menuitem', tabindex: -1 %></li>
       </ul>
     </li><!-- /.btn-group -->
   <% else %>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -8,6 +8,7 @@
     </div>
 
     <div class="input-group">
+      <label for="search-field-header" class="sr-only"><%= t("hyrax.search.form.q.label", application_name: application_name) %></label>
       <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 
       <div class="input-group-btn">

--- a/app/views/hyrax/base/_parent_relationship_table.html.erb
+++ b/app/views/hyrax/base/_parent_relationship_table.html.erb
@@ -1,5 +1,7 @@
 <% parent_solr_docs = ParentQueryService.query_parents_for_id(child_id) %>
-<h2><%= t('hyrax.base.relationships.label') unless parent_solr_docs.blank? %></h2>
+<% unless parent_solr_docs.blank? %>
+  <h2><%= t('hyrax.base.relationships.label') %></h2>
+<% end %>
 <dt> <%= t('hyrax.relationships_parent_row.label') unless parent_solr_docs.blank? %> </dt>
   <dd>
     <ul class="tabular">

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -5,5 +5,8 @@
     <%= media_display presenter.representative_presenter %>
   <% end %>
 <% else %>
-  <%= image_tag 'default.png', class: "canonical-image", :style => "max-width: 100%; max-height: 100%;" %>
+  <%= image_tag 'default.png',
+                class: "canonical-image",
+                style: "max-width: 100%; max-height: 100%;",
+                alt: thumbnail_alt_text_for(presenter) %>
 <% end %>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -25,9 +25,20 @@
       <% end %>
   <% end %>
   <% if presenter.show_deposit_for?(collections: @user_collections) %>
-      <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+      <% batch_input_id = "batch_document_#{presenter.id}" %>
+      <label class="sr-only" for="<%= batch_input_id %>"><%= t('hyrax.dashboard.my.action.include_work_in_collection_batch') %></label>
+      <input type="checkbox"
+             id="<%= batch_input_id %>"
+             class="batch_document_selector"
+             name="batch_document_ids[]"
+             value="<%= presenter.id %>"
+             checked="checked"
+             style="display: none;"
+             aria-label="<%= t('hyrax.dashboard.my.action.include_work_in_collection_batch') %>" />
       <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+                     type: 'button',
                      class: 'btn btn-default submits-batches submits-batches-add',
+                     aria: { label: t('hyrax.dashboard.my.action.add_to_collection') },
                      data: { toggle: "modal", target: "#collection-list-container" } %>
   <% end %>
   <% if presenter.work_featurable? %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -66,13 +66,9 @@
   </div>
 
   <!-- Search results label -->
-  <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
+  <% if (@members_count > 0 || @presenter.subcollection_count > 0) && has_collection_search_parameters? %>
     <div class="hyc-blacklight hyc-bl-title">
-      <h2>
-        <% if has_collection_search_parameters? %>
-            <%= t('hyrax.dashboard.collections.show.search_results') %>
-        <% end %>
-      </h2>
+      <h2><%= t('hyrax.dashboard.collections.show.search_results') %></h2>
     </div>
   <% end %>
 

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -32,14 +32,9 @@
 
       <!-- Search results label -->
 
-      <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
+      <% if (@members_count > 0 || @presenter.subcollection_count > 0) && has_collection_search_parameters? %>
           <div class="hyc-blacklight hyc-bl-title">
-            <h2>
-              <% if has_collection_search_parameters? %>
-                  <%= t('hyrax.dashboard.collections.show.search_results') %>
-              <% end %>
-              <p class="sr-only"><%= t('hyrax.dashboard.collections.show.search_results') %></p>
-            </h2>
+            <h2><%= t('hyrax.dashboard.collections.show.search_results') %></h2>
           </div>
       <% end %>
 

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -1,0 +1,19 @@
+<% if Hyrax.config.display_media_download_link? && can?(:download, file_set.id) %>
+    <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: thumbnail_alt_text_for(file_set) %>
+      <%= link_to t('hyrax.file_set.show.downloadable_content.image_link'),
+                  hyrax.download_path(file_set),
+                  data: { label: file_set.id },
+                  target: :_blank,
+                  id: "file_download" %>
+    </div>
+<% else %>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: thumbnail_alt_text_for(file_set) %>
+    </div>
+<% end %>

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb
@@ -1,0 +1,19 @@
+<% if Hyrax.config.display_media_download_link? %>
+    <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: thumbnail_alt_text_for(file_set) %>
+      <%= link_to t('hyrax.file_set.show.downloadable_content.office_link'),
+                  hyrax.download_path(file_set),
+                  target: :_blank,
+                  id: "file_download",
+                  data: { label: file_set.id } %>
+    </div>
+<% else %>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: thumbnail_alt_text_for(file_set) %>
+    </div>
+<% end %>

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -1,0 +1,19 @@
+<% if Hyrax.config.display_media_download_link? %>
+    <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: thumbnail_alt_text_for(file_set) %>
+      <%= link_to t('hyrax.file_set.show.downloadable_content.pdf_link'),
+                  hyrax.download_path(file_set),
+                  target: :_blank,
+                  id: "file_download",
+                  data: { label: file_set.id } %>
+    </div>
+<% else %>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: thumbnail_alt_text_for(file_set) %>
+    </div>
+<% end %>

--- a/app/views/hyrax/my/_search_form.html.erb
+++ b/app/views/hyrax/my/_search_form.html.erb
@@ -4,6 +4,7 @@
   <div class="form-group">
 
     <div class="input-group">
+      <label for="search-field-header" class="sr-only"><%= t("hyrax.search.form.q.label", application_name: application_name) %></label>
       <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 
       <div class="input-group-btn">

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -180,6 +180,8 @@ en:
       my:
         action:
           export_collection: "Export collection"
+          add_to_collection: "Add to collection"
+          include_work_in_collection_batch: "Include this work when adding to a collection"
       collections:
         show:
           item_count: Items in this Collection

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -172,4 +172,23 @@ RSpec.describe HyraxHelper, type: :helper do
       end
     end
   end
+
+  describe '#notification_count_badge' do
+    it 'returns an empty span with aria-hidden and invisible label classes when count is zero' do
+      html = helper.send(:notification_count_badge, 0).to_s
+
+      expect(html).to include('aria-hidden="true"')
+      expect(html).to include('invisible')
+      expect(html).to include('label-default')
+      expect(html).not_to include('>0<')
+    end
+
+    it 'returns a span with the count and danger label when count is positive' do
+      html = helper.send(:notification_count_badge, 3).to_s
+
+      expect(html).to include('3')
+      expect(html).to include('label-danger')
+      expect(html).not_to include('aria-hidden')
+    end
+  end
 end

--- a/spec/views/_toolbar.html.erb_spec.rb
+++ b/spec/views/_toolbar.html.erb_spec.rb
@@ -36,6 +36,7 @@ describe '/_toolbar.html.erb', type: :view do
     it 'has my works link' do
       render
       expect(rendered).to have_link 'My Works', href: hyrax.my_works_path
+      expect(rendered.scan(%r{href="[^"]*#{Regexp.escape(hyrax.my_works_path)}[^"]*"}).size).to eq(1)
     end
 
     context "when the user can create multiple work types" do
@@ -84,6 +85,7 @@ describe '/_toolbar.html.erb', type: :view do
       it 'has my collections link' do
         render
         expect(rendered).to have_link 'My Collections', href: hyrax.my_collections_path
+        expect(rendered.scan(%r{href="[^"]*#{Regexp.escape(hyrax.my_collections_path)}[^"]*"}).size).to eq(1)
       end
     end
 

--- a/spec/views/_user_util_links.html.erb_spec.rb
+++ b/spec/views/_user_util_links.html.erb_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe '/_user_util_links.html.erb', type: :view do
     expect(rendered).to have_link 'Edit Profile', href: hyrax.edit_dashboard_profile_path('userX')
   end
 
+  it 'wires the user menu for assistive technology' do
+    render
+    expect(rendered).to have_css(
+      'a#user-util-dropdown-toggle.dropdown-toggle[aria-controls="user-util-links"][aria-expanded="false"][aria-haspopup="menu"]'
+    )
+    expect(rendered).to have_css('ul#user-util-links[role="menu"][aria-labelledby="user-util-dropdown-toggle"]')
+    expect(rendered).to have_css('a[role="menuitem"][href="' + hyrax.dashboard_path + '"]', text: 'Dashboard')
+  end
+
   context 'when the user is using shibboleth' do
     before do
       allow(view).to receive(:current_user).and_return(stub_model(User, user_key: 'userX', provider: 'shibboleth'))
@@ -51,7 +60,32 @@ RSpec.describe '/_user_util_links.html.erb', type: :view do
   it 'shows the number of outstanding messages' do
     render
     expect(rendered).to have_selector "a[aria-label='You have no unread notifications'][href='#{hyrax.notifications_path}']"
-    expect(rendered).to have_selector 'a.notify-number span.label-default.invisible', text: '0'
+    doc = Nokogiri::HTML::DocumentFragment.parse(rendered)
+    badge = doc.at_css('a.notify-number span.label-default.invisible[aria-hidden="true"]')
+    expect(badge).to be_present
+    expect(badge.text.strip).to eq('')
+  end
+
+  context 'when the user has unread notifications' do
+    let(:mailbox) do
+      instance_double(UserMailbox, unread_count: 3, label: 'You have 3 unread notifications')
+    end
+
+    before do
+      allow(UserMailbox).to receive(:new).and_return(mailbox)
+    end
+
+    it 'shows the unread count in the badge without aria-hidden' do
+      render
+      expect(rendered).to have_selector(
+        "a.notify-number[aria-label='You have 3 unread notifications'][href='#{hyrax.notifications_path}']"
+      )
+      doc = Nokogiri::HTML::DocumentFragment.parse(rendered)
+      badge = doc.at_css('a.notify-number span.label-danger')
+      expect(badge).to be_present
+      expect(badge.text.strip).to eq('3')
+      expect(badge['aria-hidden']).to be_nil
+    end
   end
 
   describe 'translations' do

--- a/spec/views/catalog/_search_form.html.erb_spec.rb
+++ b/spec/views/catalog/_search_form.html.erb_spec.rb
@@ -18,7 +18,11 @@ RSpec.describe 'catalog/_search_form.html.erb', type: :view do
     expect(page).to have_selector("[name='search_field'][value='all_fields']", visible: false)
   end
 
-  it "does not have a search label" do
+  it "uses a screen-reader-only label for the search field" do
+    expect(rendered).to have_css('label.sr-only[for="search-field-header"]', text: /Search/)
+  end
+
+  it "does not use a visible Bootstrap control-label" do
     expect(rendered).not_to have_css('label.control-label')
   end
 end

--- a/spec/views/hyrax/base/_parent_relationship_table.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_parent_relationship_table.html.erb_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/base/_parent_relationship_table.html.erb', type: :view do
+  let(:child_id) { 'child-work-1' }
+
+  before do
+    allow(view).to receive(:url_for_document).and_return('/concern/parent/1')
+  end
+
+  context 'when the work has no parent works' do
+    before do
+      allow(ParentQueryService).to receive(:query_parents_for_id).with(child_id).and_return([])
+    end
+
+    it 'does not render an empty heading' do
+      render partial: 'hyrax/base/parent_relationship_table', locals: { child_id: child_id }
+
+      expect(rendered).not_to have_css('h2')
+    end
+  end
+
+  context 'when the work has parent works' do
+    before do
+      allow(ParentQueryService).to receive(:query_parents_for_id).with(child_id).and_return(
+        [{ 'id' => 'parent-1', 'title_tesim' => ['Parent work title'] }]
+      )
+      allow(SolrDocument).to receive(:find).with('parent-1').and_return(instance_double(SolrDocument))
+    end
+
+    it 'renders the relationships heading' do
+      render partial: 'hyrax/base/parent_relationship_table', locals: { child_id: child_id }
+
+      expect(rendered).to have_css('h2', text: I18n.t('hyrax.base.relationships.label'))
+      expect(rendered).to have_link('Parent work title', href: '/concern/parent/1')
+    end
+  end
+end

--- a/spec/views/hyrax/base/_representative_media.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_representative_media.html.erb_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/base/_representative_media.html.erb', type: :view do
+  context 'when the work has no representative file' do
+    let(:presenter) do
+      double(
+        'WorkShowPresenter',
+        representative_id: nil,
+        representative_presenter: nil,
+        human_readable_type: 'Generic Work',
+        title: ['Untitled deposit'],
+        title_or_label: 'Untitled deposit'
+      )
+    end
+
+    it 'renders default artwork with work-based alt text' do
+      render partial: 'hyrax/base/representative_media', locals: { presenter: presenter }
+
+      expect(rendered).to match(%r{src="[^"]*default[^"]*\.png})
+      expect(rendered).to include('alt="Generic Work thumbnail: Untitled deposit"')
+      expect(rendered).to include('canonical-image')
+    end
+  end
+end

--- a/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/base/_show_actions.html.erb', type: :view do
+  context 'when user may add work to a collection' do
+    let(:presenter) do
+      double(
+        'WorkShowPresenter',
+        id: '9593tv123',
+        editor?: false,
+        member_presenters: [],
+        valid_child_concerns: [],
+        work_featurable?: false,
+        show_deposit_for?: true
+      )
+    end
+
+    before do
+      assign(:user_collections, [])
+      assign(:presenter, presenter)
+      allow(Hyrax.config).to receive(:analytics?).and_return(false)
+      stub_template 'hyrax/dashboard/collections/form_for_select_collection.html.erb' => ''
+      render partial: 'hyrax/base/show_actions', locals: { presenter: presenter }
+    end
+
+    it 'associates a screen-reader label and aria-label with the batch checkbox' do
+      expect(rendered).to have_css('label.sr-only[for="batch_document_9593tv123"]',
+                                   text: 'Include this work when adding to a collection')
+      expect(rendered).to have_css(
+        'input.batch_document_selector#batch_document_9593tv123[aria-label="Include this work when adding to a collection"]',
+        visible: :hidden
+      )
+    end
+
+    it 'exposes an accessible name on the add to collection control' do
+      expect(rendered).to have_css(
+        'button.submits-batches-add[type="button"][aria-label="Add to collection"]',
+        text: 'Add to collection'
+      )
+    end
+  end
+end

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
     it 'renders parent followed by sub collections' do
       render
       # Making sure that we are verifying that the _show_actions.html.erb is rendering
-      expect(rendered).to match(/.*Search Results within this Collection.*Parent Collections .*Sub Collections.*/m)
+      expect(rendered).to match(/.*Parent Collections.*Sub Collections.*/m)
       expect(rendered).to have_text('Parent Collections (1)')
       expect(rendered).to have_text('Subcollections (1)')
     end
@@ -93,8 +93,8 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
     it 'renders only sub collections' do
       render
       # Making sure that we are verifying that the _show_actions.html.erb is rendering
-      expect(rendered).not_to match(/.*Search Results within this Collection.*Parent Collections .*Sub Collections.*/m)
-      expect(rendered).to match(/.*Search Results within this Collection.*Sub Collections.*/m)
+      expect(rendered).not_to match(/.*Parent Collections.*Sub Collections.*/m)
+      expect(rendered).to match(/.*Sub Collections.*/m)
       expect(rendered).not_to have_text('Parent Collections')
       expect(rendered).to have_text('Subcollections (1)')
     end

--- a/spec/views/hyrax/file_sets/media_display/_image.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_image.html.erb_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/file_sets/media_display/_image.html.erb', type: :view do
+  let(:file_set) do
+    instance_double(
+      Hyrax::FileSetPresenter,
+      id: 'fs1',
+      human_readable_type: 'File Set',
+      title: ['Scan page 1'],
+      title_or_label: 'Scan page 1'
+    )
+  end
+
+  before do
+    allow(view).to receive(:thumbnail_url).with(file_set).and_return('/downloads/thumb.png')
+  end
+
+  context 'when downloadable content is disabled' do
+    before do
+      allow(Hyrax.config).to receive(:display_media_download_link?).and_return(false)
+    end
+
+    it 'renders the thumbnail with descriptive alt text' do
+      render partial: 'hyrax/file_sets/media_display/image', locals: { file_set: file_set }
+
+      expect(rendered).to include('alt="File Set thumbnail: Scan page 1"')
+      expect(rendered).not_to include('role="presentation"')
+    end
+  end
+
+  context 'when downloadable content is enabled and user may download' do
+    before do
+      allow(Hyrax.config).to receive(:display_media_download_link?).and_return(true)
+      allow(view).to receive(:can?).with(:download, 'fs1').and_return(true)
+      allow(view).to receive(:hyrax).and_return(double(download_path: '/downloads/fs1'))
+    end
+
+    it 'renders the thumbnail with descriptive alt text' do
+      render partial: 'hyrax/file_sets/media_display/image', locals: { file_set: file_set }
+
+      expect(rendered).to include('alt="File Set thumbnail: Scan page 1"')
+      expect(rendered).not_to include('role="presentation"')
+    end
+  end
+end

--- a/spec/views/hyrax/file_sets/media_display/_office_document.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_office_document.html.erb_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/file_sets/media_display/_office_document.html.erb', type: :view do
+  let(:file_set) do
+    instance_double(
+      Hyrax::FileSetPresenter,
+      id: 'fs-doc',
+      human_readable_type: 'File Set',
+      title: ['Report.docx'],
+      title_or_label: 'Report.docx'
+    )
+  end
+
+  before do
+    allow(view).to receive(:thumbnail_url).with(file_set).and_return('/downloads/thumb.png')
+    allow(Hyrax.config).to receive(:display_media_download_link?).and_return(false)
+  end
+
+  it 'renders the office preview thumbnail with descriptive alt text' do
+    render partial: 'hyrax/file_sets/media_display/office_document', locals: { file_set: file_set }
+
+    expect(rendered).to include('alt="File Set thumbnail: Report.docx"')
+    expect(rendered).not_to include('role="presentation"')
+  end
+end

--- a/spec/views/hyrax/file_sets/media_display/_pdf.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display/_pdf.html.erb_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/file_sets/media_display/_pdf.html.erb', type: :view do
+  let(:file_set) do
+    instance_double(
+      Hyrax::FileSetPresenter,
+      id: 'fs-pdf',
+      human_readable_type: 'File Set',
+      title: ['Thesis.pdf'],
+      title_or_label: 'Thesis.pdf'
+    )
+  end
+
+  before do
+    allow(view).to receive(:thumbnail_url).with(file_set).and_return('/downloads/thumb.png')
+    allow(Hyrax.config).to receive(:display_media_download_link?).and_return(false)
+  end
+
+  it 'renders the PDF preview thumbnail with descriptive alt text' do
+    render partial: 'hyrax/file_sets/media_display/pdf', locals: { file_set: file_set }
+
+    expect(rendered).to include('alt="File Set thumbnail: Thesis.pdf"')
+    expect(rendered).not_to include('role="presentation"')
+  end
+end

--- a/spec/views/hyrax/my/_search_form.html.erb_spec.rb
+++ b/spec/views/hyrax/my/_search_form.html.erb_spec.rb
@@ -12,7 +12,11 @@ RSpec.describe 'hyrax/my/_search_form.html.erb', type: :view do
     render
   end
 
-  it "does not have a search label" do
+  it "uses a screen-reader-only label for the search field" do
+    expect(rendered).to have_css('label.sr-only[for="search-field-header"]', text: /Search/)
+  end
+
+  it "does not use a visible Bootstrap control-label" do
     expect(rendered).not_to have_css('label.control-label')
   end
 end


### PR DESCRIPTION
## Summary

This branch improves accessibility (including common WAVE findings) across Hyrax views and the app shell, adds meaningful **alt text** for representative thumbnails on work and file-set pages, and tightens the **notifications** badge behavior for screen readers. View and helper specs are added or updated to lock in the new markup.

## Motivation

- Thumbnails on work/file-set show pages should expose useful `alt` text instead of generic or missing descriptions.
- Several UI patterns produced empty headings, unlabeled controls, or redundant navigation links that hurt accessibility tooling and assistive tech.
- The unread notification count badge should not announce “0” when there is nothing to report, while still showing a visible count when messages are unread.

## Changes

### Thumbnails and representative media

- Override Hyrax `hyrax/file_sets/media_display` partials for **image**, **PDF**, and **office** documents to pass `alt: thumbnail_alt_text_for(...)`.
- Update `hyrax/base/_representative_media.html.erb` so the default representative image uses the same alt helper.

### Shell and Hyrax UI accessibility

- **Search**: Add a proper `<label>` (visually hidden where appropriate) for catalog and “my” dashboard search forms.
- **Work show actions**: Associate a `sr-only` label with the batch checkbox and add `aria-label` for “include work in collection” / batch selection semantics.
- **Parent relationships**: Only render the relationships `<h2>` when parent works exist (`_parent_relationship_table`).
- **Collection show** (public and dashboard): Render the search-results heading only when search parameters are present, avoiding an empty `<h2>`.
- **User menu**: Improve dropdown semantics (`role`, `aria-*`, `menuitem`) and wire the toggle to the menu it controls.
- **Toolbar**: Use non-navigating dropdown toggles for “My Works” / “My Collections” so each destination appears once as a real link (Bootstrap 3–compatible).

### Notifications

- Extract `notification_count_badge` from `render_notifications` in `HyraxHelper`.
- When the unread count is zero, render an empty badge span with `aria-hidden="true"` and invisible styling; when positive, show the numeric count with the danger label and no `aria-hidden`.

### Locales

- Add English strings in `config/locales/hyrax.en.yml` for new user-visible copy tied to the above views.

### Tests

- New specs for media display partials, representative media, show actions, and parent relationship table.
- Extended specs for toolbar, user util links (including unread notification badge behavior), search forms, collection show pages, and `notification_count_badge` in `hyrax_helper_spec`.

---
Wave view of item detail page.  Includes 1 warning for a duplicate link that cannot be fixed without more in-depth JavaScript rework.
<img width="2196" height="1369" alt="Screenshot 2026-04-10 at 1 56 56 PM" src="https://github.com/user-attachments/assets/498612b5-f713-464c-99f3-52697a0a0a02" />

