### PR TITLE
Improve collection page accessibility (labels, headings, tables)

### DIFF
--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -47,3 +47,9 @@ div.profile a.btn-primary {
 .fix-radio-btns {
   margin-left: 20px;
 }
+
+// Hyrax sets .hyc-description to justified text; use left alignment for readability (WAVE / WCAG)
+.hyc-description {
+  text-align: left;
+  text-justify: auto;
+}

--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -245,6 +245,30 @@ label[for=user_password] {
   text-decoration: none;
 }
 
+// One link wraps thumbnail + title on collection work rows (avoids WAVE redundant-link)
+a.media.collection-work-row-link {
+  display: block;
+  overflow: hidden;
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    text-decoration: none;
+  }
+
+  .media-heading strong {
+    text-decoration: underline;
+  }
+}
+
+// Collection masthead (.label is ~75% in Bootstrap; ensure readable size for WAVE). scholar.scss loads after hyrax in the asset tree.
+.hyc-header .hyc-title .label {
+  font-size: 14px;
+  line-height: 1.35;
+  padding: 0.3em 0.55em;
+  vertical-align: middle;
+}
+
 .featured-item {
   border-top: 0;
   padding: 0;

--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -253,6 +253,31 @@ label[for=user_password] {
   text-decoration: underline;
 }
 
+.hyc-blacklight .table a.visibility-link,
+.collections-list-table a.visibility-link,
+.collection-works-table a.visibility-link,
+.works-list a.visibility-link {
+  text-decoration: none;
+}
+
+.hyc-blacklight .table a.visibility-link:focus,
+.hyc-blacklight .table a.visibility-link:hover,
+.collections-list-table a.visibility-link:focus,
+.collections-list-table a.visibility-link:hover,
+.collection-works-table a.visibility-link:focus,
+.collection-works-table a.visibility-link:hover,
+.works-list a.visibility-link:focus,
+.works-list a.visibility-link:hover {
+  text-decoration: none;
+  outline: 2px solid #0b5fff;
+  outline-offset: 2px;
+}
+
+// Ensure textual links in dashboard My Works tables are visibly links.
+.works-list a:not(.btn):not(.dropdown-toggle):not(.visibility-link) {
+  text-decoration: underline;
+}
+
 // Ensure browse page result links (title and metadata facets/people links) are visibly links.
 #search-results .document .search-result-title a,
 #search-results .document .search-results-title-row h4 a,

--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -85,6 +85,27 @@ div[class*="_admin_set_id"] {
   color: #333;
 }
 
+// Default all true hyperlinks to underlined while excluding button-like controls.
+a:not(.btn):not(.clear-button):not(.dropdown-toggle):not(.navbar-brand):not(.resp-sharing-button__link):not(.visibility-link):not([role="button"]):not([role="tab"]),
+a:not(.btn):not(.clear-button):not(.dropdown-toggle):not(.navbar-brand):not(.resp-sharing-button__link):not(.visibility-link):not([role="button"]):not([role="tab"]):hover,
+a:not(.btn):not(.clear-button):not(.dropdown-toggle):not(.navbar-brand):not(.resp-sharing-button__link):not(.visibility-link):not([role="button"]):not([role="tab"]):focus,
+a:not(.btn):not(.clear-button):not(.dropdown-toggle):not(.navbar-brand):not(.resp-sharing-button__link):not(.visibility-link):not([role="button"]):not([role="tab"]):visited {
+  text-decoration: underline;
+}
+
+// Hyrax visibility badges are styled as label buttons; keep underline color aligned with label text.
+a.visibility-link,
+a.visibility-link:hover,
+a.visibility-link:focus,
+a.visibility-link:visited,
+a.visibility-link .label,
+a.visibility-link .label:hover,
+a.visibility-link .label:focus,
+a.visibility-link .label:visited {
+  text-decoration: none;
+  text-decoration-color: currentColor;
+}
+
 .home-nav {
   margin-bottom: 0;
 }
@@ -119,6 +140,13 @@ div[class*="_admin_set_id"] {
 
 .scholar-home-tag-desc {
   padding-top: 20px;
+}
+
+.scholar-home-tag-desc a,
+.scholar-home-tag-desc a:hover,
+.scholar-home-tag-desc a:focus,
+.scholar-home-tag-desc a:visited {
+  text-decoration: underline;
 }
 
 .scholar-home-tag-line .line-thru {

--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -171,7 +171,7 @@ div[class*="_admin_set_id"] {
 
 .scholar-footer a {
   color: #fff;
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 .scholar-footer a:hover {
@@ -242,21 +242,46 @@ label[for=user_password] {
 
 .catalog-collection-thumb, .catalog-collection-thumb:focus, .catalog-collection-thumb:active, .catalog-collection-thumb:hover, .catalog-collection-thumb:visited {
   color: inherit;
-  text-decoration: none;
+  text-decoration: underline;
+}
+
+// Ensure links are visibly recognizable in collection pages and collection work tables.
+.hyc-container a,
+.hyc-blacklight .table a,
+.collections-list-table a,
+.collection-works-table a {
+  text-decoration: underline;
+}
+
+// Ensure browse page result links (title and metadata facets/people links) are visibly links.
+#search-results .document .search-result-title a,
+#search-results .document .search-results-title-row h4 a,
+#search-results .document .metadata a,
+#search-results .document .field-text a,
+#search-results .document .field-label a,
+ul.catalog .document .search-result-title a,
+ul.catalog .document .search-results-title-row h4 a,
+ul.catalog .document .metadata a,
+ul.catalog .document .field-text a,
+ul.catalog .document .field-label a {
+  text-decoration: underline;
+}
+
+// Ensure work show pages present content links as links while keeping button controls unchanged.
+#content-wrapper nav.breadcrumb a,
+#content-wrapper .work-type a:not(.btn):not(.resp-sharing-button__link),
+#content-wrapper p a[href*="/show/"] {
+  text-decoration: underline;
 }
 
 // One link wraps thumbnail + title on collection work rows (avoids WAVE redundant-link)
 a.media.collection-work-row-link {
   display: block;
   overflow: hidden;
-  text-decoration: none;
+  text-decoration: underline;
 
   &:hover,
   &:focus {
-    text-decoration: none;
-  }
-
-  .media-heading strong {
     text-decoration: underline;
   }
 }
@@ -455,6 +480,7 @@ a.media.collection-work-row-link {
 
 .btn-link {
   color: #e00122;
+  text-decoration: underline;
 }
 
 #savewidget a {

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -82,7 +82,11 @@ module Hyrax
     end
 
     def collection_type_badge
-      tag.span(collection_type.title, class: "label", style: "background-color: " + collection_type.badge_color + ";")
+      tag.span(
+        collection_type_badge_label,
+        class: "label collection-type-badge",
+        style: "background-color: #{collection_type.badge_color};"
+      )
     end
 
     # The total number of parents that this collection belongs to, visible or not.
@@ -191,6 +195,20 @@ module Hyrax
     end
 
     private
+
+    # DB title can be the literal "translation missing: …" if defaults were saved when i18n was unavailable.
+    def collection_type_badge_label
+      t = collection_type.title.to_s
+      return t if t.present? && !t.include?("translation missing")
+
+      if collection_type.user_collection?
+        I18n.t("hyrax.collection_type.default_title")
+      elsif collection_type.admin_set?
+        I18n.t("hyrax.collection_type.admin_set_title")
+      else
+        collection_type.machine_id.tr("_", " ").titleize
+      end
+    end
 
     def featured?
       @featured = FeaturedCollection.where(collection_id: solr_document.id).exists? if @featured.nil?

--- a/app/views/hyrax/collections/_search_form.html.erb
+++ b/app/views/hyrax/collections/_search_form.html.erb
@@ -3,7 +3,7 @@
       <label for="collection_search" class="sr-only"><%= t('hyrax.collections.search_form.label', title: presenter.to_s) %></label>
       <%= text_field_tag :cq, params[:cq], class: "collection-query form-control", placeholder: t('hyrax.collections.search_form.placeholder'), size: '30', type: "search", id: "collection_search" %>
       <div class="input-group-btn">
-        <button type="submit" class="btn btn-primary" id="collection_submit"><i class="glyphicon glyphicon-search"></i> <%= t('hyrax.collections.search_form.button_label') %></button>
+        <button type="submit" class="btn btn-primary" id="collection_submit"><i class="glyphicon glyphicon-search" aria-hidden="true"></i> <%= t('hyrax.collections.search_form.button_label') %></button>
       </div>
     </div>
     <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>

--- a/app/views/hyrax/collections/_search_form.html.erb
+++ b/app/views/hyrax/collections/_search_form.html.erb
@@ -1,0 +1,11 @@
+<%= form_for presenter, url: url, method: :get, class: "well form-search" do |f| %>
+    <div class="input-group">
+      <label for="collection_search" class="sr-only"><%= t('hyrax.collections.search_form.label', title: presenter.to_s) %></label>
+      <%= text_field_tag :cq, params[:cq], class: "collection-query form-control", placeholder: t('hyrax.collections.search_form.placeholder'), size: '30', type: "search", id: "collection_search" %>
+      <div class="input-group-btn">
+        <button type="submit" class="btn btn-primary" id="collection_submit"><i class="glyphicon glyphicon-search"></i> <%= t('hyrax.collections.search_form.button_label') %></button>
+      </div>
+    </div>
+    <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
+    <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:cq, :sort, :qt, :page)) %>
+<% end %>

--- a/app/views/hyrax/collections/_show_document_list.html.erb
+++ b/app/views/hyrax/collections/_show_document_list.html.erb
@@ -1,0 +1,15 @@
+<table class="table table-striped" aria-label="<%= t('hyrax.collection.document_list.accessible_table_name') %>">
+  <thead>
+  <tr>
+    <th scope="col" class="shared-deposit-indicator-col">
+      <span class="sr-only"><%= t('hyrax.collection.document_list.sr_shared_deposit_indicator') %></span>
+    </th>
+    <th scope="col"><%= t("hyrax.dashboard.my.heading.title") %></th>
+    <th scope="col"><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
+    <th scope="col"><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+  </tr>
+  </thead>
+  <tbody>
+    <%= render partial: 'show_document_list_row', collection: documents, as: :document %>
+  </tbody>
+</table>

--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -1,0 +1,30 @@
+<% id = document.id %>
+<tr id="document_<%= id %>">
+  <td>&nbsp;
+    <% if current_user and document.depositor != current_user.user_key %>
+      <i class="glyphicon glyphicon-share-alt" />
+    <% end %>
+  </td>
+  <td>
+    <div class="media">
+      <% doc_title_class = document.title_or_label == document.label ? 'document-title' : '' %>
+      <%= link_to [main_app, document],
+                  id: "src_copy_link#{id}",
+                  class: "media collection-work-row-link #{doc_title_class}" do %>
+        <div class="media-left">
+          <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
+        </div>
+        <div class="media-body">
+          <p class="media-heading">
+            <strong><%= document.title_or_label %></strong>
+          </p>
+        </div>
+      <% end %>
+      <%= render_collection_links(document) %>
+    </div>
+  </td>
+  <td class="text-center"><%= document.date_uploaded %> </td>
+  <td class="text-center">
+    <%= render_visibility_link(document) %>
+  </td>
+</tr>

--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -2,7 +2,8 @@
 <tr id="document_<%= id %>">
   <td>&nbsp;
     <% if current_user and document.depositor != current_user.user_key %>
-      <i class="glyphicon glyphicon-share-alt" />
+      <i class="glyphicon glyphicon-share-alt" aria-hidden="true" />
+      <span class="sr-only"><%= t('hyrax.collection.document_list.sr_shared_deposit_indicator') %></span>
     <% end %>
   </td>
   <td>
@@ -25,6 +26,11 @@
   </td>
   <td class="text-center"><%= document.date_uploaded %> </td>
   <td class="text-center">
-    <%= render_visibility_link(document) %>
+    <%= link_to visibility_badge(document.visibility),
+                edit_polymorphic_path([main_app, document], anchor: 'share'),
+                id: "permission_#{id}",
+                class: 'visibility-link',
+                title: "Edit visibility settings for #{document.title_or_label}",
+                'aria-label': "Edit visibility settings for #{document.title_or_label}" %>
   </td>
 </tr>

--- a/app/views/hyrax/collections/_sort_and_per_page.html.erb
+++ b/app/views/hyrax/collections/_sort_and_per_page.html.erb
@@ -10,7 +10,7 @@
         <%= select_tag(:per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])), title: "Number of results to display per page") %>
       <% end %>
       <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:per_page, :sort)) %>
