### PR TITLE
Updates sidekiq_limit gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'hydra-remote_identifier', github: 'uclibs/hydra-remote_identifier', branch:
 gem 'kaltura', '0.1.1'
 gem 'nio4r', '~> 2.7', '>= 2.7.1'
 gem 'rack', '2.2.3'
-gem 'sidekiq-limit_fetch'
+gem 'sidekiq-limit_fetch', '~> 4.0'
 
 # Hyrax improvements
 gem "okcomputer", "~> 1.18.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,7 +276,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.10)
-    connection_pool (2.2.5)
+    connection_pool (2.5.5)
     coveralls_reborn (0.28.0)
       simplecov (~> 0.22.0)
       term-ansicolor (~> 1.7)
@@ -903,9 +903,9 @@ GEM
       rexml (~> 3.2)
     redic (1.5.3)
       hiredis
-    redis (5.4.0)
+    redis (5.4.1)
       redis-client (>= 0.22.0)
-    redis-client (0.24.0)
+    redis-client (0.28.0)
       connection_pool
     redis-namespace (1.9.0)
       redis (>= 4)
@@ -1034,8 +1034,8 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.5.0)
-    sidekiq-limit_fetch (3.4.0)
-      sidekiq (>= 4)
+    sidekiq-limit_fetch (4.4.1)
+      sidekiq (>= 6)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -1229,7 +1229,7 @@ DEPENDENCIES
   shoulda-matchers (~> 3.1)
   show_me_the_cookies
   sidekiq (>= 6.0)
-  sidekiq-limit_fetch
+  sidekiq-limit_fetch (~> 4.0)
   simplecov-lcov
   solr_wrapper (>= 0.3)
   sqlite3 (= 1.3.13)


### PR DESCRIPTION
We needed to update this gem to support 

sidekiq 6.5.5
Redis server v=5.0.3 sha=00000000:0 malloc=jemalloc-5.1.0 bits=64 build=d0e2dcdeba8c0cee