### PR TITLE
LIBSCH1-76 Bug fix: menu width correction

### DIFF
--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -1,3 +1,10 @@
+// Ensure facet menu and its children are not flex items
+.facet-values,
+.facet-values > *,
+.facet-label,
+.facet-count {
+  display: block;
+}
 @import 'morris.js/0.5.1/morris';
 @import 'bootstrap/variables';
 $tab-margin: 44px !default;

--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -4,6 +4,7 @@
 .facet-label,
 .facet-count {
   display: block;
+  width: 100%;
 }
 @import 'morris.js/0.5.1/morris';
 @import 'bootstrap/variables';


### PR DESCRIPTION
Fix sidebar facet menu width when body uses flex layout

This PR fixes an issue where the sidebar facet menu items appeared only one character wide after the body was set to `display: flex`. The solution is to explicitly set `display: block` on the facet menu container and its children, ensuring correct width and layout.

**Changes:**
- Add `display: block` to `.facet-values`, `.facet-values > *`, `.facet-label`, and `.facet-count` in `hyrax/dashboard.scss`.
- Add `width: 100%` to the same to allow labels to display in one line

No other changes are included. This resolves the menu width regression while preserving the site-wide flexbox layout.

Before this change:
<img width="279" height="927" alt="Screenshot 2026-04-17 at 9 28 30 AM" src="https://github.com/user-attachments/assets/705cf85a-0f23-476a-8165-915796119df4" />

After this change:
<img width="292" height="252" alt="Screenshot 2026-04-17 at 11 50 27 AM" src="https://github.com/user-attachments/assets/cfdd4ab4-3d99-4f5a-9040-e013a75edeb6" />
<img width="337" height="269" alt="Screenshot 2026-04-17 at 11 50 21 AM" src="https://github.com/user-attachments/assets/8376f22f-ec3e-4b01-a5b7-0281cafc3562" />