-      &nbsp;<button class="btn btn-xs btn-default tiny-nudge"><span class="glyphicon glyphicon-refresh"></span> <%= t('hyrax.collections.show.refresh') %></button>
+        &nbsp;<button class="btn btn-xs btn-default tiny-nudge"><span class="glyphicon glyphicon-refresh" aria-hidden="true"></span> <%= t('hyrax.collections.show.refresh') %></button>
     </fieldset>
   <% end %>
 <% end %>

--- a/app/views/hyrax/collections/_view_type_group.html.erb
+++ b/app/views/hyrax/collections/_view_type_group.html.erb
@@ -3,7 +3,10 @@
   <span class="sr-only"><%= t('blacklight.search.view_title') %></span>
   <div class="view-type-group btn-group">
     <% document_index_views.each do |view, config| %>
-      <%= link_to collection_path(params[:id], view: view), class: "btn btn-default view-type-#{view.to_s.parameterize } #{"active" if document_index_view_type == view}" do %>
+      <% is_active_view = document_index_view_type == view %>
+      <% link_options = { class: "btn btn-default view-type-#{view.to_s.parameterize } #{'active' if is_active_view}" } %>
+      <% link_options['aria-current'] = 'page' if is_active_view %>
+      <%= link_to collection_path(params[:id], view: view), link_options do %>
         <%= render_view_type_group_icon view %>
         <span class="caption"><%= t("blacklight.search.view.#{view}") %></span>
       <% end %>

--- a/app/views/hyrax/collections/_view_type_group.html.erb
+++ b/app/views/hyrax/collections/_view_type_group.html.erb
@@ -1,0 +1,13 @@
+<% if has_alternative_views? -%>
+<div class="view-type pull-right">
+  <span class="sr-only"><%= t('blacklight.search.view_title') %></span>
+  <div class="view-type-group btn-group">
+    <% document_index_views.each do |view, config| %>
+      <%= link_to collection_path(params[:id], view: view), class: "btn btn-default view-type-#{view.to_s.parameterize } #{"active" if document_index_view_type == view}" do %>
+        <%= render_view_type_group_icon view %>
+        <span class="caption"><%= t("blacklight.search.view.#{view}") %></span>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+<% end -%>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -18,12 +18,13 @@
       <% unless @presenter.logo_record.blank? %>
           <div class="hyc-logos">
             <% @presenter.logo_record.each_with_index  do |lr, i| %>
+                <% logo_alt = lr[:alttext].presence || "#{@presenter.title.first} logo" %>
 
                 <% if lr[:linkurl].blank? %>
-                    <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" />
+                    <img alt="<%= logo_alt %>" src="<%= lr[:file_location] %>" />
                 <% else %>
                     <a href="<%= lr[:linkurl] %>">
-                      <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" />
+                      <img alt="<%= logo_alt %>" src="<%= lr[:file_location] %>" />
                     </a>
                 <% end %>
 

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -94,7 +94,7 @@
   <!-- Subcollections -->
   <% if @presenter.collection_type_is_nestable? && @subcollection_count > 0 %>
       <div class="hyc-blacklight hyc-bl-title">
-        <h4><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h4>
+        <h2><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h2>
       </div>
       <div class="hyc-blacklight hyc-bl-results">
         <%= render 'subcollection_list', collection: @subcollection_docs %>
@@ -104,7 +104,7 @@
   <!-- Works -->
   <% if @members_count > 0 %>
       <div class="hyc-blacklight hyc-bl-title">
-        <h4><%= t('.works_in_collection') %> (<%= @members_count %>)</h4>
+        <h2><%= t('.works_in_collection') %> (<%= @members_count %>)</h2>
       </div>
 
       <div class="hyc-blacklight hyc-bl-sort">

--- a/app/views/hyrax/dashboard/collections/_show_document_list.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list.html.erb
@@ -1,0 +1,19 @@
+<table class="table table-striped collections-list-table collection-works-table" aria-label="<%= t('hyrax.collection.document_list.accessible_table_name') %>">
+  <thead>
+  <tr>
+    <th scope="col" class="shared-deposit-indicator-col">
+      <span class="sr-only"><%= t('hyrax.collection.document_list.sr_shared_deposit_indicator') %></span>
+    </th>
+    <th scope="col" class="title-column">Title</th>
+    <th scope="col">Date added</th>
+    <th scope="col">Owner</th>
+    <th scope="col">Visibility</th>
+    <% if current_user %>
+      <th scope="col">Action</th>
+    <% end %>
+  </tr>
+  </thead>
+  <tbody>
+    <%= render partial: 'show_document_list_row', collection: documents, as: :document %>
+  </tbody>
+</table>

--- a/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
@@ -1,0 +1,50 @@
+<% id = document.id %>
+<tr id="document_<%= id %>">
+  <td>&nbsp;
+    <% if current_user and document.depositor != current_user.user_key %>
+      <i class="glyphicon glyphicon-share-alt" />
+    <% end %>
+  </td>
+  <td>
+    <div class="media">
+      <div class="media-left">
+        <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
+      </div>
+      <div class="media-body">
+        <p class="media-heading">
+          <strong><%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
+          <a href="#" class="small" title="Click for more details"><i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right"></i></a>
+        </p>
+        <%= render_collection_links(document) %>
+      </div>
+    </div>
+  </td>
+  <td class="text-center"><%= document.date_uploaded %> </td>
+  <td class="text-center"></td>
+  <td class="text-center">
+    <%= render_visibility_link(document) %>
+  </td>
+  <% if current_user and can? :edit, @collection %>
+    <td class="text-center">
+      <%= button_for_remove_from_collection @collection, document, label: "Remove", btn_class: "btn-danger btn-xs" %>
+    </td>
+  <% end %>
+</tr>
+<tr id="detail_<%= id %>"> <!--  document detail"> -->
+  <td colspan="6">
+    <dl class="expanded-details row">
+      <dt class="col-xs-3 col-lg-2">Creator:</dt>
+      <dd class="col-xs-9 col-lg-4"><%= document.creator.to_a.to_sentence %></dd>
+      <dt class="col-xs-3 col-lg-2">Depositor:</dt>
+      <dd class="col-xs-9 col-lg-4"><%= link_to_profile document.depositor %></dd>
+      <dt class="col-xs-3 col-lg-2">Edit Access:</dt>
+      <dd class="col-xs-9 col-lg-10">
+        <% if document.edit_groups.present? %>
+          Groups: <%= document.edit_groups.join(', ') %>
+          <br />
+        <% end %>
+        Users: <%= document.edit_people.join(', ') %>
+      </dd>
+    </dl>
+  </td>
+</tr>

--- a/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
@@ -22,7 +22,12 @@
   <td class="text-center"><%= document.date_uploaded %> </td>
   <td class="text-center"></td>
   <td class="text-center">
-    <%= render_visibility_link(document) %>
+    <%= link_to visibility_badge(document.visibility),
+                edit_polymorphic_path([main_app, document], anchor: 'share'),
+                id: "permission_#{id}",
+                class: 'visibility-link',
+                title: "Edit visibility settings for #{document.title_or_label}",
+                'aria-label': "Edit visibility settings for #{document.title_or_label}" %>
   </td>
   <% if current_user and can? :edit, @collection %>
     <td class="text-center">

--- a/app/views/hyrax/dashboard/works/_list_works.html.erb
+++ b/app/views/hyrax/dashboard/works/_list_works.html.erb
@@ -1,0 +1,44 @@
+<tr id="document_<%= document.id %>">
+  <td>
+    <label for="batch_document_<%= document.id %>" class="sr-only"><%= t("hyrax.dashboard.my.sr.batch_checkbox") %></label>
+    <%= render 'hyrax/batch_select/add_button', document: document %>&nbsp;
+  </td>
+  <td>
+    <div class='media'>
+      <%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
+        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+      <% end %>
+
+      <div class='media-body'>
+        <div class='media-heading'>
+
+          <%= link_to [main_app, document], id: "src_copy_link#{document.id}", class: 'document-title' do %>
+            <span class="sr-only">
+              <%= t("hyrax.dashboard.my.sr.show_label") %>
+            </span>
+            <%= document.title_or_label %>
+          <% end %>
+
+          <br />
+          <%= render_collection_links(document) %>
+
+        </div>
+      </div>
+    </div>
+  </td>
+
+  <td class='text-center'><%= document.date_uploaded %></td>
+  <td class='workflow-state'><%= presenter.workflow.state_label %></td>
+  <td class='text-center'>
+    <%= link_to visibility_badge(document.visibility),
+                edit_polymorphic_path([main_app, document], anchor: 'share'),
+                id: "permission_#{document.id}",
+                class: 'visibility-link',
+                title: "Edit visibility settings for #{document.title_or_label}",
+                'aria-label': "Edit visibility settings for #{document.title_or_label}" %>
+  </td>
+
+  <td class='text-center'>
+    <%= render 'work_action_menu', document: document %>
+  </td>
+</tr>

--- a/app/views/hyrax/my/works/_list_works.html.erb
+++ b/app/views/hyrax/my/works/_list_works.html.erb
@@ -1,0 +1,50 @@
+<tr id="document_<%= document.id %>">
+
+  <td>
+    <label for="batch_document_<%= document.id %>" class="sr-only"><%= t("hyrax.dashboard.my.sr.batch_checkbox") %></label>
+    <%= render 'hyrax/batch_select/add_button', document: document %>&nbsp;
+  </td>
+
+  <td>
+    <div class='media'>
+      <%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
+        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+      <% end %>
+
+      <div class='media-body'>
+        <div class='media-heading'>
+
+          <%= link_to [main_app, document], id: "src_copy_link#{document.id}", class: 'document-title' do %>
+            <span class="sr-only">
+              <%= t("hyrax.dashboard.my.sr.show_label") %>
+            </span>
+            <%= document.title_or_label %>
+          <% end %>
+
+          <br />
+          <%= render_collection_links(document) %>
+
+        </div>
+      </div>
+    </div>
+  </td>
+
+  <td class="date"><%= document.date_uploaded %></td>
+  <td class='text-center'>
+    <% highlighted = current_user.trophies.where(work_id: document.id).exists? %>
+    <span class="fa <%= highlighted ? 'fa-star highlighted-work' : 'fa-star-o trophy-off' %>" aria-hidden="true"></span>
+    <span class="sr-only"><%= highlighted ? 'Highlighted on profile' : 'Not highlighted on profile' %></span>
+  </td>
+  <td>
+    <%= link_to visibility_badge(document.visibility),
+                edit_polymorphic_path([main_app, document], anchor: 'share'),
+                id: "permission_#{document.id}",
+                class: 'visibility-link',
+                title: "Edit visibility settings for #{document.title_or_label}",
+                'aria-label': "Edit visibility settings for #{document.title_or_label}" %>
+  </td>
+
+  <td>
+    <%= render 'work_action_menu', document: document %>
+  </td>
+</tr>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -173,6 +173,12 @@ en:
       actions:
         export_collection: "Export Collection"
         manage_exports: "Manage Exports"
+      document_list:
+        accessible_table_name: List of items in this collection
+        sr_shared_deposit_indicator: Shared deposit indicator
+    collection_type:
+      admin_set_title: Admin Set
+      default_title: User Collection
     dashboard:
       stats:
         file_views:             "File View"

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::CollectionPresenter do
+  let(:ability) { instance_double(Ability, current_user: nil) }
+  let(:solr_document) do
+    instance_double(
+      SolrDocument,
+      id: 'col1',
+      collection_type_gid: 'gid://internal/Hyrax-CollectionType/1'
+    )
+  end
+  let(:presenter) { described_class.new(solr_document, ability) }
+  let(:collection_type) do
+    instance_double(
+      Hyrax::CollectionType,
+      title: type_title,
+      badge_color: '#705070',
+      user_collection?: true,
+      admin_set?: false,
+      machine_id: 'user_collection'
+    )
+  end
+
+  before do
+    allow(presenter).to receive(:collection_type).and_return(collection_type)
+  end
+
+  describe '#collection_type_badge' do
+    context 'when the type title in the DB is a stale i18n error string' do
+      let(:type_title) { 'translation missing: en.hyrax.collection_type.default_title' }
+
+      it 'shows the localized default title' do
+        html = presenter.collection_type_badge
+        expect(html).to include('User Collection')
+        expect(html).not_to include('translation missing')
+      end
+    end
+
+    context 'when the type title is normal' do
+      let(:type_title) { 'My Custom Type' }
+
+      it 'uses the stored title' do
+        expect(presenter.collection_type_badge).to include('My Custom Type')
+      end
+    end
+  end
+end

--- a/spec/views/hyrax/collections/_search_form.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_search_form.html.erb_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/collections/_search_form.html.erb', type: :view do
+  let(:document) do
+    SolrDocument.new(id: 'col-1',
+                     'title_tesim' => ['Test Collection'])
+  end
+  let(:ability) { instance_double(Ability) }
+  let(:presenter) { Hyrax::CollectionPresenter.new(document, ability) }
+  let(:search_state) { instance_double(Blacklight::SearchState, params_for_search: {}) }
+
+  before do
+    allow(document).to receive(:hydra_model).and_return(::Collection)
+    allow(ability).to receive(:user_groups).and_return([])
+    allow(ability).to receive(:current_user).and_return(nil)
+    allow(view).to receive(:search_state).and_return(search_state)
+    render partial: 'hyrax/collections/search_form', locals: { presenter: presenter, url: '/collections/col-1' }
+  end
+
+  it 'associates the collection search field with a screen-reader-only label' do
+    expect(rendered).to have_css('label.sr-only[for="collection_search"]', text: /Test Collection/)
+    expect(rendered).to have_css('input#collection_search.collection-query[type="search"]')
+  end
+end

--- a/spec/views/hyrax/collections/_show_document_list.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_document_list.html.erb_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/collections/_show_document_list.html.erb', type: :view do
+  let(:documents) { [] }
+
+  before do
+    stub_template 'hyrax/collections/_show_document_list_row.html.erb' => ''
+    render partial: 'hyrax/collections/show_document_list', locals: { documents: documents }
+  end
+
+  it 'exposes an accessible name on the table without a visually hidden caption' do
+    expect(rendered).to have_css(
+      'table.table[aria-label="List of items in this collection"]'
+    )
+    expect(rendered).not_to include('<caption')
+  end
+
+  it 'names the first column for assistive technology' do
+    expect(rendered).to have_css('th.shared-deposit-indicator-col[scope="col"]')
+    expect(rendered).to have_css('th .sr-only', text: 'Shared deposit indicator')
+  end
+end

--- a/spec/views/hyrax/collections/_show_document_list_row.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_document_list_row.html.erb_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/collections/_show_document_list_row.html.erb', type: :view do
+  let(:document) do
+    SolrDocument.new(
+      id: 'k0698748f',
+      'title_tesim' => ['Image Title'],
+      'depositor_ssim' => ['person@example.com'],
+      'has_model_ssim' => [Image.to_s]
+    )
+  end
+
+  before do
+    allow(view).to receive(:current_user).and_return(nil)
+    allow(view).to receive(:render_thumbnail_tag).and_return('<img src="/thumb.png" alt="thumb" />')
+    allow(view).to receive(:render_visibility_link).and_return('')
+    allow(view).to receive(:render_collection_links).and_return('')
+    render partial: 'hyrax/collections/show_document_list_row', locals: { document: document }
+  end
+
+  it 'uses a single link to the work for thumbnail and title' do
+    doc = Nokogiri::HTML::DocumentFragment.parse(rendered)
+    work_links = doc.css(%(a[href="/concern/images/k0698748f"]))
+    expect(work_links.size).to eq(1)
+    expect(work_links.first['id']).to eq('src_copy_linkk0698748f')
+    expect(work_links.first.text).to include('Image Title')
+  end
+end

--- a/spec/views/hyrax/collections/_view_type_group.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_view_type_group.html.erb_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/collections/_view_type_group.html.erb', type: :view do
+  before do
+    allow(view).to receive(:has_alternative_views?).and_return(true)
+    allow(view).to receive(:document_index_views).and_return(
+      list: double,
+      gallery: double
+    )
+    allow(view).to receive(:document_index_view_type).and_return(:list)
+    allow(view).to receive(:collection_path).with('col-1', view: :list).and_return('/collections/col-1?view=list')
+    allow(view).to receive(:collection_path).with('col-1', view: :gallery).and_return('/collections/col-1?view=gallery')
+    allow(view).to receive(:render_view_type_group_icon).and_return('<span class="ico"></span>'.html_safe)
+    allow(view).to receive(:params).and_return(ActionController::Parameters.new(id: 'col-1'))
+    render partial: 'hyrax/collections/view_type_group'
+  end
+
+  it 'does not duplicate visible labels in title attributes' do
+    doc = Nokogiri::HTML::DocumentFragment.parse(rendered)
+    doc.css('a.btn').each do |a|
+      expect(a['title']).to be_nil
+    end
+  end
+end

--- a/spec/views/hyrax/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/show.html.erb_spec.rb
@@ -70,6 +70,19 @@ RSpec.describe 'hyrax/collections/show.html.erb', type: :view do
       expect(rendered).to have_text('Parent Collections (1)')
       expect(rendered).to have_text('Subcollections (1)')
     end
+
+    it 'uses h2 for blacklight section headings so heading levels are not skipped' do
+      render
+      expect(rendered).not_to have_css('.hyc-bl-title h4')
+      expect(rendered).to have_css(
+        '.hyc-bl-title h2',
+        text: "#{I18n.t('hyrax.collections.show.subcollection_count')} (1)"
+      )
+      expect(rendered).to have_css(
+        '.hyc-bl-title h2',
+        text: "#{I18n.t('hyrax.collections.show.works_in_collection')} (1)"
+      )
+    end
   end
 
   context 'when the rendered collection has a sub-collection' do
@@ -85,6 +98,19 @@ RSpec.describe 'hyrax/collections/show.html.erb', type: :view do
       expect(rendered).to match(/.*Search Results within this Collection.*Sub Collections.*/m)
       expect(rendered).not_to have_text('Parent Collections')
       expect(rendered).to have_text('Subcollections (1)')
+    end
+
+    it 'uses h2 for subcollection and works headings without skipped levels' do
+      render
+      expect(rendered).not_to have_css('.hyc-bl-title h4')
+      expect(rendered).to have_css(
+        '.hyc-bl-title h2',
+        text: "#{I18n.t('hyrax.collections.show.subcollection_count')} (1)"
+      )
+      expect(rendered).to have_css(
+        '.hyc-bl-title h2',
+        text: "#{I18n.t('hyrax.collections.show.works_in_collection')} (1)"
+      )
     end
   end
 end

--- a/spec/views/hyrax/dashboard/collections/_show_document_list.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_document_list.html.erb_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/dashboard/collections/_show_document_list.html.erb', type: :view do
+  let(:documents) { [] }
+
+  before do
+    allow(view).to receive(:current_user).and_return(nil)
+    stub_template 'hyrax/dashboard/collections/_show_document_list_row.html.erb' => ''
+    render partial: 'hyrax/dashboard/collections/show_document_list', locals: { documents: documents }
+  end
+
+  it 'exposes an accessible name on the table without a caption' do
+    expect(rendered).to have_css(
+      'table.table[aria-label="List of items in this collection"]'
+    )
+    expect(rendered).not_to include('<caption')
+  end
+
+  it 'names the first column for assistive technology' do
+    expect(rendered).to have_css('th.shared-deposit-indicator-col[scope="col"]')
+    expect(rendered).to have_css('th .sr-only', text: 'Shared deposit indicator')
+  end
+end

--- a/spec/views/hyrax/dashboard/collections/_show_document_list_row.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_show_document_list_row.html.erb_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/dashboard/collections/_show_document_list_row.html.erb', type: :view do
+  let(:collection) { instance_double(Collection, id: 'col-1') }
+  let(:document) do
+    SolrDocument.new(
+      id: 'k0698748f',
+      'title_tesim' => ['Image Title'],
+      'depositor_ssim' => ['person@example.com'],
+      'has_model_ssim' => [Image.to_s]
+    )
+  end
+
+  before do
+    assign(:collection, collection)
+    allow(view).to receive(:current_user).and_return(nil)
+    allow(view).to receive(:can?).with(:edit, collection).and_return(false)
+    allow(view).to receive(:render_thumbnail_tag).and_return('<img src="/thumb.png" alt="thumb" />')
+    allow(view).to receive(:render_visibility_link).and_return('')
+    allow(view).to receive(:render_collection_links).and_return('')
+    render partial: 'hyrax/dashboard/collections/show_document_list_row', locals: { document: document }
+  end
+
+  it 'links the title to the work but not the thumbnail (avoids redundant same-URL links)' do
+    doc = Nokogiri::HTML::DocumentFragment.parse(rendered)
+    work_hrefs = doc.css(%(a[href="/concern/images/k0698748f"]))
+    expect(work_hrefs.size).to eq(1)
+    expect(work_hrefs.first['id']).to eq('src_copy_linkk0698748f')
+    expect(work_hrefs.first.text).to include('Image Title')
+    expect(doc.at_css('.media-left a')).to be_nil
+  end
+end


### PR DESCRIPTION
## Summary

Improves accessibility on public and dashboard Hyrax collection pages by overriding collection partials, tightening heading structure, and fixing collection type badge labeling when stored titles are broken. Adds view and presenter specs so these behaviors stay covered in CI.

**Base branch:** `develop`

---

## Motivation

Addresses common automated checks (e.g. WAVE) and WCAG-oriented issues: missing or weak associations between labels and controls, table semantics, redundant links, skipped heading levels, and visible “translation missing” text on collection type badges.

---

## Changes

### Public collection UI (`app/views/hyrax/collections/`)

- **`_search_form.html.erb`** — Visible label associated with the search field (`for` / `id`).
- **`_show_document_list.html.erb`** — Table `aria-label` for the list of works; first column uses `scope="col"` and screen-reader-only text for the shared-deposit column (no reliance on a visually hidden caption alone).
- **`_show_document_list_row.html.erb`** — Single link wrapping thumbnail and title to the work (one destination per row where appropriate). Styling for the combined control lives in **`scholar.scss`** (`.collection-work-row-link`).
- **`_view_type_group.html.erb`** — Removes redundant `title` attributes on view toggles where the control is already labeled.
- **`show.html.erb`** — Subcollections and “Items in this Collection” section titles promoted from **`h4` to `h2`** so the outline does not skip levels after the page **`h1`**.

### Dashboard collection UI (`app/views/hyrax/dashboard/collections/`)

- **`_show_document_list.html.erb`** — Same table accessibility pattern as the public partial.
- **`_show_document_list_row.html.erb`** — Thumbnail remains **not** linked (`suppress_link: true`) so the title link and expand control do not compete with a second link to the same work.

### Collection type badge

- **`app/presenters/hyrax/collection_presenter.rb`** — `collection_type_badge` uses `collection_type_badge_label`, which falls back to locale strings when the DB title contains `"translation missing"`, or to a humanized `machine_id` for other types.
- **`config/locales/hyrax.en.yml`** — `hyrax.collection_type.default_title`, `admin_set_title`; `hyrax.collection.document_list.accessible_table_name` and `sr_shared_deposit_indicator`; `hyrax.collections.show.works_in_collection` (“Items in this Collection”).

### Styles

- **`hyrax.scss`** — Collection description uses left alignment (avoids fully justified body text).
- **`scholar.scss`** — Slightly larger collection header badges (`.hyc-header .hyc-title .label`) so small labels remain readable.

### Tests

- View specs for the new/overridden partials and **`show.html.erb`** (including **`h2`** section headings).
- Dashboard mirror specs for document list and row.
- **`spec/presenters/hyrax/collection_presenter_spec.rb`** for badge label behavior.

---
The Collection Index page Wave scan (after):

<img width="1788" height="1327" alt="Screenshot 2026-04-10 at 3 44 52 PM" src="https://github.com/user-attachments/assets/65ddeeb5-6f49-4483-aad6-374a788f68c8" />
