### PR TITLE
Hyku db seed

### DIFF
--- a/.cursor/rules/markdown-docs-style.mdc
+++ b/.cursor/rules/markdown-docs-style.mdc
@@ -22,8 +22,9 @@ Primary local setup entry point: `docs/local/README.md` (multi-page, step-by-ste
 ## Commands in the terminal
 
 - When the reader must decide based on output, give **one command** (or one clear choice), then the next instruction.
-- Multi-line / chained commands are OK only when they are a fixed, always-together sequence with no judgment (e.g. source env then start Sidekiq).
-- Show the exact command in a fenced `bash` block. Prefer copy-pasteable paths; use `/path/to/ucrate` when the real path varies.
+- Multi-line / chained commands are OK only when they are a fixed, always-together sequence with no judgment (e.g. start Sidekiq with fixed flags).
+- Show the exact command in a fenced code block with **no language tag** (opening line is exactly ` ``` ` with nothing after it). Do **not** use `bash`, `sh`, or `text` — language tags turn on syntax highlighting, and `$VAR` / `$(…)` often become nearly invisible in Cursor/VS Code preview. A bare fence keeps copy-paste commands readable.
+- Prefer copy-pasteable commands; avoid fake paths like `/path/to/ucrate` inside paste blocks when the reader should already be in the clone.
 
 ## Preview readability (critical)
 

--- a/.env.local.mac.example
+++ b/.env.local.mac.example
@@ -5,15 +5,18 @@
 #
 # Setup (once per machine):
 #   cp .env.local.mac.example .env.local.mac
-#   # edit DB_USER later (see docs/local/dependencies/02-postgresql.md)
+#   # edit DB_USER later (see docs/local/dependencies/postgresql.md)
 #
-# Usage (each terminal that runs Rails/Sidekiq/setup):
-#   set -a && source .env.local.mac && set +a
+# Usage: direnv loads this file in the clone (docs/local/dependencies/direnv.md).
 #
 # .env.local.mac is gitignored — keep local edits there.
 # This .example file is committed for teammates.
 #
 # Do NOT source the committed .env for local runs (Docker hostnames).
+#
+# HYKU_CACHE_ROOT must be an absolute path (see docs/local/environment.md).
+# From the clone root run: echo "$PWD"/tmp/hyku_file_cache
+# Then open this file and paste that path into HYKU_CACHE_ROOT below.
 
 # Simple single-tenant local run (http://localhost:3000)
 export HYKU_MULTITENANT=false
@@ -38,8 +41,9 @@ export SOLR_URL=http://127.0.0.1:8983/solr/
 # Leave FCREPO_HOST unset (fedora.yml already defaults to localhost:8984)
 
 # Hyku defaults file cache to Docker path /app/samvera/file_cache (fails on macOS).
-# Source this file from the repo root so $PWD is the project directory.
-export HYKU_CACHE_ROOT="$PWD/tmp/hyku_file_cache"
+# From the clone root run: echo "$PWD"/tmp/hyku_file_cache
+# Then paste that printed path between the quotes below (do not leave $PWD in the saved value).
+export HYKU_CACHE_ROOT="/REPLACE/WITH/ABSOLUTE/PATH/TO/ucrate/tmp/hyku_file_cache"
 
 # Jobs: use Sidekiq for local no-Docker setup (required)
 export HYRAX_ACTIVE_JOB_QUEUE=sidekiq

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+# Load personal local env when you enter this directory (direnv).
+# Setup: docs/local/dependencies/direnv.md
+source_env_if_exists .env.local.mac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
     name: UC customizations
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -99,7 +99,7 @@ jobs:
     name: RuboCop
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -121,7 +121,7 @@ jobs:
     name: Brakeman and bundler-audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -153,7 +153,7 @@ jobs:
       CI_NODE_INDEX: ${{ matrix.ci_node_index }}
       CI_NODE_TOTAL: "6"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Restore on every shard (must download tarballs). Do not use lookup-only:
       # that reports cache-hit without restoring files, so shards 1–5 tried to
@@ -382,7 +382,7 @@ jobs:
       contents: write
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref || github.ref }}
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,25 @@ env:
   DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
 
 jobs:
+  uc_customizations:
+    name: UC customizations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check UC customizations inventory
+        env:
+          UC_CUSTOMIZATIONS_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          UC_CUSTOMIZATIONS_HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            export UC_CUSTOMIZATIONS_ENFORCE_PR=1
+            export UC_CUSTOMIZATIONS_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          fi
+          ruby scripts/ci/check_uc_customizations.rb
+
   lint:
     name: RuboCop
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           bundler-cache: true
 
       - name: Cache RuboCop
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: tmp/rubocop_cache
           key: rubocop-${{ runner.os }}-${{ hashFiles('Gemfile.lock', '.rubocop.yml', '.rubocop_todo.yml', '.rubocop_todo.hyrax.yml') }}
@@ -129,7 +129,7 @@ jobs:
           bundler-cache: true
 
       - name: Cache ruby-advisory-db
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/ruby-advisory-db
           key: ruby-advisory-db-${{ runner.os }}-${{ github.run_id }}
@@ -160,7 +160,7 @@ jobs:
       # docker load an empty directory while shard 0 (writer) actually restored.
       - name: Restore CI Docker image cache
         id: cache-docker
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/ci-docker-images
           key: ci-docker-v5-${{ runner.os }}-${{ hashFiles('docker-compose.ci.yml') }}
@@ -188,7 +188,7 @@ jobs:
           ruby-version: "3.3.6"
           bundler-cache: true
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: yarn
@@ -238,7 +238,7 @@ jobs:
 
       - name: Save CI Docker image cache
         if: steps.pack-docker.outcome == 'success' && matrix.ci_node_index == 0
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: /tmp/ci-docker-images
           key: ci-docker-v5-${{ runner.os }}-${{ hashFiles('docker-compose.ci.yml') }}

--- a/app/services/uc/sample_seed_service.rb
+++ b/app/services/uc/sample_seed_service.rb
@@ -11,13 +11,15 @@
 #
 module Uc
   class SampleSeedService # rubocop:disable Metrics/ClassLength
-    # Written only after a full successful run. Presence = safe no-op on re-run.
+    # Written only after a full successful run. Fixed Fedora id so presence
+    # does not depend on Solr indexing (avoids duplicate seeds after a crash).
     COMPLETION_MARKER = 'uc-seed-v1-complete'
+    COMPLETION_WORK_ID = 'uc-seed-v1-complete-marker'
     SEED_ID_PREFIX = 'uc-seed-'
     PUBLIC = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     RIGHTS = ['http://rightsstatements.org/vocab/InC/1.0/'].freeze
 
-    Result = Struct.new(:status, :password, :created_count, keyword_init: true)
+    Result = Struct.new(:status, :password_source, :created_count, keyword_init: true)
 
     def self.call(works_per_user: ENV.fetch('UC_SEED_WORKS_PER_USER', '10').to_i)
       new(works_per_user: works_per_user).call
@@ -25,12 +27,14 @@ module Uc
 
     def initialize(works_per_user:)
       @works_per_user = works_per_user
-      @password = Devise.friendly_token.first(8)
+      @password = ENV['INITIAL_ADMIN_PASSWORD'].presence
       @created = []
       @logger = Logger.new($stdout)
     end
 
     def call
+      refuse_non_development_environments!
+
       switch_to_single_tenant!
 
       if already_seeded? && !force?
@@ -38,12 +42,14 @@ module Uc
         return Result.new(status: :skipped)
       end
 
+      require_initial_admin_password!
+
       setup_active_fedora_mode!
       begin
         remove_uc_seed_objects! if force? || uc_seed_solr_docs.any?
 
         @logger.info('Creating UC sample seeds (adapted from develop onto Hyku OOB models)...')
-        @logger.info("Password for UC sample accounts: #{@password}")
+        @logger.info('Sample account password: INITIAL_ADMIN_PASSWORD from your env (same as Hyku db:seed admin).')
 
         users = create_users
         @admin_set = find_or_create_active_fedora_admin_set!(users[:admin])
@@ -53,13 +59,25 @@ module Uc
 
         index_created!
         @logger.info("Indexed #{@created.size} UC sample objects.")
-        Result.new(status: :created, password: @password, created_count: @created.size)
+        Result.new(status: :created, password_source: :initial_admin_password, created_count: @created.size)
       ensure
         restore_active_fedora_mode!
       end
     end
 
     private
+
+    def refuse_non_development_environments!
+      return unless Rails.env.production? || Rails.env.staging? # rubocop:disable Rails/UnknownEnv
+
+      raise 'UC sample seeds must not run in production or staging.'
+    end
+
+    def require_initial_admin_password!
+      return if @password.present?
+
+      raise 'INITIAL_ADMIN_PASSWORD is not set. Add it to .env.local.mac (same value as for db:setup), then re-run.'
+    end
 
     def force?
       ActiveModel::Type::Boolean.new.cast(ENV.fetch('UC_SEED_FORCE', 'false'))
@@ -74,26 +92,93 @@ module Uc
     end
 
     # Hyku's default admin set is often AdminSetResource (Valkyrie). AF works need
-    # an ActiveFedora::AdminSet — same approach as Sample::ActiveFedoraService.
+    # an ActiveFedora::AdminSet with Sipity workflows — same approach as
+    # Sample::ActiveFedoraService.
     def find_or_create_active_fedora_admin_set!(user)
+      @workflow_user = user
       admin_set = AdminSet.where(id: AdminSet::DEFAULT_ID).first
-      return admin_set if admin_set.present?
-
-      admin_set = AdminSet.new(id: AdminSet::DEFAULT_ID, title: ['UC Sample Admin Set'])
-      admin_set.creator = [user.user_key]
-      raise "Failed to save ActiveFedora AdminSet: #{admin_set.errors.full_messages}" unless admin_set.save
-
-      ActiveRecord::Base.transaction do
-        permission_template = Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set.id)
-        permission_template.access_grants.find_or_create_by!(
-          agent_type: 'user',
-          agent_id: user.user_key,
-          access: Hyrax::PermissionTemplateAccess::MANAGE
-        )
-        permission_template.reset_access_controls_for(collection: admin_set, interpret_visibility: true)
+      unless admin_set
+        admin_set = AdminSet.new(id: AdminSet::DEFAULT_ID, title: ['UC Sample Admin Set'])
+        admin_set.creator = [user.user_key]
+        raise "Failed to save ActiveFedora AdminSet: #{admin_set.errors.full_messages}" unless admin_set.save
       end
 
+      ensure_admin_set_workflows!(admin_set)
       admin_set
+    end
+
+    def ensure_admin_set_workflows!(admin_set)
+      ActiveRecord::Base.transaction do
+        permission_template = create_or_update_permission_template!(admin_set)
+        workflow = create_workflows_for(permission_template: permission_template)
+        create_default_deposit_access!(permission_template: permission_template, workflow: workflow)
+      end
+    end
+
+    def create_or_update_permission_template!(admin_set)
+      permission_template = Hyrax::PermissionTemplate.find_or_initialize_by(source_id: admin_set.id)
+      if permission_template.new_record?
+        permission_template.access_grants_attributes = admin_set_access_grants_attributes
+        permission_template.save!
+      else
+        ensure_manage_grants!(permission_template)
+      end
+      permission_template.reset_access_controls_for(collection: admin_set, interpret_visibility: true)
+      permission_template
+    end
+
+    def admin_set_access_grants_attributes
+      [
+        { agent_type: 'group', agent_id: Ability.admin_group_name, access: Hyrax::PermissionTemplateAccess::MANAGE }
+      ].tap do |grants|
+        grants << {
+          agent_type: 'user',
+          agent_id: @workflow_user.user_key,
+          access: Hyrax::PermissionTemplateAccess::MANAGE
+        }
+      end
+    end
+
+    def ensure_manage_grants!(permission_template)
+      admin_set_access_grants_attributes.each do |attrs|
+        permission_template.access_grants.find_or_create_by!(
+          agent_type: attrs[:agent_type],
+          agent_id: attrs[:agent_id],
+          access: attrs[:access]
+        )
+      end
+    end
+
+    def create_workflows_for(permission_template:)
+      Hyrax::Workflow::WorkflowImporter.load_workflow_for(permission_template: permission_template)
+      grant_all_workflow_roles!(permission_template: permission_template)
+      Sipity::Workflow.activate!(
+        permission_template: permission_template,
+        workflow_name: Hyrax.config.default_active_workflow_name
+      )
+    end
+
+    def grant_all_workflow_roles!(permission_template:)
+      Sipity::Role[Hyrax::RoleRegistry::MANAGING]
+      permission_template.available_workflows.each do |workflow|
+        Sipity::Role.find_each do |role|
+          workflow.update_responsibilities(role: role, agents: workflow_agents)
+        end
+      end
+    end
+
+    def workflow_agents
+      [Hyrax::Group.new(Ability.admin_group_name), @workflow_user].compact
+    end
+
+    def create_default_deposit_access!(permission_template:, workflow:)
+      permission_template.access_grants.find_or_create_by!(
+        agent_type: 'group',
+        agent_id: Ability.registered_group_name,
+        access: Hyrax::PermissionTemplateAccess::DEPOSIT
+      )
+      deposit = Sipity::Role[Hyrax::RoleRegistry::DEPOSITING]
+      workflow.update_responsibilities(role: deposit, agents: Hyrax::Group.new('registered'))
     end
 
     def setup_active_fedora_mode!
@@ -107,16 +192,16 @@ module Uc
     end
 
     def already_seeded?
-      solr_id_exists?(COMPLETION_MARKER)
-    end
+      # Prefer Fedora existence (stable); Solr is only a fallback for older runs.
+      return true if ActiveFedora::Base.exists?(COMPLETION_WORK_ID)
 
-    def solr_id_exists?(bulkrax_id)
-      GenericWork.where(bulkrax_identifier_tesim: bulkrax_id).any?
+      GenericWork.where(bulkrax_identifier_tesim: COMPLETION_MARKER).any?
     end
 
     # Wipe prior UC seed objects (failed run leftovers, or UC_SEED_FORCE=true).
     # Solr text fields don't reliably match uc-seed-* wildcards, so filter in Ruby.
     def remove_uc_seed_objects!
+      destroy_completion_marker_in_fedora!
       docs = uc_seed_solr_docs
       return if docs.blank?
 
@@ -129,6 +214,14 @@ module Uc
       rescue StandardError => e
         @logger.warn("Could not destroy #{doc['id']}: #{e.message}")
       end
+    end
+
+    def destroy_completion_marker_in_fedora!
+      return unless ActiveFedora::Base.exists?(COMPLETION_WORK_ID)
+
+      GenericWork.find(COMPLETION_WORK_ID).destroy
+    rescue StandardError => e
+      @logger.warn("Could not destroy completion marker #{COMPLETION_WORK_ID}: #{e.message}")
     end
 
     def uc_seed_solr_docs
@@ -146,6 +239,7 @@ module Uc
     def write_completion_marker!(user)
       work = save_work!(
         GenericWork.new(
+          id: COMPLETION_WORK_ID,
           title: ['UC seed completion marker'],
           description: ['Internal marker — UC sample seed completed successfully.'],
           creator: [user.display_name.presence || user.email],
@@ -157,6 +251,7 @@ module Uc
         ),
         user
       )
+      work.update_index
       @created << work
     end
 

--- a/app/services/uc/sample_seed_service.rb
+++ b/app/services/uc/sample_seed_service.rb
@@ -1,0 +1,422 @@
+# frozen_string_literal: true
+
+# Adapts Scholar@UC develop db/seeds.rb sample users/works onto Hyku OOB models.
+# Removable UC-local path — does not replace stock Hyku db/seeds.rb.
+#
+# Mapping onto models Hyku already ships (no UC custom work types):
+#   develop Article / Document / Dataset / Medium / StudentWork / GenericWork → GenericWork
+#     (develop-only fields recorded in description; resource_type notes the develop type)
+#   Image → Image; Etd → Etd
+#   User first_name/last_name/ucdepartment → display_name / department
+#
+module Uc
+  class SampleSeedService # rubocop:disable Metrics/ClassLength
+    # Written only after a full successful run. Presence = safe no-op on re-run.
+    COMPLETION_MARKER = 'uc-seed-v1-complete'
+    SEED_ID_PREFIX = 'uc-seed-'
+    PUBLIC = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    RIGHTS = ['http://rightsstatements.org/vocab/InC/1.0/'].freeze
+
+    Result = Struct.new(:status, :password, :created_count, keyword_init: true)
+
+    def self.call(works_per_user: ENV.fetch('UC_SEED_WORKS_PER_USER', '10').to_i)
+      new(works_per_user: works_per_user).call
+    end
+
+    def initialize(works_per_user:)
+      @works_per_user = works_per_user
+      @password = Devise.friendly_token.first(8)
+      @created = []
+      @logger = Logger.new($stdout)
+    end
+
+    def call
+      switch_to_single_tenant!
+
+      if already_seeded? && !force?
+        @logger.info('UC sample seeds already complete; skipping work creation.')
+        return Result.new(status: :skipped)
+      end
+
+      setup_active_fedora_mode!
+      begin
+        remove_uc_seed_objects! if force? || uc_seed_solr_docs.any?
+
+        @logger.info('Creating UC sample seeds (adapted from develop onto Hyku OOB models)...')
+        @logger.info("Password for UC sample accounts: #{@password}")
+
+        users = create_users
+        @admin_set = find_or_create_active_fedora_admin_set!(users[:admin])
+        create_bulk_generic_works(users[:depositors])
+        create_complete_works_collection(users[:many_deposits])
+        write_completion_marker!(users[:many_deposits])
+
+        index_created!
+        @logger.info("Indexed #{@created.size} UC sample objects.")
+        Result.new(status: :created, password: @password, created_count: @created.size)
+      ensure
+        restore_active_fedora_mode!
+      end
+    end
+
+    private
+
+    def force?
+      ActiveModel::Type::Boolean.new.cast(ENV.fetch('UC_SEED_FORCE', 'false'))
+    end
+
+    def switch_to_single_tenant!
+      cname = ENV.fetch('HYKU_SINGLE_TENANT_CNAME', 'single.tenant.default')
+      account = Account.find_by(cname: cname)
+      raise "Single-tenant account not found (cname=#{cname}). Run rails db:seed first." if account.blank?
+
+      AccountElevator.switch!(account.cname)
+    end
+
+    # Hyku's default admin set is often AdminSetResource (Valkyrie). AF works need
+    # an ActiveFedora::AdminSet — same approach as Sample::ActiveFedoraService.
+    def find_or_create_active_fedora_admin_set!(user)
+      admin_set = AdminSet.where(id: AdminSet::DEFAULT_ID).first
+      return admin_set if admin_set.present?
+
+      admin_set = AdminSet.new(id: AdminSet::DEFAULT_ID, title: ['UC Sample Admin Set'])
+      admin_set.creator = [user.user_key]
+      raise "Failed to save ActiveFedora AdminSet: #{admin_set.errors.full_messages}" unless admin_set.save
+
+      ActiveRecord::Base.transaction do
+        permission_template = Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set.id)
+        permission_template.access_grants.find_or_create_by!(
+          agent_type: 'user',
+          agent_id: user.user_key,
+          access: Hyrax::PermissionTemplateAccess::MANAGE
+        )
+        permission_template.reset_access_controls_for(collection: admin_set, interpret_visibility: true)
+      end
+
+      admin_set
+    end
+
+    def setup_active_fedora_mode!
+      @original_use_valkyrie = Hyrax.config.use_valkyrie?
+      ENV['HYRAX_VALKYRIE'] = 'false'
+      Hyrax.config.use_valkyrie = false
+    end
+
+    def restore_active_fedora_mode!
+      Hyrax.config.use_valkyrie = @original_use_valkyrie unless @original_use_valkyrie.nil?
+    end
+
+    def already_seeded?
+      solr_id_exists?(COMPLETION_MARKER)
+    end
+
+    def solr_id_exists?(bulkrax_id)
+      GenericWork.where(bulkrax_identifier_tesim: bulkrax_id).any?
+    end
+
+    # Wipe prior UC seed objects (failed run leftovers, or UC_SEED_FORCE=true).
+    # Solr text fields don't reliably match uc-seed-* wildcards, so filter in Ruby.
+    def remove_uc_seed_objects!
+      docs = uc_seed_solr_docs
+      return if docs.blank?
+
+      @logger.info("Removing #{docs.size} prior UC seed object(s)...")
+      docs.each do |doc|
+        model = Array(doc['has_model_ssim']).first
+        next if model.blank?
+
+        model.constantize.find(doc['id']).destroy
+      rescue StandardError => e
+        @logger.warn("Could not destroy #{doc['id']}: #{e.message}")
+      end
+    end
+
+    def uc_seed_solr_docs
+      %w[GenericWork Image Etd Collection].flat_map do |model|
+        Hyrax::SolrService.query(
+          "has_model_ssim:#{model}",
+          rows: 10_000,
+          fl: 'id,has_model_ssim,bulkrax_identifier_tesim'
+        ).select do |doc|
+          Array(doc['bulkrax_identifier_tesim']).any? { |value| value.start_with?(SEED_ID_PREFIX) }
+        end
+      end
+    end
+
+    def write_completion_marker!(user)
+      work = save_work!(
+        GenericWork.new(
+          title: ['UC seed completion marker'],
+          description: ['Internal marker — UC sample seed completed successfully.'],
+          creator: [user.display_name.presence || user.email],
+          rights_statement: RIGHTS,
+          bulkrax_identifier: COMPLETION_MARKER,
+          visibility: PUBLIC,
+          admin_set: @admin_set,
+          resource_type: ['Generic Work']
+        ),
+        user
+      )
+      @created << work
+    end
+
+    def create_users
+      many = upsert_user(
+        email: 'manydeposits@example.com',
+        display_name: 'Many Deposits',
+        department: 'CCM Music'
+      )
+      no_deposits = upsert_user(
+        email: 'nodeposits@example.com',
+        display_name: 'No Deposits',
+        department: 'UCL Research'
+      )
+      delegate = upsert_user(
+        email: 'delegate@example.com',
+        display_name: 'Student Delegate',
+        department: 'CEAS Computer Science'
+      )
+      admin = upsert_user(
+        email: 'admin@example.com',
+        display_name: 'Admin User',
+        department: nil,
+        admin: true
+      )
+
+      { many_deposits: many, no_deposits: no_deposits, delegate: delegate, admin: admin,
+        depositors: [many, delegate, admin] }
+    end
+
+    def upsert_user(email:, display_name:, department:, admin: false)
+      user = User.find_or_initialize_by(email: email)
+      user.password = @password
+      user.password_confirmation = @password
+      user.display_name = display_name
+      user.department = department if department
+      user.save!
+      grant_admin!(user) if admin
+      @logger.info("Account ready: #{email}")
+      user
+    end
+
+    def grant_admin!(user)
+      user.add_role(:admin) unless user.has_role?(:admin)
+      return if user.has_role?(:admin, Site.instance)
+
+      user.add_role(:admin, Site.instance)
+    end
+
+    def create_bulk_generic_works(users)
+      users.each do |user|
+        @works_per_user.times do |i|
+          work = save_work!(
+            GenericWork.new(
+              title: ['This is the title'],
+              description: ['This is the description'],
+              creator: [user.display_name.presence || user.email],
+              subject: %w[geography history chemistry],
+              rights_statement: RIGHTS,
+              publisher: ['Penguin Publishing'],
+              language: ['English'],
+              date_created: [Time.zone.at(rand * Time.now.to_i).to_date.to_s],
+              bulkrax_identifier: "uc-seed-bulk-#{user.id}-#{i}",
+              visibility: PUBLIC,
+              admin_set: @admin_set,
+              resource_type: ['Generic Work']
+            ),
+            user
+          )
+          @created << work
+        end
+        @logger.info("#{@works_per_user} Generic Works created for #{user.email}")
+      end
+    end
+
+    def create_complete_works_collection(user)
+      collection_type = Hyrax::CollectionType.find_or_create_default_collection_type
+      collection = Collection.new(
+        title: ['Complete Works'],
+        description: ['This is a collection of works with all their metadata filled in.'],
+        creator: [user.display_name],
+        visibility: PUBLIC,
+        collection_type_gid: collection_type.to_global_id.to_s,
+        bulkrax_identifier: 'uc-seed-complete-collection'
+      )
+      collection.apply_depositor_metadata(user.user_key)
+      collection.save!
+      Sample::PermissionTemplateService.create_for_collection(collection, user)
+      @created << collection
+
+      members = complete_member_works(user)
+      members.each do |work|
+        work.member_of_collections << collection
+        work.save!
+      end
+      collection.update_index
+      @logger.info("Complete Works collection created for #{user.email} (#{members.size} members)")
+    end
+
+    def complete_member_works(user)
+      [
+        complete_generic_work(user),
+        complete_as_generic_work(user, type: 'Article', title: 'Article Title',
+                                       extras: { journal_title: 'Article Journal', issn: '0001' }),
+        complete_as_generic_work(user, type: 'Document', title: 'Document Title',
+                                       extras: { genre: 'Document Genre' }),
+        complete_as_generic_work(user, type: 'Dataset', title: 'Dataset Title'),
+        complete_image(user),
+        complete_as_generic_work(user, type: 'Medium', title: 'Medium Title'),
+        complete_etd(user),
+        complete_as_generic_work(
+          user,
+          type: 'Student Work',
+          title: 'Student Work Title',
+          extras: { advisor: 'Student Work Advisor', degree: 'Student Work Degree' }
+        )
+      ]
+    end
+
+    def complete_generic_work(user)
+      save_work!(
+        GenericWork.new(
+          title: ['Generic Work Title'],
+          creator: ['Generic Work Creator', 'Secondary Generic Work Creator'],
+          description: [fold_uc_metadata(
+            'This is the description of a Generic Work',
+            college: 'Generic Work College',
+            department: 'Generic Work Department',
+            alternate_title: 'Generic Work Alternate Title',
+            geo_subject: 'Generic Work Geo Subject',
+            time_period: 'Generic Work Time Period',
+            required_software: 'Generic Work Required Software',
+            note: 'Generic Work Note'
+          )],
+          publisher: ['Generic Work Publisher', 'Secondary Generic Work Publisher'],
+          date_created: ['2001-01-01'],
+          subject: ['Generic Work Subject', 'Secondary Generic Work Subject'],
+          language: ['Generic Work Language', 'Secondary Generic Work Language'],
+          related_url: ['http://example.com/generic_work', 'http://example.com/secondary_generic_work'],
+          rights_statement: RIGHTS,
+          bulkrax_identifier: 'uc-seed-complete-generic',
+          visibility: PUBLIC,
+          admin_set: @admin_set,
+          resource_type: ['Generic Work']
+        ),
+        user
+      ).tap { |w| @created << w }
+    end
+
+    def complete_as_generic_work(user, type:, title:, extras: {})
+      desc_fields = {
+        college: "#{type} College",
+        department: "#{type} Department",
+        alternate_title: "#{type} Alternate Title",
+        geo_subject: "#{type} Geo Subject",
+        time_period: "#{type} Time Period",
+        required_software: "#{type} Required Software",
+        note: "#{type} Note"
+      }.merge(extras)
+
+      save_work!(
+        GenericWork.new(
+          title: [title],
+          creator: ["#{type} Creator", "Secondary #{type} Creator"],
+          description: [fold_uc_metadata("This is the description of a #{type}", **desc_fields)],
+          publisher: ["#{type} Publisher", "Secondary #{type} Publisher"],
+          date_created: ['2001-01-01'],
+          subject: ["#{type} Subject", "Secondary #{type} Subject"],
+          language: ["#{type} Language", "Secondary #{type} Language"],
+          related_url: ["http://example.com/#{type.parameterize}", "http://example.com/secondary_#{type.parameterize}"],
+          rights_statement: RIGHTS,
+          bulkrax_identifier: "uc-seed-complete-#{type.parameterize}",
+          visibility: PUBLIC,
+          admin_set: @admin_set,
+          resource_type: [type]
+        ),
+        user
+      ).tap { |w| @created << w }
+    end
+
+    def complete_image(user)
+      save_work!(
+        Image.new(
+          title: ['Image Title'],
+          creator: ['Image Work Creator', 'Secondary Image Work Creator'],
+          description: [fold_uc_metadata(
+            'This is the description of an Image',
+            college: 'Image College',
+            department: 'Image Department',
+            genre: 'Image Genre',
+            alternate_title: 'Image Alternate Title',
+            geo_subject: 'Image Geo Subject',
+            time_period: 'Image Work Time Period',
+            required_software: 'Image Work Required Software',
+            note: 'Image Work Note'
+          )],
+          publisher: ['Image Publisher', 'Secondary Image Publisher'],
+          date_created: ['2001-01-01'],
+          subject: ['Image Subject', 'Secondary Image Subject'],
+          language: ['Image Work Language', 'Secondary Image Work Language'],
+          related_url: ['http://example.com/image', 'http://example.com/secondary_image'],
+          rights_statement: RIGHTS,
+          bulkrax_identifier: 'uc-seed-complete-image',
+          visibility: PUBLIC,
+          admin_set: @admin_set,
+          resource_type: ['Image']
+        ),
+        user
+      ).tap { |w| @created << w }
+    end
+
+    def complete_etd(user)
+      save_work!(
+        Etd.new(
+          title: ['Etd Work Title'],
+          creator: ['Etd Creator', 'Secondary Etd Creator'],
+          description: [fold_uc_metadata(
+            'This is the description of an Etd work.',
+            college: 'Etd Work College',
+            alternate_title: 'Etd Alternate Title',
+            genre: 'Etd Genre',
+            geo_subject: 'Etd Work Geo Subject',
+            time_period: 'Etd Work Time Period',
+            required_software: 'Etd Work Required Software',
+            note: 'etd Work Note',
+            etd_publisher: 'Generic Work Publisher'
+          )],
+          advisor: ['Etd Advisor', 'Secondary Etd Advisor'],
+          committee_member: ['Committee Member', 'Secondary Committee Member'],
+          degree_name: ['Etd Degree'],
+          department: ['Etd Department'],
+          date_created: ['2001-01-01'],
+          subject: ['Etd Subject', 'Secondary Etd Subject'],
+          language: ['Etd Work Language', 'Secondary Etd Work Language'],
+          related_url: ['http://example.com/etd', 'http://example.com/secondary_etd'],
+          rights_statement: RIGHTS,
+          bulkrax_identifier: 'uc-seed-complete-etd',
+          visibility: PUBLIC,
+          admin_set: @admin_set,
+          resource_type: ['Masters Thesis']
+        ),
+        user
+      ).tap { |w| @created << w }
+    end
+
+    def fold_uc_metadata(base, **fields)
+      extras = fields.compact.map { |k, v| "#{k}: #{v}" }.join(' | ')
+      extras.empty? ? base : "#{base} [UC seed fields: #{extras}]"
+    end
+
+    def save_work!(work, user)
+      work.apply_depositor_metadata(user.user_key)
+      work.edit_users += [user.email] unless work.edit_users.include?(user.email)
+      work.save!
+      work
+    end
+
+    def index_created!
+      @logger.info('Indexing UC sample objects in Solr...')
+      @created.each(&:update_index)
+    end
+  end
+end

--- a/docs/local/README.md
+++ b/docs/local/README.md
@@ -101,6 +101,7 @@ Follow these steps in order:
 	This is where one-time database seeding happens for this branch.
 	It creates the admin user from `.env.local.mac` and site defaults (admin set, workflows, enabled work types).
 	It does **not** deposit sample works — an empty catalog after seed is normal.
+	Optional UC samples (adapted from `develop`): see `uc:seed:samples` on [run-the-app.md](./run-the-app.md).
 	Before `db:setup` / `db:seed`, wait until Solr has finished downloading and is listening (see that page).
 	Your env must set `SOLR_HOST=localhost` and `HYKU_CACHE_ROOT` under the repo (see [environment.md](./environment.md)).
 	That page also covers starting or restarting Rails if it is not up yet.

--- a/docs/local/README.md
+++ b/docs/local/README.md
@@ -8,7 +8,7 @@ This team workflow is **manual services**, not Docker. Start each service yourse
 
 1. **These docs (`docs/local/`)** are our Scholar@UC source of truth for running this branch on a Mac without Docker. Follow [docs/local/README.md](./README.md) (this page) in order. Upstream Hyku’s root [README.md](../../README.md) is for Hyku generally and may change on merges — do not treat it as our local setup guide.
 
-2. **Local environment file:** copy the committed template `.env.local.mac.example` to a personal `.env.local.mac` (gitignored). Full steps: [environment.md](./environment.md). [Open the template file](../../.env.local.mac.example).  
+2. **Local environment file:** copy the committed template `.env.local.mac.example` to a personal `.env.local.mac` (gitignored), then use [direnv](./dependencies/direnv.md) so it loads in this clone only. Full steps: [environment.md](./environment.md). [Open the template file](../../.env.local.mac.example).  
    Do **not** source the repo’s Docker `.env` for local no-Docker runs.
 
 If you have already set up this branch before and just need to run services, go to [start-services.md](./start-services.md).
@@ -26,11 +26,10 @@ If you need to start test services specifically, go to [start-test-services.md](
 
 Follow these steps in order:
 
-1. Confirm branch and workspace:
+1. Confirm branch:
 
 	```bash
 	git branch --show-current
-	pwd
 	```
 
 	Expected branch: `hyku-oob`
@@ -52,49 +51,55 @@ Follow these steps in order:
 
 	[environment.md](./environment.md)
 
-4. Dependency 1: Homebrew
+4. Dependency: Homebrew
 
-	[dependencies/01-homebrew.md](./dependencies/01-homebrew.md)
+	[dependencies/homebrew.md](./dependencies/homebrew.md)
 
-5. Dependency 2: PostgreSQL
+5. Dependency: direnv
 
-	[dependencies/02-postgresql.md](./dependencies/02-postgresql.md)
+	[dependencies/direnv.md](./dependencies/direnv.md)
 
-6. Dependency 3: Ruby + rbenv
+	Required. Loads `.env.local.mac` when you enter this clone and unloads it when you leave.
 
-	[dependencies/03-ruby-rbenv.md](./dependencies/03-ruby-rbenv.md)
+6. Dependency: PostgreSQL
 
-7. Dependency 4: Bundler
+	[dependencies/postgresql.md](./dependencies/postgresql.md)
 
-	[dependencies/04-bundler.md](./dependencies/04-bundler.md)
+7. Dependency: Ruby + rbenv
 
-8. Dependency 5: Rails (project-managed)
+	[dependencies/ruby-rbenv.md](./dependencies/ruby-rbenv.md)
 
-	[dependencies/05-rails.md](./dependencies/05-rails.md)
+8. Dependency: Bundler
 
-9. Dependency 6: Node + Yarn
+	[dependencies/bundler.md](./dependencies/bundler.md)
 
-	[dependencies/06-node-yarn.md](./dependencies/06-node-yarn.md)
+9. Dependency: Rails (project-managed)
 
-10. Dependency 7: Redis
+	[dependencies/rails.md](./dependencies/rails.md)
 
-	[dependencies/07-redis.md](./dependencies/07-redis.md)
+10. Dependency: Node + Yarn
 
-11. Dependency 8: Java 8
+	[dependencies/node-yarn.md](./dependencies/node-yarn.md)
 
-	[dependencies/08-java-8.md](./dependencies/08-java-8.md)
+11. Dependency: Redis
 
-12. Dependency 9: ImageMagick + LibreOffice
+	[dependencies/redis.md](./dependencies/redis.md)
 
-	[dependencies/09-imagemagick-libreoffice.md](./dependencies/09-imagemagick-libreoffice.md)
+12. Dependency: Java 8
 
-13. Start runtime dependencies:
+	[dependencies/java-8.md](./dependencies/java-8.md)
+
+13. Dependency: ImageMagick + LibreOffice
+
+	[dependencies/imagemagick-libreoffice.md](./dependencies/imagemagick-libreoffice.md)
+
+14. Start runtime dependencies:
 
 	[start-services.md](./start-services.md)
 
 	[start-test-services.md](./start-test-services.md)
 
-14. Run the app and one-time database setup/seeding:
+15. Run the app and one-time database setup/seeding:
 
 	[run-the-app.md](./run-the-app.md)
 
@@ -103,10 +108,10 @@ Follow these steps in order:
 	It does **not** deposit sample works — an empty catalog after seed is normal.
 	Optional UC samples (adapted from `develop`): see `uc:seed:samples` on [run-the-app.md](./run-the-app.md).
 	Before `db:setup` / `db:seed`, wait until Solr has finished downloading and is listening (see that page).
-	Your env must set `SOLR_HOST=localhost` and `HYKU_CACHE_ROOT` under the repo (see [environment.md](./environment.md)).
-	That page also covers starting or restarting Rails if it is not up yet.
+	Your env must set `SOLR_HOST=localhost` and an absolute `HYKU_CACHE_ROOT` under the clone (see [environment.md](./environment.md)).
+	That page also covers first sign-in after seeding.
 
-15. Run tests only when needed:
+16. Run tests only when needed:
 
 	[run-tests.md](./run-tests.md)
 
@@ -116,12 +121,14 @@ Follow these steps in order:
 |-----|----------|
 | [dependencies/](./dependencies) | One-dependency-at-a-time setup path for juniors |
 | [versions-and-ports.md](./versions-and-ports.md) | Version targets and dev/test ports |
-| [environment.md](./environment.md) | `.env.local.mac` setup (`HYKU_ROOT_HOST`, Sidekiq, `SOLR_*`, `HYKU_CACHE_ROOT`; fill `DB_USER` later) |
+| [environment.md](./environment.md) | `.env.local.mac` setup (`HYKU_ROOT_HOST`, Sidekiq, `SOLR_*`, absolute `HYKU_CACHE_ROOT`; fill `DB_USER` later) |
+| [dependencies/direnv.md](./dependencies/direnv.md) | Auto-load `.env.local.mac` in this clone only |
 | [start-services.md](./start-services.md) | Single source for runtime service startup commands |
 | [start-test-services.md](./start-test-services.md) | Startup commands for test runtime services on test ports |
-| [run-the-app.md](./run-the-app.md) | One-time DB setup/seeding, Rails start/restart if needed, first sign-in |
+| [run-the-app.md](./run-the-app.md) | One-time DB setup/seeding and first sign-in |
 | [run-tests.md](./run-tests.md) | Optional local RSpec and `rake ci` |
 | [switching-to-develop.md](./switching-to-develop.md) | Switching back to Scholar@UC `develop` |
 | [troubleshooting.md](./troubleshooting.md) | Common errors and fixes |
 | [updating-from-hyku.md](./updating-from-hyku.md) | Pulling Hyku updates with `git merge` |
+| [uc-hyku-customizations.md](./uc-hyku-customizations.md) | Inventory of UC changes vs Hyku (keep/conflict on merge; CI-enforced) |
 | [github-actions.md](./github-actions.md) | CI behavior on `hyku-oob` |

--- a/docs/local/dependencies/bundler.md
+++ b/docs/local/dependencies/bundler.md
@@ -1,4 +1,4 @@
-# 4) Bundler
+# Bundler
 
 Back to setup index: [docs/local/README.md](../README.md)
 
@@ -6,7 +6,7 @@ This project lockfile is pinned to Bundler 2.6.9.
 
 ## Check
 
-```bash
+```
 bundler -v
 ```
 
@@ -14,7 +14,7 @@ Expected: Bundler 2.6.9 (or install that exact version).
 
 ## If missing or wrong version
 
-```bash
+```
 gem install bundler -v 2.6.9
 bundler -v
 ```
@@ -29,28 +29,27 @@ For this project, only Bundler version needs to match now. Team-wide RubyGems up
 
 ## Install gems
 
-Before installing gems, confirm you are in this repo and on the `hyku-oob` branch.
+Before installing gems, confirm you are in your **ucrate clone root** and on the `hyku-oob` branch.
 
-```bash
-cd /path/to/ucrate
+```
 git branch --show-current
 ```
 
 If branch output is not `hyku-oob`, switch first:
 
-```bash
+```
 git checkout hyku-oob
 ```
 
 Then install gems:
 
-```bash
+```
 bundle install
 ```
 
 If you see a Bundler version mismatch error, retry with:
 
-```bash
+```
 bundle _2.6.9_ install
 ```
 
@@ -58,4 +57,4 @@ Expected: install completes with no dependency errors.
 
 ## Next
 
-Go to [5) Rails](./05-rails.md).
+Go to [Rails](./rails.md).

--- a/docs/local/dependencies/direnv.md
+++ b/docs/local/dependencies/direnv.md
@@ -1,0 +1,68 @@
+# direnv
+
+Back to setup index: [docs/local/README.md](../README.md)
+
+direnv loads `.env.local.mac` when you enter the ucrate clone and unloads it when you leave, so other apps on your machine are not affected. This is how local env is loaded for this branch.
+
+You should already have created `.env.local.mac` ([environment.md](../environment.md)) and have Homebrew ([Homebrew](./homebrew.md)).
+
+## Install
+
+```
+brew install direnv
+```
+
+## Allow this repo (once per clone)
+
+From your **ucrate clone root** (the directory with `Gemfile` and `.envrc`):
+
+```
+direnv allow
+```
+
+This approves the committed `.envrc` for this clone ([open .envrc](../../../.envrc)). That file only loads your personal `.env.local.mac` if it exists; it does not commit secrets.
+
+Do this **before** enabling the zsh hook, so the next step does not print a “blocked” error.
+
+## Hook into zsh (once per Mac)
+
+```
+echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+Expected: something like `direnv: loading …` / `direnv: export …` (exact text varies by version).
+
+If you use bash instead of zsh, see https://direnv.net/docs/hook.html.
+
+## Confirm
+
+Still in the clone root:
+
+```
+env | grep '^HYKU_ROOT_HOST='
+env | grep '^HYKU_CACHE_ROOT='
+```
+
+Expected: `HYKU_ROOT_HOST=localhost` and your absolute `HYKU_CACHE_ROOT` path.
+
+Then leave the directory and check that the vars are gone:
+
+```
+cd ..
+env | grep '^HYKU_ROOT_HOST=' || echo 'HYKU_ROOT_HOST unset (good)'
+cd -
+```
+
+## After you change env files
+
+| You changed… | What to do |
+|--------------|------------|
+| `.env.local.mac` | Hit Enter in a shell that is already in the clone (or open a new terminal there). **Restart** Rails / Sidekiq if they were already running so they pick up the new values. |
+| `.envrc` (rare) | Run `direnv allow` again in the clone root. |
+
+You do **not** need `direnv allow` for normal edits to `.env.local.mac`.
+
+## Next
+
+Go to [PostgreSQL](./postgresql.md).

--- a/docs/local/dependencies/homebrew.md
+++ b/docs/local/dependencies/homebrew.md
@@ -1,4 +1,4 @@
-# 1) Homebrew
+# Homebrew
 
 Back to setup index: [docs/local/README.md](../README.md)
 
@@ -6,7 +6,7 @@ Use this step to make sure package management works on your Mac.
 
 ## Check
 
-```bash
+```
 brew --version
 brew --prefix
 ```
@@ -19,10 +19,10 @@ Install Homebrew from the official script on https://brew.sh.
 
 After install, open a new terminal and run:
 
-```bash
+```
 brew --version
 ```
 
 ## Next
 
-Go to [2) PostgreSQL](./02-postgresql.md).
+Go to [direnv](./direnv.md).

--- a/docs/local/dependencies/imagemagick-libreoffice.md
+++ b/docs/local/dependencies/imagemagick-libreoffice.md
@@ -1,4 +1,4 @@
-# 9) ImageMagick + LibreOffice
+# ImageMagick + LibreOffice
 
 Back to setup index: [docs/local/README.md](../README.md)
 
@@ -8,21 +8,21 @@ These tools are used for derivatives and office document conversion.
 
 Run this command:
 
-```bash
+```
 command -v magick
 ```
 
-If output prints a path, ImageMagick is on PATH.
+If output prints a path, ImageMagick is on PATH — go to **Step 3**.
 
 If output is empty, run this command:
 
-```bash
+```
 command -v convert
 ```
 
-If `convert` prints a path, ImageMagick is installed (older command name).
+If `convert` prints a path, ImageMagick is installed (older command name) — go to **Step 3**.
 
-If both `magick` and `convert` are empty, go to Step 2.
+If both `magick` and `convert` are empty, go to **Step 2**.
 
 ## Step 2: install ImageMagick if needed
 
@@ -30,19 +30,19 @@ These extra formulae support ImageMagick on this branch. LibreOffice does not us
 
 Run this command:
 
-```bash
+```
 brew install imagemagick shared-mime-info
 ```
 
 Then re-check:
 
-```bash
+```
 command -v magick
 ```
 
 If `magick` is still empty, run:
 
-```bash
+```
 command -v convert
 ```
 
@@ -50,13 +50,13 @@ command -v convert
 
 Run this command:
 
-```bash
+```
 command -v soffice
 ```
 
-If output prints a path, LibreOffice is on PATH.
+If output prints a path, LibreOffice is on PATH — you are done with ImageMagick and LibreOffice. Go to **Next**.
 
-If output is empty, go to Step 4.
+If output is empty, go to **Step 4**.
 
 ## Step 4: install LibreOffice if needed
 
@@ -64,15 +64,17 @@ LibreOffice only needs its own package here.
 
 Run this command:
 
-```bash
+```
 brew install libreoffice
 ```
 
 Then re-check:
 
-```bash
+```
 command -v soffice
 ```
+
+If output prints a path, go to **Next**.
 
 If anything is still missing after Step 4, use [docs/local/troubleshooting.md](../troubleshooting.md) before continuing.
 

--- a/docs/local/dependencies/java-8.md
+++ b/docs/local/dependencies/java-8.md
@@ -1,4 +1,4 @@
-# 8) Java 8 (Temurin)
+# Java 8 (Temurin)
 
 Back to setup index: [docs/local/README.md](../README.md)
 
@@ -8,7 +8,7 @@ Fedora 4 wrapper on this stack needs Java 8.
 
 Run this command:
 
-```bash
+```
 /usr/libexec/java_home -v 1.8
 ```
 
@@ -20,13 +20,13 @@ If this prints an error about no matching Java version, go to Step 2.
 
 Run this command:
 
-```bash
+```
 brew install --cask temurin@8
 ```
 
 Then run this command again:
 
-```bash
+```
 /usr/libexec/java_home -v 1.8
 ```
 
@@ -35,4 +35,4 @@ If you still run into Java issues, use [Java 8 quick fix](../troubleshooting.md#
 
 ## Next
 
-Go to [9) ImageMagick + LibreOffice](./09-imagemagick-libreoffice.md).
+Go to [ImageMagick + LibreOffice](./imagemagick-libreoffice.md).

--- a/docs/local/dependencies/node-yarn.md
+++ b/docs/local/dependencies/node-yarn.md
@@ -1,4 +1,4 @@
-# 6) Node + Yarn
+# Node + Yarn
 
 Back to setup index: [docs/local/README.md](../README.md)
 
@@ -6,7 +6,7 @@ Node and Yarn are needed for frontend assets (Universal Viewer setup).
 
 ## Step 1: check Node and Yarn
 
-```bash
+```
 node -v
 yarn -v
 ```
@@ -29,13 +29,13 @@ What to do next:
 
 Check NVM:
 
-```bash
+```
 command -v nvm
 ```
 
 If NVM is missing, install it with Homebrew:
 
-```bash
+```
 brew install nvm
 mkdir -p ~/.nvm
 echo 'export NVM_DIR="$HOME/.nvm"' >> ~/.zshrc
@@ -45,7 +45,7 @@ source ~/.zshrc
 
 Install/use Node 20 LTS:
 
-```bash
+```
 nvm install 20
 nvm use 20
 node -v
@@ -62,19 +62,19 @@ If Yarn is missing or not `1.x`, set Yarn to 1 Classic:
 
 First check Corepack:
 
-```bash
+```
 command -v corepack
 ```
 
 If `corepack` is missing, install it:
 
-```bash
+```
 npm install -g corepack
 ```
 
 Then (whether Corepack was already present or just installed), set Yarn to 1 Classic:
 
-```bash
+```
 corepack prepare yarn@1.22.22 --activate
 yarn -v
 ```
@@ -84,8 +84,9 @@ Expected: `1.22.x`
 
 ## Step 4: install JS dependencies
 
-```bash
-cd /path/to/ucrate
+From your **ucrate clone root**:
+
+```
 yarn install
 ```
 
@@ -101,7 +102,7 @@ What is `public/uv`?
 
 Quick check:
 
-```bash
+```
 ls public/uv
 ```
 
@@ -109,4 +110,4 @@ If `yarn install` fails with errors like `command not found: if`, `command not f
 
 ## Next
 
-Go to [7) Redis](./07-redis.md).
+Go to [Redis](./redis.md).

--- a/docs/local/dependencies/postgresql.md
+++ b/docs/local/dependencies/postgresql.md
@@ -1,4 +1,4 @@
-# 2) PostgreSQL
+# PostgreSQL
 
 Back to setup index: [docs/local/README.md](../README.md)
 
@@ -13,7 +13,7 @@ For local setup on this branch, PostgreSQL **14 or newer** is acceptable.
 
 ### Step 1: check for `psql`
 
-```bash
+```
 which psql
 ```
 
@@ -24,7 +24,7 @@ If output is empty or says `psql not found`: go to **Step 2**.
 
 ### Step 2: check whether Postgres is installed but not on PATH
 
-```bash
+```
 brew list --versions | egrep '^postgresql(@| )' || true
 ```
 
@@ -37,19 +37,19 @@ If this command prints any `postgresql@...` line, Postgres is already installed.
 
 Example permanent PATH entry for `postgresql@16`:
 
-```bash
+```
 echo 'export PATH="$(brew --prefix postgresql@16)/bin:$PATH"' >> ~/.zshrc
 ```
 
 Then run:
 
-```bash
+```
 source ~/.zshrc
 ```
 
 Now re-check:
 
-```bash
+```
 which psql
 psql --version
 ```
@@ -61,23 +61,23 @@ If brew list is empty (nothing printed), Postgres is missing. Install it in **St
 
 #### Step 2A: install Postgres (only if missing)
 
-```bash
+```
 brew install postgresql@16
 ```
 
-```bash
+```
 psql --version
 ```
 
 If `psql --version` says `command not found`, add permanent PATH in `~/.zshrc`:
 
-```bash
+```
 echo 'export PATH="$(brew --prefix postgresql@16)/bin:$PATH"' >> ~/.zshrc
 ```
 
 Then run:
 
-```bash
+```
 source ~/.zshrc
 psql --version
 ```
@@ -87,7 +87,7 @@ Then go to **Step 4**.
 
 ### Step 3: read installed version (informational)
 
-```bash
+```
 psql --version
 ```
 
@@ -101,7 +101,7 @@ Safety note for users upgrading from 12/13:
 - Problems usually come from PATH/service confusion, not from having both versions installed.
 - After installing, verify what is active:
 
-```bash
+```
 which psql
 psql --version
 brew services list | grep -i postgres
@@ -115,38 +115,22 @@ Then go to **Step 4**.
 
 Start the version you actually have installed.
 
-If you installed `postgresql@16`:
-
-```bash
+```
 brew services start postgresql@16
 ```
 
-If you already had an earlier formula, start that one instead (example):
-
-```bash
-brew services start postgresql@15
-```
-
-Or:
-
-```bash
-brew services start postgresql@14
-```
-
-If your formula is just `postgresql`, start it with:
-
-```bash
-brew services start postgresql
-```
+If your formula has a different name (for example `postgresql@15` or plain `postgresql`), start that one instead.
 
 
 ### Step 5: verify Postgres is running
 
-```bash
+```
 pg_isready -h localhost
 ```
 
-Expected: `accepting connections`.
+Expected: `localhost:5432 - accepting connections`.
+
+Ignore any following `direnv: loading …` / `direnv: export …` lines — those come from direnv, not Postgres.
 
 ### Step 6: find the `DB_USER` value (required)
 
@@ -154,7 +138,7 @@ Who should do this: everyone setting up local env on this branch.
 
 Run this command:
 
-```bash
+```
 psql -d postgres -c 'SELECT current_user;'
 ```
 
@@ -167,7 +151,7 @@ Then choose the matching case:
 
 Fallback command (force the DB login user to `postgres`):
 
-```bash
+```
 psql -U postgres -d postgres -c 'SELECT current_user;'
 ```
 
@@ -179,7 +163,7 @@ If both commands fail, stop here and use [docs/local/troubleshooting.md](../trou
 
 Open `.env.local.mac` and set:
 
-```bash
+```
 DB_USER=<value from SELECT current_user;>
 ```
 
@@ -195,19 +179,19 @@ These commands are safe to re-run.
 
 Creates the `hyku` database only if needed:
 
-```bash
+```
 psql -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='hyku'" | grep -q 1 || createdb hyku
 ```
 
 Creates the `hyku_test` database only if needed:
 
-```bash
+```
 psql -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='hyku_test'" | grep -q 1 || createdb hyku_test
 ```
 
 Checks that both Hyku databases exist:
 
-```bash
+```
 psql -d postgres -c '\l' | grep hyku
 ```
 
@@ -215,4 +199,4 @@ Expected: both `hyku` and `hyku_test` exist.
 
 ## Next
 
-Go to [3) Ruby + rbenv](./03-ruby-rbenv.md).
+Go to [Ruby + rbenv](./ruby-rbenv.md).

--- a/docs/local/dependencies/rails.md
+++ b/docs/local/dependencies/rails.md
@@ -1,4 +1,4 @@
-# 5) Rails
+# Rails
 
 Back to setup index: [docs/local/README.md](../README.md)
 
@@ -7,15 +7,16 @@ Rails comes from the Gemfile and is run through Bundler.
 
 ## Check
 
-```bash
-cd /path/to/ucrate
+From your **ucrate clone root**:
+
+```
 bundle exec rails -v
 ```
 
 Expected: prints Rails 7.2.x.
 
-If this fails, go back to [4) Bundler](./04-bundler.md) and re-run `bundle _2.6.9_ install`.
+If this fails, go back to [Bundler](./bundler.md) and re-run `bundle _2.6.9_ install`.
 
 ## Next
 
-Go to [6) Node + Yarn](./06-node-yarn.md).
+Go to [Node + Yarn](./node-yarn.md).

--- a/docs/local/dependencies/redis.md
+++ b/docs/local/dependencies/redis.md
@@ -1,4 +1,4 @@
-# 7) Redis
+# Redis
 
 Back to setup index: [docs/local/README.md](../README.md)
 
@@ -12,7 +12,7 @@ Do not start app services from this page.
 
 Run this command:
 
-```bash
+```
 command -v redis-server
 ```
 
@@ -20,13 +20,13 @@ If output prints a path, continue.
 
 If output is empty, install Redis:
 
-```bash
+```
 brew install redis
 ```
 
 Now run this command:
 
-```bash
+```
 command -v redis-cli
 ```
 
@@ -34,13 +34,13 @@ If output prints a path, you are done with this step.
 
 If output is empty, Redis is likely a broken/incomplete install. Reinstall Redis:
 
-```bash
+```
 brew reinstall redis
 ```
 
 Then run:
 
-```bash
+```
 command -v redis-cli
 ```
 
@@ -51,4 +51,4 @@ If this is still empty, stop here and use [Redis CLI quick fix](../troubleshooti
 
 ## Next
 
-Go to [8) Java 8 (Temurin)](./08-java-8.md).
+Go to [Java 8 (Temurin)](./java-8.md).

--- a/docs/local/dependencies/ruby-rbenv.md
+++ b/docs/local/dependencies/ruby-rbenv.md
@@ -1,4 +1,4 @@
-# 3) Ruby version manager + Ruby 3.3.x
+# Ruby version manager + Ruby 3.3.x
 
 Back to setup index: [docs/local/README.md](../README.md)
 
@@ -12,7 +12,7 @@ Important:
 
 ## Step 1: check active Ruby version
 
-```bash
+```
 ruby -v
 ```
 
@@ -25,7 +25,7 @@ If Ruby is not `3.3.x` (example: `3.4.7`), continue to Step 2.
 
 Run:
 
-```bash
+```
 command -v rbenv || command -v rvm
 ```
 
@@ -43,20 +43,21 @@ Use RVM only. Do not initialize rbenv in the same shell.
 
 Install Ruby 3.3.6 if needed:
 
-```bash
+```
 rvm install 3.3.6
 ```
 
 Switch to Ruby 3.3.6 for this project:
 
-```bash
-cd /path/to/ucrate
+From your **ucrate clone root**:
+
+```
 rvm use 3.3.6
 ```
 
 Verify:
 
-```bash
+```
 ruby -v
 ```
 
@@ -67,13 +68,13 @@ Expected: `ruby 3.3.x ...`
 
 1. Check whether `rbenv` is available:
 
-```bash
+```
 command -v rbenv
 ```
 
 If this prints nothing, install rbenv + ruby-build:
 
-```bash
+```
 brew install rbenv ruby-build
 ```
 
@@ -83,15 +84,16 @@ If Step 2 already found `rbenv`, skip this step.
 
 If `rbenv` was missing and you just installed it, run:
 
-```bash
+```
 echo 'eval "$(rbenv init - zsh)"' >> ~/.zshrc
 source ~/.zshrc
 ```
 
 3. Install and set Ruby 3.3.6 for this repo:
 
-```bash
-cd /path/to/ucrate
+From your **ucrate clone root**:
+
+```
 rbenv install -s 3.3.6
 rbenv local 3.3.6
 ruby -v
@@ -101,7 +103,7 @@ Expected: `ruby 3.3.x ...`
 
 If rbenv says `3.3.6` is unavailable (or definition missing), update ruby-build and retry:
 
-```bash
+```
 brew upgrade ruby-build
 rbenv install -s 3.3.6
 ```
@@ -110,4 +112,4 @@ If you already have another 3.3.x installed, use that version with `rbenv local`
 
 ## Next
 
-Go to [4) Bundler](./04-bundler.md).
+Go to [Bundler](./bundler.md).

--- a/docs/local/environment.md
+++ b/docs/local/environment.md
@@ -2,119 +2,48 @@
 
 **These instructions are for `hyku-oob` only.** Team index: [docs/local/README.md](./README.md).
 
-## What this file is for
+Hyku’s committed `.env` is for Docker. On a Mac without Docker, you use a personal file instead:
 
-Hyku ships a Docker-oriented `.env`. For **local macOS without Docker**, we use a separate personal file instead:
+| File | In git? | Role |
+|------|---------|------|
+| `.env.local.mac.example` | Yes | Team template — [open it](../../.env.local.mac.example) |
+| `.env.local.mac` | No | Your copy (gitignored) |
+| `.envrc` | Yes | Loads your copy via [direnv](./dependencies/direnv.md) |
 
-| File | In git? | Purpose |
-|------|---------|---------|
-| `.env.local.mac.example` ([open in repo](../../.env.local.mac.example)) | Yes (committed template) | Shared starting point for the team |
-| `.env.local.mac` | No (gitignored) | **Your** copy — edit this on your machine |
+Create `.env.local.mac` once. direnv loads it when you work in this clone and unloads it when you leave.
 
-You create `.env.local.mac` once, then `source` it in every terminal that runs Rails, Sidekiq, database setup, or specs.
+## Steps
 
-## Create your personal env file
+1. Open a terminal in your **ucrate clone root** (the folder with `Gemfile`). In Cursor, that is usually the project you opened.
 
-Copy the committed template to a **personal** file. This does **not** overwrite the Docker `.env`.
+2. Copy the template (this does not touch Docker’s `.env`):
 
-```bash
+```
 cp .env.local.mac.example .env.local.mac
 ```
 
-Edit `.env.local.mac` and leave `DB_USER=YOUR_MAC_USERNAME_HERE` in place for now. We set the real value later in [dependencies/02-postgresql.md](./dependencies/02-postgresql.md) (`whoami` / `psql -d postgres -c 'SELECT current_user;'`).
+3. Leave `DB_USER=YOUR_MAC_USERNAME_HERE` alone for now. You set the real value later in [dependencies/postgresql.md](./dependencies/postgresql.md).
 
-## Required for Sidekiq and Rails (already in the template)
+4. Still in the clone root, print the cache path:
 
-The template already includes these. Keep them in your `.env.local.mac`:
-
-```bash
-export HYKU_ROOT_HOST=localhost
-export HYRAX_ACTIVE_JOB_QUEUE=sidekiq
-export SOLR_HOST=localhost
-export SOLR_PORT=8983
-export SOLR_URL=http://127.0.0.1:8983/solr/
-export HYKU_CACHE_ROOT="$PWD/tmp/hyku_file_cache"
+```
+echo "$PWD"/tmp/hyku_file_cache
 ```
 
-- `HYKU_ROOT_HOST=localhost` — required so the app knows its host in single-tenant local mode.
-- `HYRAX_ACTIVE_JOB_QUEUE=sidekiq` — use Sidekiq for background jobs (not Docker’s Good Job setup).
-- `SOLR_*` — required for `db:seed` (Hyku otherwise defaults to Docker host `solr`).
-- `HYKU_CACHE_ROOT` — required for the homepage (Hyku otherwise defaults to Docker path `/app/...`). **Source from the repo root** so `$PWD` is correct.
+Expected: one absolute path, for example `/Users/alex/Codebases/ruby-on-rails/ucrate/tmp/hyku_file_cache`. Copy that whole line.
 
-If you copied an older template and these lines are missing, add them now (or re-copy from `.env.local.mac.example` and re-apply your `DB_USER`).
+5. Open `.env.local.mac`, find `HYKU_CACHE_ROOT`, and paste your path between the quotes so it looks like:
 
-## Template
-
-Also in `.env.local.mac.example` ([open in repo](../../.env.local.mac.example)):
-
-```bash
-# .env.local.mac — source this from the repo root; do not use Docker hostnames
-export HYKU_MULTITENANT=false
-export HYKU_ROOT_HOST=localhost
-export DB_ADAPTER=postgresql
-export DB_HOST=localhost
-export DB_PORT=5432
-export DB_NAME=hyku
-export DB_TEST_NAME=hyku_test
-export DB_USER=YOUR_MAC_USERNAME_HERE   # from dependencies/02-postgresql.md
-export DB_PASSWORD=                     # usually empty on Homebrew Postgres
-export REDIS_HOST=localhost
-export REDIS_PORT=6379
-export SOLR_HOST=localhost
-export SOLR_PORT=8983
-export SOLR_URL=http://127.0.0.1:8983/solr/
-export HYKU_CACHE_ROOT="$PWD/tmp/hyku_file_cache"
-export HYRAX_ACTIVE_JOB_QUEUE=sidekiq
-# Used by `rails db:setup` / `rails db:seed` to create the first admin user:
-export INITIAL_ADMIN_EMAIL=admin@example.com
-export INITIAL_ADMIN_PASSWORD=testing123
-export SECRET_KEY_BASE=dev-secret-change-me
-export DISABLE_REDIS_CLUSTER=true
+```
+export HYKU_CACHE_ROOT="/Users/alex/Codebases/ruby-on-rails/ucrate/tmp/hyku_file_cache"
 ```
 
-You will source `.env.local.mac` later in the runtime docs, in the terminals that run Rails, Sidekiq, `db:setup`, or specs.
+Use your path from step 4, not the example. Keep the quotes. The value must start with `/`, end with `/tmp/hyku_file_cache`, and must not contain `$PWD` or `~`.
 
-> **Multitenancy:** Upstream Hyku often uses `*.localhost.direct` and Stack Car. Stay on `HYKU_MULTITENANT=false` until the single-tenant stack is solid.
+Hyku defaults the cache to a Docker path (`/app/...`). Without this absolute path, the homepage can fail with `Errno::EROFS`.
 
-**Do not** source the committed `.env` for local no-Docker runs — it uses Docker hostnames (`db`, `solr`, `redis`, `fcrepo`).
-
-### Solr host (required for `db:setup` / `db:seed`)
-
-Hyku’s account/seed code defaults `SOLR_HOST` to `solr` (Docker). Without an explicit localhost setting, seed fails with `Connection refused` / `getaddrinfo` for host `solr`.
-
-Your `.env.local.mac` must include:
-
-```bash
-export SOLR_HOST=localhost
-export SOLR_PORT=8983
-export SOLR_URL=http://127.0.0.1:8983/solr/
-```
-
-Check after sourcing:
-
-```bash
-env | grep '^SOLR_HOST='
-env | grep '^SOLR_URL='
-```
-
-Expected: `SOLR_HOST=localhost` and a URL that uses `127.0.0.1` or `localhost` (not the hostname `solr`).
-
-If you previously sourced the Docker `.env`, also run `unset SOLR_URL SOLR_HOST FCREPO_HOST` and source `.env.local.mac` again.
-
-### File cache root (required for the homepage)
-
-Hyku defaults `HYKU_CACHE_ROOT` to `/app/samvera/file_cache` (a Docker path). On a Mac that becomes `Errno::EROFS` / “Read-only file system @ dir_s_mkdir - /app” when the homepage tries to write the cache.
-
-Your `.env.local.mac` must include (source from the repo root):
-
-```bash
-export HYKU_CACHE_ROOT="$PWD/tmp/hyku_file_cache"
-```
-
-Then restart Rails after re-sourcing ([run-the-app.md](./run-the-app.md) has a start/restart section).
+If you move the clone later, repeat steps 4–5.
 
 ## Next
 
-- [Start services](./start-services.md)
-- [Run the app](./run-the-app.md)
-- [Run tests](./run-tests.md)
+Go to [Homebrew](./dependencies/homebrew.md).

--- a/docs/local/github-actions.md
+++ b/docs/local/github-actions.md
@@ -8,12 +8,13 @@ PRs and pushes to **`hyku-oob`** run [`.github/workflows/ci.yml`](../../.github/
 
 | Job | What it does |
 |-----|----------------|
+| **UC customizations** | Ensures [uc-hyku-customizations.md](./uc-hyku-customizations.md) and [uc-hyku-customizations.manifest.yml](./uc-hyku-customizations.manifest.yml) stay in sync with UC-owned files; on PRs, changing a listed customization requires updating that inventory |
 | **RuboCop** | `bundle exec rubocop` (no Solr/Fedora) |
 | **Brakeman and bundler-audit** | Security scans (no Solr/Fedora). Known Hyku OOB findings are baselined in [`config/brakeman.ignore`](../../config/brakeman.ignore) and [`.bundler-audit.yml`](../../.bundler-audit.yml); **new** Medium/High Brakeman warnings or unignored advisories still fail CI. |
 | **RSpec (shards 0–5)** | Six parallel jobs; each starts Postgres, Redis, Solr, Fedora (and Chrome) via [`docker-compose.ci.yml`](../../docker-compose.ci.yml), then runs ~1/6 of the spec files |
 | **Coverage gate** | Downloads each shard’s SimpleCov `.resultset.json`, merges with `SimpleCov.collate`, compares to [`coverage/coverage_baseline.txt`](../../coverage/coverage_baseline.txt) |
 
-Required checks for PRs into `hyku-oob` should be those jobs (lint, security, all six RSpec shards, and the coverage gate). No release labels are required for these checks.
+Required checks for PRs into `hyku-oob` should include those jobs (UC customizations, lint, security, all six RSpec shards, and the coverage gate). No release labels are required for these checks.
 
 CI uses Actions + Docker **only on the runner**. Local macOS setup under `docs/local/` stays no-Docker.
 

--- a/docs/local/run-tests.md
+++ b/docs/local/run-tests.md
@@ -7,9 +7,9 @@ You do **not** need to run the full suite for every change. A complete local run
 ## Prerequisites
 
 - Dependency setup complete (see [docs/local/dependencies](./dependencies))
-- Postgres running with `hyku_test` created ([dependencies/02-postgresql.md](./dependencies/02-postgresql.md))
+- Postgres running with `hyku_test` created ([dependencies/postgresql.md](./dependencies/postgresql.md))
 - Redis running
-- Source `.env.local.mac` first ([environment.md](./environment.md); `DB_TEST_NAME=hyku_test`, etc.)
+- [direnv](./dependencies/direnv.md) set up so `.env.local.mac` loads in the clone ([environment.md](./environment.md); `DB_TEST_NAME=hyku_test`, etc.)
 - Port reference: [versions-and-ports.md](./versions-and-ports.md) (test: Solr **8985**, Fedora **8986**)
 
 Keep **development** wrappers (8983/8984) separate from **test** wrappers (8985/8986). Mixing them causes confusing failures.
@@ -22,7 +22,7 @@ Run **one command at a time**. Match each reply to the Expected line under that 
 
 ### Postgres
 
-```bash
+```
 pg_isready -h localhost
 ```
 
@@ -30,7 +30,7 @@ Expected: `localhost:5432 - accepting connections`
 
 ### Redis
 
-```bash
+```
 redis-cli ping
 ```
 
@@ -38,7 +38,7 @@ Expected: `PONG`
 
 ### Solr (test port 8985)
 
-```bash
+```
 lsof -i :8985 | grep LISTEN
 ```
 
@@ -48,7 +48,7 @@ If this command prints nothing, Solr test is not listening yet.
 
 ### Fedora (test port 8986)
 
-```bash
+```
 lsof -i :8986 | grep LISTEN
 ```
 
@@ -62,10 +62,9 @@ Skip these checks when using Option A (`rake ci`), which starts test Solr and Fe
 
 This matches the repo’s non-Docker default (`Rakefile` → `with_server 'test'`). It starts Solr/Fedora using the **test** wrapper configs, then runs the specs.
 
-```bash
-cd /path/to/ucrate
-set -a && source .env.local.mac && set +a
+From your **ucrate clone root** ([direnv](./dependencies/direnv.md) loads the env here):
 
+```
 export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
 export PATH="$JAVA_HOME/bin:$PATH"
 
@@ -86,7 +85,7 @@ What `rake ci` uses:
 
 ### RuboCop only (no Solr/Fedora; much faster)
 
-```bash
+```
 bundle exec rubocop
 ```
 
@@ -98,8 +97,7 @@ Use this if you want wrappers left running across multiple spec invocations.
 
 ### Terminal 1 — Fedora (test, 8986)
 
-```bash
-cd /path/to/ucrate
+```
 export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
 export PATH="$JAVA_HOME/bin:$PATH"
 bundle exec fcrepo_wrapper -c config/fcrepo_wrapper_test.yml
@@ -107,8 +105,7 @@ bundle exec fcrepo_wrapper -c config/fcrepo_wrapper_test.yml
 
 ### Terminal 2 — Solr (test, 8985)
 
-```bash
-cd /path/to/ucrate
+```
 RUBYOPT="-r./config/fcrepo_wrapper_compat" bundle exec solr_wrapper --config config/solr_wrapper_test.yml
 ```
 
@@ -116,16 +113,13 @@ RUBYOPT="-r./config/fcrepo_wrapper_compat" bundle exec solr_wrapper --config con
 
 Skip if `brew services` already runs it:
 
-```bash
+```
 redis-server
 ```
 
 ### Terminal 4 — Specs
 
-```bash
-cd /path/to/ucrate
-set -a && source .env.local.mac && set +a
-
+```
 RAILS_ENV=test bundle exec rails db:prepare
 
 # Full suite:

--- a/docs/local/run-the-app.md
+++ b/docs/local/run-the-app.md
@@ -71,7 +71,7 @@ It does **not** create repository works. An empty catalog after seed is normal. 
 
 ### Optional: UC sample works
 
-After `db:setup`, this loads Scholar@UC-style sample users and public works onto Hyku’s existing models (`GenericWork`, `Image`, `Etd`):
+After `db:setup`, this loads Scholar@UC-style sample users and public works onto Hyku’s existing models (`GenericWork`, `Image`, `Etd`). Local/dev only — the task refuses production and staging.
 
 ```bash
 cd /path/to/ucrate
@@ -81,7 +81,7 @@ RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec rake uc:seed:samples
 
 Expected: a `RESULT: OK` banner at the end (ignore Hyrax/Blacklight boot warnings above it).
 
-- First successful run prints the sample-account password and creates public works plus a **Complete Works** collection.
+- First successful run creates public works plus a **Complete Works** collection. Sample accounts (`manydeposits@example.com`, etc., and `admin@example.com`) use `INITIAL_ADMIN_PASSWORD` from `.env.local.mac` — same password as the Hyku admin from `db:setup`.
 - Re-run after success: `RESULT: OK — ... already present (skipped)` — nothing changes.
 - Wipe and recreate: `UC_SEED_FORCE=true`. Fewer bulk works: `UC_SEED_WORKS_PER_USER=3` (default `10`).
 

--- a/docs/local/run-the-app.md
+++ b/docs/local/run-the-app.md
@@ -2,17 +2,13 @@
 
 **These instructions are for `hyku-oob` only.** Team index: [docs/local/README.md](./README.md).
 
-This page is **only** the one-time database setup/seeding step and how to sign in.
+This page is database setup, optional sample works, and first sign-in.
 
-Do **not** start Postgres, Redis, Fedora, Solr, or Sidekiq here. Those commands live on [start-services.md](./start-services.md). Finish that page first (keep those terminals running), then come here.
+Start Postgres, Redis, Fedora, Solr, and Sidekiq first — [start-services.md](./start-services.md) — and leave those terminals running. For tests, see [run-tests.md](./run-tests.md).
 
-For tests (different Solr/Fedora ports), see [run-tests.md](./run-tests.md).
+## Quick checks
 
-## Quick checks (do this first)
-
-Seeds talk to Solr and Fedora. Do **not** run `db:setup` / `db:seed` while Solr is still downloading (progress % in the Solr terminal from [start-services.md](./start-services.md)).
-
-Run **one command at a time** in a free terminal. Match each reply to the Expected line under that command.
+Do not run `db:setup` while Solr is still downloading (watch the Solr terminal from [start-services.md](./start-services.md)).
 
 ### Postgres
 
@@ -30,32 +26,29 @@ redis-cli ping
 
 Expected: `PONG`
 
-### Solr (dev port 8983)
+### Solr (port 8983)
 
 ```bash
 lsof -i :8983 | grep LISTEN
 ```
 
-Expected: at least one line that includes `8983` and `LISTEN` (for example `TCP *:8983 (LISTEN)`).
+Expected: a line with `8983` and `LISTEN`. If empty, wait for Solr to finish starting, then check again.
 
-If this command prints nothing, Solr is not listening yet. Wait until the Solr terminal finishes downloading and stays running, then run the check again.
-
-### Fedora (dev port 8984)
+### Fedora (port 8984)
 
 ```bash
 lsof -i :8984 | grep LISTEN
 ```
 
-Expected: at least one line that includes `8984` and `LISTEN` (for example `TCP *:8984 (LISTEN)`).
+Expected: a line with `8984` and `LISTEN`.
 
-If any check fails, go back to [start-services.md](./start-services.md). Do not re-copy startup commands onto this page.
+If any check fails, fix it on [start-services.md](./start-services.md), then return here.
 
 ## One-time database setup
 
-If you are used to Scholar@UC `develop`: do not run the old MySQL-era setup sequence.
-On this branch, use `db:setup` (or `db:migrate` + `db:seed`) against PostgreSQL.
+Use `db:setup` on PostgreSQL (not the old MySQL flow from Scholar@UC `develop`).
 
-Work from the **repo root** (so `$PWD` in `.env.local.mac` resolves correctly for `HYKU_CACHE_ROOT`):
+From the **repo root** (`HYKU_CACHE_ROOT` uses `$PWD`):
 
 ```bash
 cd /path/to/ucrate
@@ -64,75 +57,77 @@ set -a && source .env.local.mac && set +a
 RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec rails db:setup
 ```
 
-`db:setup` = create + schema + seed. Seeds need Solr and Fedora already listening. `RUBYOPT` loads the same Redis shim Sidekiq uses (without it, seed can fail with `unknown keyword: :thread_safe`).
+`db:setup` creates the database, loads the schema, and runs Hyku’s seed. Solr and Fedora must already be listening. `RUBYOPT` loads the local Redis shim (without it, seed can fail with `unknown keyword: :thread_safe`).
 
-Expected outcome: command completes without errors.
+Expected: the command finishes without errors.
 
-What seed creates (and does **not** create):
+Hyku seed creates:
 
-- Single-tenant account, default admin set, collection types, and Sipity **workflows** (permission/process definitions — not repository items)
-- Work *types* enabled on the site (Generic Work, etc.) so you can deposit later
-- Initial admin user from `INITIAL_ADMIN_EMAIL` / `INITIAL_ADMIN_PASSWORD`
+- Single-tenant account, default admin set, collection types, and Sipity workflows
+- Enabled work types (Generic Work, and so on)
+- Admin user from `INITIAL_ADMIN_EMAIL` / `INITIAL_ADMIN_PASSWORD`
 
-It does **not** deposit sample works or files. An empty public homepage after a successful seed is normal. Sign in with the `INITIAL_ADMIN_*` values to deposit content.
+It does **not** create repository works. An empty catalog after seed is normal. Sign in with `INITIAL_ADMIN_*` to deposit, or use the optional step below.
 
-If the database already exists:
+### Optional: UC sample works
+
+After `db:setup`, this loads Scholar@UC-style sample users and public works onto Hyku’s existing models (`GenericWork`, `Image`, `Etd`):
 
 ```bash
-RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec rails db:migrate
-RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec rails db:seed
+cd /path/to/ucrate
+set -a && source .env.local.mac && set +a
+RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec rake uc:seed:samples
 ```
 
-You do not need a separate Rails console step for the first admin user.
+Expected: a `RESULT: OK` banner at the end (ignore Hyrax/Blacklight boot warnings above it).
+
+- First successful run prints the sample-account password and creates public works plus a **Complete Works** collection.
+- Re-run after success: `RESULT: OK — ... already present (skipped)` — nothing changes.
+- Wipe and recreate: `UC_SEED_FORCE=true`. Fewer bulk works: `UC_SEED_WORKS_PER_USER=3` (default `10`).
+
+Develop-only types/fields (`Article`, `college`, …) are stored on Hyku models via `resource_type` and description text — not as separate UC work classes.
 
 ## Start or restart Rails (if needed)
 
-Rails may already be running from [start-services.md](./start-services.md) Step 6. You still need a **restart** if you changed `.env.local.mac` after Rails started (for example after adding `HYKU_CACHE_ROOT` or `SOLR_*`).
-
-Check whether something is listening on port **3000**:
+Rails may already be up from [start-services.md](./start-services.md) Step 6. Restart it if you changed `.env.local.mac` after it started.
 
 ```bash
 lsof -i :3000 | grep LISTEN
 ```
 
-- **No output:** Rails is not running. Start it (command below).
-- **Has `LISTEN`:** If env is already correct, skip to [Open the app](#open-the-app). If you just updated `.env.local.mac`, stop Rails with Ctrl+C in its terminal, then start it again with the command below.
-
-From the repo root:
+- No output → start Rails with the command below.
+- Has `LISTEN` and env is already correct → go to [Open the app](#open-the-app).
+- Has `LISTEN` but you just changed `.env.local.mac` → Ctrl+C in the Rails terminal, then start again:
 
 ```bash
 cd /path/to/ucrate
 set -a && source .env.local.mac && set +a && DISABLE_REDIS_CLUSTER=true RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec rails server -b 0.0.0.0 -p 3000
 ```
 
-Expected outcome: Rails boots and stays running in this terminal.
+Expected: Rails stays running in that terminal.
 
-Confirm env was loaded (optional):
+Optional check:
 
 ```bash
 env | grep '^HYKU_CACHE_ROOT='
 env | grep '^SOLR_HOST='
 ```
 
-Expected: a path under your repo `tmp/hyku_file_cache`, and `SOLR_HOST=localhost`.
+Expected: a path under `tmp/hyku_file_cache`, and `SOLR_HOST=localhost`.
 
 ## Open the app
 
-Open **http://localhost:3000**
+Open **http://localhost:3000** and sign in with `INITIAL_ADMIN_*` from `.env.local.mac`.
 
-Sign in with the `INITIAL_ADMIN_*` values from `.env.local.mac`.
-
-If the page shows pending migrations, finish the [database setup](#one-time-database-setup) section above, then reload.
-
-If you see `Errno::EROFS` / mkdir `/app`, Rails was started without `HYKU_CACHE_ROOT`. Fix `.env.local.mac` ([environment.md](./environment.md)), then [restart Rails](#start-or-restart-rails-if-needed).
-
-If the page does not load, check the service terminals from [start-services.md](./start-services.md) in this order: Fedora, Solr, Redis, Sidekiq, Rails.
+| If you see… | Then… |
+|-------------|--------|
+| Pending migrations | Finish [database setup](#one-time-database-setup), reload |
+| `Errno::EROFS` / mkdir `/app` | Set `HYKU_CACHE_ROOT` ([environment.md](./environment.md)), [restart Rails](#start-or-restart-rails-if-needed) |
+| Page will not load | Check service terminals: Fedora → Solr → Redis → Sidekiq → Rails ([start-services.md](./start-services.md)) |
 
 ## Later days
 
-You usually do **not** need `db:setup` again.
-
-Everyday restarts: [start-services.md](./start-services.md) only. Stop with Ctrl+C in each terminal. Safe to leave brew-managed Postgres/Redis running.
+You usually do not need `db:setup` again. Everyday restarts: [start-services.md](./start-services.md) only.
 
 ## Related
 

--- a/docs/local/run-the-app.md
+++ b/docs/local/run-the-app.md
@@ -4,7 +4,7 @@
 
 This page is database setup, optional sample works, and first sign-in.
 
-Start Postgres, Redis, Fedora, Solr, and Sidekiq first — [start-services.md](./start-services.md) — and leave those terminals running. For tests, see [run-tests.md](./run-tests.md).
+Start services first — [start-services.md](./start-services.md) — and leave those terminals running (including Rails). For tests, see [run-tests.md](./run-tests.md).
 
 ## Quick checks
 
@@ -12,7 +12,7 @@ Do not run `db:setup` while Solr is still downloading (watch the Solr terminal f
 
 ### Postgres
 
-```bash
+```
 pg_isready -h localhost
 ```
 
@@ -20,7 +20,7 @@ Expected: `localhost:5432 - accepting connections`
 
 ### Redis
 
-```bash
+```
 redis-cli ping
 ```
 
@@ -28,7 +28,7 @@ Expected: `PONG`
 
 ### Solr (port 8983)
 
-```bash
+```
 lsof -i :8983 | grep LISTEN
 ```
 
@@ -36,7 +36,7 @@ Expected: a line with `8983` and `LISTEN`. If empty, wait for Solr to finish sta
 
 ### Fedora (port 8984)
 
-```bash
+```
 lsof -i :8984 | grep LISTEN
 ```
 
@@ -48,12 +48,9 @@ If any check fails, fix it on [start-services.md](./start-services.md), then ret
 
 Use `db:setup` on PostgreSQL (not the old MySQL flow from Scholar@UC `develop`).
 
-From the **repo root** (`HYKU_CACHE_ROOT` uses `$PWD`):
+Run from your **ucrate clone root** (the directory with `Gemfile`). [direnv](./dependencies/direnv.md) loads the env in this directory.
 
-```bash
-cd /path/to/ucrate
-set -a && source .env.local.mac && set +a
-
+```
 RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec rails db:setup
 ```
 
@@ -73,9 +70,7 @@ It does **not** create repository works. An empty catalog after seed is normal. 
 
 After `db:setup`, this loads Scholar@UC-style sample users and public works onto Hyku’s existing models (`GenericWork`, `Image`, `Etd`). Local/dev only — the task refuses production and staging.
 
-```bash
-cd /path/to/ucrate
-set -a && source .env.local.mac && set +a
+```
 RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec rake uc:seed:samples
 ```
 
@@ -87,43 +82,15 @@ Expected: a `RESULT: OK` banner at the end (ignore Hyrax/Blacklight boot warning
 
 Develop-only types/fields (`Article`, `college`, …) are stored on Hyku models via `resource_type` and description text — not as separate UC work classes.
 
-## Start or restart Rails (if needed)
-
-Rails may already be up from [start-services.md](./start-services.md) Step 6. Restart it if you changed `.env.local.mac` after it started.
-
-```bash
-lsof -i :3000 | grep LISTEN
-```
-
-- No output → start Rails with the command below.
-- Has `LISTEN` and env is already correct → go to [Open the app](#open-the-app).
-- Has `LISTEN` but you just changed `.env.local.mac` → Ctrl+C in the Rails terminal, then start again:
-
-```bash
-cd /path/to/ucrate
-set -a && source .env.local.mac && set +a && DISABLE_REDIS_CLUSTER=true RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec rails server -b 0.0.0.0 -p 3000
-```
-
-Expected: Rails stays running in that terminal.
-
-Optional check:
-
-```bash
-env | grep '^HYKU_CACHE_ROOT='
-env | grep '^SOLR_HOST='
-```
-
-Expected: a path under `tmp/hyku_file_cache`, and `SOLR_HOST=localhost`.
-
 ## Open the app
 
-Open **http://localhost:3000** and sign in with `INITIAL_ADMIN_*` from `.env.local.mac`.
+Open **http://localhost:3000** and sign in with `INITIAL_ADMIN_*` from `.env.local.mac`. Rails should already be running from [start-services.md](./start-services.md) Step 6.
 
 | If you see… | Then… |
 |-------------|--------|
 | Pending migrations | Finish [database setup](#one-time-database-setup), reload |
-| `Errno::EROFS` / mkdir `/app` | Set `HYKU_CACHE_ROOT` ([environment.md](./environment.md)), [restart Rails](#start-or-restart-rails-if-needed) |
-| Page will not load | Check service terminals: Fedora → Solr → Redis → Sidekiq → Rails ([start-services.md](./start-services.md)) |
+| `Errno::EROFS` / mkdir `/app` | Fix `HYKU_CACHE_ROOT` ([environment.md](./environment.md)), then restart Rails from [start-services.md](./start-services.md) Step 6 |
+| Page will not load / nothing on port 3000 | Check service terminals: Fedora → Solr → Redis → Sidekiq → Rails ([start-services.md](./start-services.md)) |
 
 ## Later days
 

--- a/docs/local/start-services.md
+++ b/docs/local/start-services.md
@@ -8,35 +8,34 @@ This page is for the development environment (dev ports), not test ports.
 
 Need test services instead? Use [docs/local/start-test-services.md](./start-test-services.md).
 
-Run each service in its own terminal tab/window so logs stay visible and each process keeps running.
+Before starting services, confirm env is loaded in a terminal at your **ucrate clone root** (the directory with `Gemfile`). [direnv](./dependencies/direnv.md) must already be set up.
 
-Before Sidekiq (Step 5) and Rails (Step 6), you must have already created `.env.local.mac` from `.env.local.mac.example` — see [environment.md](./environment.md). That template includes `HYKU_ROOT_HOST`, `HYRAX_ACTIVE_JOB_QUEUE=sidekiq`, `SOLR_*` localhost settings, and `HYKU_CACHE_ROOT`.
+### Env check (do this first)
 
-**Always `cd` to the repo root before sourcing `.env.local.mac`.** `HYKU_CACHE_ROOT` uses `$PWD`.
-
-Quick check in the terminal where you will run the worker or Rails:
-
-```bash
-cd /path/to/ucrate
-set -a && source .env.local.mac && set +a
+```
 env | grep '^HYKU_ROOT_HOST='
 env | grep '^HYRAX_ACTIVE_JOB_QUEUE='
 env | grep '^SOLR_HOST='
+env | grep '^SOLR_URL='
 env | grep '^HYKU_CACHE_ROOT='
 ```
 
 Expected:
 
-```bash
+```
 HYKU_ROOT_HOST=localhost
 HYRAX_ACTIVE_JOB_QUEUE=sidekiq
 SOLR_HOST=localhost
-HYKU_CACHE_ROOT=.../ucrate/tmp/hyku_file_cache
+SOLR_URL=http://127.0.0.1:8983/solr/
 ```
 
-If any line is missing, fix `.env.local.mac` using [environment.md](./environment.md) before continuing.
+Plus a `HYKU_CACHE_ROOT=` line with the **same full path** you set in [environment.md](./environment.md) (also confirmed under [direnv](./dependencies/direnv.md)). It must start with `/` and end with `/tmp/hyku_file_cache` — not a placeholder and not `$PWD`.
 
-Run these from `/path/to/ucrate` unless noted.
+- **No output / vars missing:** direnv is not loading the file — finish [direnv](./dependencies/direnv.md) (`direnv allow`, zsh hook), then hit Enter or open a new terminal in the clone and re-check.
+- **Wrong `SOLR_*` or other `HYKU_*` values** (Docker hostname `solr`, etc.): fix `.env.local.mac` in [environment.md](./environment.md), hit Enter so direnv reloads, then re-check.
+- **Wrong cache path:** fix `HYKU_CACHE_ROOT` in [environment.md](./environment.md), hit Enter so direnv reloads, then re-check.
+
+Do not continue until this check looks right. You will run each service below from the clone root with env loaded (direnv).
 
 ## 1) Start PostgreSQL
 
@@ -44,13 +43,13 @@ PostgreSQL may already be running from earlier setup.
 
 Check status first:
 
-```bash
+```
 brew services list | grep -i postgres
 ```
 
-If your Postgres service is not `started`, start it:
+If your Postgres service is not `started`:
 
-```bash
+```
 brew services start postgresql@16
 ```
 
@@ -60,7 +59,9 @@ If it was running but you stopped it, start it again with the same command.
 
 ## 2) Start Redis
 
-```bash
+From a new terminal, run:
+
+```
 redis-server
 ```
 
@@ -68,7 +69,9 @@ Use the same Redis terminal process for both dev and test on this branch. If you
 
 ## 3) Start Fedora wrapper
 
-```bash
+From a new terminal, run:
+
+```
 export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" && export PATH="$JAVA_HOME/bin:$PATH" && RUBYOPT="-r./config/fcrepo_wrapper_compat" bundle exec fcrepo_wrapper -p 8984
 ```
 
@@ -76,7 +79,9 @@ export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" && export PATH="$JAVA_HOME/b
 
 First start on a machine may take several minutes (downloads Solr **7.4.0** into `tmp/solr-download` and installs it under `tmp/solr-development`). Later starts reuse that install and should be much faster.
 
-```bash
+From a new terminal, run:
+
+```
 RUBYOPT="-r./config/fcrepo_wrapper_compat" bundle exec solr_wrapper
 ```
 
@@ -86,8 +91,10 @@ You can continue to Step 5 (Sidekiq) while Solr is still downloading. Sidekiq on
 
 ## 5) Start Sidekiq
 
-```bash
-set -a && source .env.local.mac && set +a && DISABLE_REDIS_CLUSTER=true RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec sidekiq
+From a new terminal, run:
+
+```
+DISABLE_REDIS_CLUSTER=true RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec sidekiq
 ```
 
 `RUBYOPT` loads a small local shim that strips a legacy Redis option Hyku still passes (`thread_safe`). Without it, Sidekiq 7 exits with `unknown keyword: :thread_safe`.
@@ -100,8 +107,10 @@ It connects to Redis (`REDIS_HOST`/`REDIS_PORT`), and this branch uses the same 
 
 ## 6) Start Rails server (port 3000)
 
-```bash
-set -a && source .env.local.mac && set +a && DISABLE_REDIS_CLUSTER=true RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec rails server -b 0.0.0.0 -p 3000
+From a new terminal, run:
+
+```
+DISABLE_REDIS_CLUSTER=true RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec rails server -b 0.0.0.0 -p 3000
 ```
 
 Expected outcome: Rails boots and stays running in this terminal.
@@ -114,5 +123,5 @@ If you change `.env.local.mac` later (Solr URL, cache root, etc.), stop Rails wi
 
 Keep the terminals from this page running.
 
-- **First time on this branch:** go to [run-the-app.md](./run-the-app.md) for quick checks and one-time DB setup/seeding. Do not open the browser yet — http://localhost:3000 usually shows a pending-migrations error until seeding finishes. That page also covers restarting Rails if you updated env after Step 6.
+- **First time on this branch:** go to [run-the-app.md](./run-the-app.md) for quick checks and one-time DB setup/seeding. Do not open the browser yet — http://localhost:3000 usually shows a pending-migrations error until seeding finishes.
 - **Already set up this branch locally:** open http://localhost:3000.

--- a/docs/local/start-test-services.md
+++ b/docs/local/start-test-services.md
@@ -17,30 +17,26 @@ You can run the app stack and the test stack at the same time because Solr and F
 
 Need development services instead? Use [start-services.md](./start-services.md).
 
-Run each service in its own terminal tab/window so logs stay visible and each process keeps running.
+Before optional Sidekiq (Step 5), confirm env is loaded from the **ucrate clone root** ([direnv](./dependencies/direnv.md)):
 
-Before optional Sidekiq (Step 5), you must have already created `.env.local.mac` from `.env.local.mac.example` — see [environment.md](./environment.md). That template includes `HYKU_ROOT_HOST=localhost` and `HYRAX_ACTIVE_JOB_QUEUE=sidekiq`.
-
-Quick check in the terminal where you will run Sidekiq (if needed):
-
-```bash
-set -a && source .env.local.mac && set +a
+```
 env | grep '^HYKU_ROOT_HOST='
 env | grep '^HYRAX_ACTIVE_JOB_QUEUE='
 ```
 
 Expected:
 
-```bash
+```
 HYKU_ROOT_HOST=localhost
 HYRAX_ACTIVE_JOB_QUEUE=sidekiq
 ```
 
-If either line is missing, fix `.env.local.mac` using [environment.md](./environment.md) before continuing.
+- **No output:** finish [direnv](./dependencies/direnv.md), then re-check.
+- **Wrong values:** fix `.env.local.mac` in [environment.md](./environment.md), hit Enter so direnv reloads, then re-check.
 
 Most people use `rake ci` on [run-tests.md](./run-tests.md) (it can start test Solr/Fedora for you). Use **this** page when you want test wrappers left running across multiple spec invocations.
 
-Run these from `/path/to/ucrate` unless noted.
+Run each service in its own terminal tab/window so logs stay visible and each process keeps running. Run the commands on this page from your **ucrate clone root** (the directory with `Gemfile`) unless noted.
 
 ## 1) Start PostgreSQL
 
@@ -48,19 +44,19 @@ PostgreSQL may already be running from earlier setup or from [start-services.md]
 
 If Postgres is already accepting connections, skip this step:
 
-```bash
+```
 pg_isready -h localhost
 ```
 
 Otherwise check Homebrew status:
 
-```bash
+```
 brew services list | grep -i postgres
 ```
 
 If your Postgres service is not `started`, start it:
 
-```bash
+```
 brew services start postgresql@16
 ```
 
@@ -74,13 +70,13 @@ If you already started Redis for the development environment ([start-services.md
 
 If Redis is not running yet:
 
-```bash
+```
 redis-server
 ```
 
 If Homebrew’s Redis service already owns port 6379 and you prefer a foreground `redis-server` in this terminal, stop the service first:
 
-```bash
+```
 brew services stop redis
 ```
 
@@ -90,7 +86,7 @@ Then run `redis-server` as above.
 
 This is a **separate** process from the development Fedora on **8984**. Start it even if dev Fedora is already running.
 
-```bash
+```
 export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" && export PATH="$JAVA_HOME/bin:$PATH" && RUBYOPT="-r./config/fcrepo_wrapper_compat" bundle exec fcrepo_wrapper -c config/fcrepo_wrapper_test.yml
 ```
 
@@ -102,7 +98,7 @@ This is a **separate** process from the development Solr on **8983**. Start it e
 
 First start may download Solr if you have not already run the **dev** Solr wrapper (same zip cache in `tmp/solr-download`). The test instance lives under `tmp/solr-test`.
 
-```bash
+```
 RUBYOPT="-r./config/fcrepo_wrapper_compat" bundle exec solr_wrapper --config config/solr_wrapper_test.yml
 ```
 
@@ -116,8 +112,8 @@ Most test runs do not require a separate worker process.
 
 If you are running tests that depend on background jobs, start Sidekiq:
 
-```bash
-set -a && source .env.local.mac && set +a && DISABLE_REDIS_CLUSTER=true RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec sidekiq
+```
+DISABLE_REDIS_CLUSTER=true RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec sidekiq
 ```
 
 `RUBYOPT` loads a small local shim that strips a legacy Redis option Hyku still passes (`thread_safe`). Without it, Sidekiq 7 exits with `unknown keyword: :thread_safe`.

--- a/docs/local/switching-to-develop.md
+++ b/docs/local/switching-to-develop.md
@@ -4,7 +4,7 @@
 
 `develop` still wants Ruby 2.7.8, MySQL, and its own README (on that branch). When you switch:
 
-```bash
+```
 git checkout develop
 rbenv local 2.7.8    # or whatever develop documents
 # use develop’s MySQL + service instructions from that branch’s README

--- a/docs/local/troubleshooting.md
+++ b/docs/local/troubleshooting.md
@@ -20,6 +20,7 @@
 | Homepage / Rails: `Errno::EROFS` or mkdir `/app` | `HYKU_CACHE_ROOT` still Docker default `/app/samvera/file_cache` | Set `HYKU_CACHE_ROOT="$PWD/tmp/hyku_file_cache"` in `.env.local.mac` ([environment.md](./environment.md)); re-source from repo root; restart Rails |
 | Seeds fail with connection to host `solr` / `RSolr::Error::ConnectionRefused` | `SOLR_HOST` still Docker default (`solr`), or Docker `.env` was sourced | Set `SOLR_HOST=localhost` and `SOLR_URL=http://127.0.0.1:8983/solr/` in `.env.local.mac` ([environment.md](./environment.md)); `unset SOLR_URL SOLR_HOST` if needed; re-source; ensure Solr listens on **8983**; re-run `db:seed` |
 | Seeds fail | Solr/Fedora not ready | Start wrappers first, wait, re-run `db:seed` |
+| `uc:seed:samples` fails with missing single-tenant account | Stock Hyku `db:seed` not run yet | Finish [run-the-app.md](./run-the-app.md) `db:setup` / `db:seed` first, then re-run `rake uc:seed:samples` |
 | Solr/Fedora connection errors (app) | Dev wrappers not up, or Docker `.env` hosts loaded | Confirm ports **8983/8984**; set `SOLR_HOST=localhost` / unset Docker `SOLR_URL` / `FCREPO_HOST` |
 | Specs can’t reach Solr/Fedora | Using dev ports, or test wrappers down | Test ports are **8985/8986**; see [run-tests.md](./run-tests.md) |
 | Specs fail after using develop’s Fedora **8080** | Wrong test Fedora port on this branch | Use **8986** (`config/fcrepo_wrapper_test.yml`) |

--- a/docs/local/troubleshooting.md
+++ b/docs/local/troubleshooting.md
@@ -4,21 +4,23 @@
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `psql: command not found` | Postgres not installed or not on PATH | [dependencies/02-postgresql.md](./dependencies/02-postgresql.md) check/install; PATH for **your** version only |
+| `psql: command not found` | Postgres not installed or not on PATH | [dependencies/postgresql.md](./dependencies/postgresql.md) check/install; PATH for **your** version only |
 | `SELECT current_user;` fails for both default and `-U postgres` | Role/login mismatch | Run `whoami` and `psql -d postgres -c '\du'`, then pick an existing role for `DB_USER` in `.env.local.mac` |
-| `pg_isready` fails / connection refused | Server not running | Start **existing** version ([dependencies/02-postgresql.md](./dependencies/02-postgresql.md)); don’t install a second copy |
+| `pg_isready` fails / connection refused | Server not running | Start **existing** version ([dependencies/postgresql.md](./dependencies/postgresql.md)); don’t install a second copy |
 | Port 5432 already in use when starting brew Postgres | Another Postgres already running | `lsof -i :5432`; use that server instead |
-| `role "postgres" does not exist` | Homebrew user is your macOS name, not `postgres` | [dependencies/02-postgresql.md](./dependencies/02-postgresql.md); set `DB_USER` to `whoami` |
-| `database "hyku" does not exist` | Hyku DBs not created yet | [dependencies/02-postgresql.md](./dependencies/02-postgresql.md) |
+| `role "postgres" does not exist` | Homebrew user is your macOS name, not `postgres` | [dependencies/postgresql.md](./dependencies/postgresql.md); set `DB_USER` to `whoami` |
+| `database "hyku" does not exist` | Hyku DBs not created yet | [dependencies/postgresql.md](./dependencies/postgresql.md) |
 | `fcrepo_wrapper: command not found` | Not using Bundler | `bundle exec fcrepo_wrapper` from the project root after `bundle install` |
 | Unable to locate a Java Runtime / wrong Java | Java 8 missing or not active in the Fedora terminal | Use [Java 8 quick fix](#java-8-quick-fix) |
-| DB connection errors from Rails | Wrong `DB_*` or Postgres not running | Re-check [dependencies/02-postgresql.md](./dependencies/02-postgresql.md) and [environment.md](./environment.md) |
-| `corepack: command not found` | Corepack is not installed/enabled in your Node setup | Run `npm install -g corepack`, then continue Node/Yarn setup in [dependencies/06-node-yarn.md](./dependencies/06-node-yarn.md) |
+| DB connection errors from Rails | Wrong `DB_*` or Postgres not running | Re-check [dependencies/postgresql.md](./dependencies/postgresql.md) and [environment.md](./environment.md) |
+| `corepack: command not found` | Corepack is not installed/enabled in your Node setup | Run `npm install -g corepack`, then continue Node/Yarn setup in [dependencies/node-yarn.md](./dependencies/node-yarn.md) |
 | `yarn install` fails with `command not found: if` / `fi` or `No matches found: "../config/uv/*"` | Yarn 4 is not supported on this branch | Use Node 20 LTS and Yarn 1 Classic: `corepack prepare yarn@1.22.22 --activate`, confirm `yarn -v` is `1.22.x`, then re-run `yarn install` |
 | `Unable to copy ... to tmp/solr-development` after Solr zip download | rubyzip 3 + old `solr_wrapper` extract API (fixed by local shim) | Use `RUBYOPT="-r./config/fcrepo_wrapper_compat"`; remove stray `var/` under the repo if present; re-run `solr_wrapper` (zip in `tmp/solr-download` is reused) |
 | Sidekiq / Rails / `db:seed` fails with `unknown keyword: :thread_safe` | Hyku Redis config + Sidekiq 7 | Use `RUBYOPT="-r./config/sidekiq_redis_compat"` for Sidekiq, Rails server, and `db:setup` / `db:seed` |
-| Homepage / Rails: `Errno::EROFS` or mkdir `/app` | `HYKU_CACHE_ROOT` still Docker default `/app/samvera/file_cache` | Set `HYKU_CACHE_ROOT="$PWD/tmp/hyku_file_cache"` in `.env.local.mac` ([environment.md](./environment.md)); re-source from repo root; restart Rails |
-| Seeds fail with connection to host `solr` / `RSolr::Error::ConnectionRefused` | `SOLR_HOST` still Docker default (`solr`), or Docker `.env` was sourced | Set `SOLR_HOST=localhost` and `SOLR_URL=http://127.0.0.1:8983/solr/` in `.env.local.mac` ([environment.md](./environment.md)); `unset SOLR_URL SOLR_HOST` if needed; re-source; ensure Solr listens on **8983**; re-run `db:seed` |
+| Homepage / Rails: `Errno::EROFS` or mkdir `/app` | `HYKU_CACHE_ROOT` still Docker default `/app/samvera/file_cache`, or a relative/`$PWD` path | Set an **absolute** `HYKU_CACHE_ROOT` in `.env.local.mac` ([environment.md](./environment.md): from the clone root run `echo "$PWD"/tmp/hyku_file_cache`, then paste into the file); hit Enter so direnv reloads; restart Rails |
+| `direnv: error … not allowed` / env empty in clone | `.envrc` not allowed yet, or direnv not hooked | From the clone root: `direnv allow`; confirm the zsh hook ([dependencies/direnv.md](./dependencies/direnv.md)) |
+| Env vars missing after editing `.env.local.mac` | Shell or long-running process still has old env | Hit Enter in the clone terminal (direnv reload); restart Rails/Sidekiq |
+| Seeds fail with connection to host `solr` / `RSolr::Error::ConnectionRefused` | `SOLR_HOST` still Docker default (`solr`), or Docker `.env` was sourced | Set `SOLR_HOST=localhost` and `SOLR_URL=http://127.0.0.1:8983/solr/` in `.env.local.mac` ([environment.md](./environment.md)); `unset SOLR_URL SOLR_HOST` if needed; hit Enter so direnv reloads; ensure Solr listens on **8983**; re-run `db:seed` |
 | Seeds fail | Solr/Fedora not ready | Start wrappers first, wait, re-run `db:seed` |
 | `uc:seed:samples` fails with missing single-tenant account | Stock Hyku `db:seed` not run yet | Finish [run-the-app.md](./run-the-app.md) `db:setup` / `db:seed` first, then re-run `rake uc:seed:samples` |
 | Solr/Fedora connection errors (app) | Dev wrappers not up, or Docker `.env` hosts loaded | Confirm ports **8983/8984**; set `SOLR_HOST=localhost` / unset Docker `SOLR_URL` / `FCREPO_HOST` |
@@ -33,37 +35,37 @@
 
 1. Check whether Homebrew installed Redis:
 
-```bash
+```
 brew list --versions redis
 ```
 
 If this prints nothing, install Redis:
 
-```bash
+```
 brew install redis
 ```
 
 2. Check where Homebrew put redis-cli:
 
-```bash
+```
 ls "$(brew --prefix redis)/bin/redis-cli"
 ```
 
 If this command says file not found, repair install:
 
-```bash
+```
 brew reinstall redis
 ```
 
 3. Refresh your shell command cache:
 
-```bash
+```
 hash -r
 ```
 
 4. Re-check command lookup:
 
-```bash
+```
 command -v redis-cli
 ```
 
@@ -71,17 +73,17 @@ If this now prints a path, the issue is fixed.
 
 5. If still missing, add Redis bin to PATH and reload shell:
 
-```bash
+```
 echo 'export PATH="$(brew --prefix redis)/bin:$PATH"' >> ~/.zshrc
 ```
 
-```bash
+```
 source ~/.zshrc
 ```
 
 6. Confirm again:
 
-```bash
+```
 command -v redis-cli
 redis-cli --version
 ```
@@ -92,7 +94,7 @@ If still missing after Step 6, collect outputs from Steps 1, 2, 4, and 6 and sha
 
 1. Check whether Java 8 is installed:
 
-```bash
+```
 /usr/libexec/java_home -v 1.8
 ```
 
@@ -102,29 +104,29 @@ If this prints an error about no matching Java version, continue to Step 2.
 
 2. Install Java 8:
 
-```bash
+```
 brew install --cask temurin@8
 ```
 
 Then re-check:
 
-```bash
+```
 /usr/libexec/java_home -v 1.8
 ```
 
 3. In the terminal where you run Fedora, activate Java 8:
 
-```bash
+```
 export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
 ```
 
-```bash
+```
 export PATH="$JAVA_HOME/bin:$PATH"
 ```
 
 4. Confirm active Java in that same terminal:
 
-```bash
+```
 java -version
 ```
 

--- a/docs/local/uc-hyku-customizations.manifest.yml
+++ b/docs/local/uc-hyku-customizations.manifest.yml
@@ -1,0 +1,184 @@
+# Machine-readable list of Scholar@UC customizations vs Hyku.
+# Human explanations: docs/local/uc-hyku-customizations.md
+# Enforced by: scripts/ci/check_uc_customizations.rb (CI job "UC customizations")
+#
+# When you add a customization:
+#   1. Add a path (or prefix) under entries below
+#   2. Document what/why in uc-hyku-customizations.md
+# When you remove one: delete the entry and the doc section.
+
+inventory_doc: docs/local/uc-hyku-customizations.md
+
+# Every on-disk file matching these globs must be covered by an entry
+# (exact path, or a prefix entry ending with / that covers it).
+watch_globs:
+  - app/services/uc/**
+  - lib/tasks/uc_*
+  - spec/services/uc/**
+  - spec/tasks/uc_*
+  - config/*_compat.rb
+  - .cursor/rules/**
+  - scripts/ci/**
+  - .envrc
+  - .env.local.mac.example
+  - .bundler-audit.yml
+  - config/brakeman.ignore
+  - docker-compose.ci.yml
+  - coverage/coverage_baseline.txt
+  - .github/workflows/ci.yml
+
+# Paths Hyku also ships that we patched. PR changes to these require updating
+# the inventory markdown in the same PR (enforced on pull_request).
+hyku_patched:
+  - README.md
+  - Gemfile
+  - Gemfile.lock
+  - .gitignore
+  - .solr_wrapper
+  - config/solr_wrapper_test.yml
+  - .github/workflows/verify_labels.yml
+  - .github/workflows/build-test-lint.yaml
+  - spec/rails_helper.rb
+  - spec/features/appearance_theme_spec.rb
+  - spec/features/show_page_theme_spec.rb
+  - spec/features/community_theme_spec.rb
+  - spec/features/cultural_repository_theme_spec.rb
+  - spec/features/institutional_repository_theme_spec.rb
+  - spec/features/collection_type_spec.rb
+  - spec/models/featured_collection_list_spec.rb
+  - yarn.lock
+
+# Registered customizations (path = file or directory prefix ending in /).
+# kind: uc_only | hyku_patched
+entries:
+  - path: docs/local/
+    kind: uc_only
+    id: local-docs
+
+  - path: .env.local.mac.example
+    kind: uc_only
+    id: env-template
+
+  - path: .envrc
+    kind: uc_only
+    id: direnv
+
+  - path: README.md
+    kind: hyku_patched
+    id: readme-pointer
+
+  - path: config/sidekiq_redis_compat.rb
+    kind: uc_only
+    id: sidekiq-redis-compat
+
+  - path: config/fcrepo_wrapper_compat.rb
+    kind: uc_only
+    id: fcrepo-wrapper-compat
+
+  - path: .solr_wrapper
+    kind: hyku_patched
+    id: solr-wrapper-dev
+
+  - path: config/solr_wrapper_test.yml
+    kind: hyku_patched
+    id: solr-wrapper-test
+
+  - path: Gemfile
+    kind: hyku_patched
+    id: security-gems
+
+  - path: Gemfile.lock
+    kind: hyku_patched
+    id: security-gems-lock
+
+  - path: config/brakeman.ignore
+    kind: uc_only
+    id: brakeman-baseline
+
+  - path: .bundler-audit.yml
+    kind: uc_only
+    id: bundler-audit-baseline
+
+  - path: .github/workflows/ci.yml
+    kind: uc_only
+    id: ci-workflow
+
+  - path: docker-compose.ci.yml
+    kind: uc_only
+    id: docker-compose-ci
+
+  - path: scripts/ci/
+    kind: uc_only
+    id: ci-scripts
+
+  - path: coverage/coverage_baseline.txt
+    kind: uc_only
+    id: coverage-baseline
+
+  - path: .github/workflows/verify_labels.yml
+    kind: hyku_patched
+    id: verify-labels
+
+  - path: .github/workflows/build-test-lint.yaml
+    kind: hyku_patched
+    id: build-test-lint-guard
+
+  - path: spec/rails_helper.rb
+    kind: hyku_patched
+    id: rails-helper-ci
+
+  - path: spec/features/appearance_theme_spec.rb
+    kind: hyku_patched
+    id: flaky-appearance-theme
+
+  - path: spec/features/show_page_theme_spec.rb
+    kind: hyku_patched
+    id: flaky-show-page-theme
+
+  - path: spec/features/community_theme_spec.rb
+    kind: hyku_patched
+    id: flaky-community-theme
+
+  - path: spec/features/cultural_repository_theme_spec.rb
+    kind: hyku_patched
+    id: flaky-cultural-theme
+
+  - path: spec/features/institutional_repository_theme_spec.rb
+    kind: hyku_patched
+    id: flaky-institutional-theme
+
+  - path: spec/features/collection_type_spec.rb
+    kind: hyku_patched
+    id: flaky-collection-type
+
+  - path: spec/models/featured_collection_list_spec.rb
+    kind: hyku_patched
+    id: flaky-featured-collection-list
+
+  - path: yarn.lock
+    kind: hyku_patched
+    id: yarn-lock
+
+  - path: .gitignore
+    kind: hyku_patched
+    id: gitignore-uc
+
+  - path: .cursor/rules/
+    kind: uc_only
+    id: cursor-rules
+
+  - path: app/services/uc/
+    kind: uc_only
+    id: uc-sample-seed-service
+
+  - path: lib/tasks/uc_sample_seeds.rake
+    kind: uc_only
+    id: uc-sample-seed-rake
+
+  - path: spec/services/uc/
+    kind: uc_only
+    id: uc-sample-seed-specs
+
+  - path: spec/tasks/uc_sample_seeds_rake_spec.rb
+    kind: uc_only
+    id: uc-sample-seed-rake-spec

--- a/docs/local/uc-hyku-customizations.manifest.yml
+++ b/docs/local/uc-hyku-customizations.manifest.yml
@@ -19,6 +19,7 @@ watch_globs:
   - config/*_compat.rb
   - .cursor/rules/**
   - scripts/ci/**
+  - lib/uc/**
   - .envrc
   - .env.local.mac.example
   - .bundler-audit.yml
@@ -110,6 +111,10 @@ entries:
   - path: scripts/ci/
     kind: uc_only
     id: ci-scripts
+
+  - path: lib/uc/
+    kind: uc_only
+    id: uc-lib
 
   - path: coverage/coverage_baseline.txt
     kind: uc_only

--- a/docs/local/uc-hyku-customizations.md
+++ b/docs/local/uc-hyku-customizations.md
@@ -79,6 +79,7 @@ See [github-actions.md](./github-actions.md) for the CI job name.
 | `scripts/ci/coverage_gate.sh` | **Keep** | Compares merged SimpleCov % to baseline (0.5pt tolerance); PR ratchet can bump baseline. |
 | `scripts/ci/merge_coverage.rb` | **Keep** | `SimpleCov.collate` across shard resultsets. |
 | `scripts/ci/check_uc_customizations.rb` | **Keep** | Enforces this inventory + manifest (see above). |
+| `lib/uc/hyku_customizations_inventory.rb` | **Keep** | Inventory check logic used by the CI script (and specs). |
 | `coverage/coverage_baseline.txt` | **Keep** | Committed coverage floor for the gate. |
 | `.github/workflows/verify_labels.yml` | **Conflict likely** | Restricted to PRs into **`main`** so feature PRs into `hyku-oob` do not need Hyku release labels. Restore if upstream resets to `branches: ['**']`. |
 | `.github/workflows/build-test-lint.yaml` | **Conflict likely** | Jobs gated with `if: github.repository == 'samvera/hyku'` so this fork does not publish to `ghcr.io/samvera/hyku`. Re-apply guards after merge if lost. |

--- a/docs/local/uc-hyku-customizations.md
+++ b/docs/local/uc-hyku-customizations.md
@@ -1,0 +1,158 @@
+# Scholar@UC customizations vs Hyku
+
+**These notes are for the `hyku-oob` lineage.** Team index: [docs/local/README.md](./README.md).
+
+This is the **canonical inventory** of what we changed relative to upstream Samvera Hyku. Use it when merging Hyku updates (`git merge hyku/main` or a Hyku tag) so you know what to **keep**, what will **conflict**, and what is safe to **take from upstream**.
+
+Merge how-to: [updating-from-hyku.md](./updating-from-hyku.md).
+
+Path list used by CI: [uc-hyku-customizations.manifest.yml](./uc-hyku-customizations.manifest.yml).
+
+## How to keep this document honest
+
+Full “auto-document every change with a good why” is not reliable in CI. Instead we enforce **registration**:
+
+1. **Every UC path** that matches the watch list in the manifest must appear in that manifest (new file under `app/services/uc/`, new `config/*_compat.rb`, etc. → add a manifest entry **and** a short section here).
+2. **CI fails** if the repo has watched files that are missing from the manifest, or if a PR changes a listed customization without also updating **this** markdown file (so the “why” cannot silently rot).
+3. When you only edit prose under `docs/local/` that is not this inventory, you do **not** need to touch this file — the whole `docs/local/` tree is already one UC-owned customization.
+
+See [github-actions.md](./github-actions.md) for the CI job name.
+
+---
+
+## Legend
+
+| Merge risk | Meaning |
+|------------|---------|
+| **Keep** | UC-only (Hyku has no counterpart). Always keep ours. |
+| **Conflict likely** | Hyku ships the file; we patched it. Expect a merge conflict — keep our behavior, take upstream improvements carefully. |
+| **Safe overwrite** | Prefer Hyku’s version; re-check only if our docs assumed old upstream behavior. |
+
+---
+
+## 1. Local macOS docs and env
+
+| Path | Risk | What / why |
+|------|------|------------|
+| `docs/local/**` | **Keep** | Scholar@UC source of truth for no-Docker Mac setup (services, DB seed, tests, troubleshooting). Upstream Hyku docs stay under `docs/*.md` and may change on merge — do not treat them as our local guide. |
+| `.env.local.mac.example` | **Keep** | Committed template for personal `.env.local.mac` (localhost DB/Solr/Redis, Sidekiq queue, absolute `HYKU_CACHE_ROOT`, admin seed creds). Do **not** replace with Docker `.env`. |
+| `.envrc` | **Keep** | direnv loads `.env.local.mac` in this clone only and unloads when you leave (multi-app safe). Setup: [dependencies/direnv.md](./dependencies/direnv.md). |
+| `README.md` (top pointer only) | **Conflict likely** | Short Scholar@UC / `hyku-oob` blurb pointing at `docs/local/`. After a Hyku merge, **re-apply** that pointer if upstream wiped it; keep the rest of the Hyku README. |
+
+**Conflicts / issues:** Developers who source Docker `.env` get wrong hosts (`solr`, `db`). `HYKU_CACHE_ROOT` must be an absolute path (see [environment.md](./environment.md)).
+
+---
+
+## 2. Local runtime shims (Solr / Fedora / Sidekiq)
+
+| Path | Risk | What / why |
+|------|------|------------|
+| `config/sidekiq_redis_compat.rb` | **Keep** | Preload via `RUBYOPT=-r./config/sidekiq_redis_compat`. Strips legacy Redis `thread_safe:` so Sidekiq 7 / redis-client boot. Used for Rails, Sidekiq, `db:setup`, seeds. |
+| `config/fcrepo_wrapper_compat.rb` | **Keep** | Preload for `solr_wrapper` / `fcrepo_wrapper`. Ruby 3.3 + rubyzip 3 fixes (e.g. `File.exists?`, zip extract) so wrappers run on modern Ruby. |
+| `.solr_wrapper` | **Conflict likely** | Pins Solr **7.4.0**, port **8983**, download/install under `tmp/solr-download` and `tmp/solr-development` (avoids path/space issues and matches local docs). |
+| `config/solr_wrapper_test.yml` | **Conflict likely** | Same download strategy for test Solr on **8985** / `tmp/solr-test`. |
+
+**Not UC-patched (take Hyku):** `.fcrepo_wrapper`, `config/fcrepo_wrapper_test.yml` — docs still tell you to use the compat preload.
+
+**Conflicts / issues:** Forgetting `RUBYOPT` → Sidekiq/`db:seed` fail with `unknown keyword: :thread_safe`, or Solr extract errors. Mixing dev ports (8983/8984) with test ports (8985/8986) causes confusing failures.
+
+---
+
+## 3. Security gems and baselines
+
+| Path | Risk | What / why |
+|------|------|------------|
+| `Gemfile` / `Gemfile.lock` (`brakeman`, `bundler-audit`) | **Conflict likely** | Dev/test gems so CI can run security scans on this fork. |
+| `config/brakeman.ignore` | **Keep** | Baselines **known** Hyku OOB findings so CI fails only on **new** Medium/High issues. |
+| `.bundler-audit.yml` | **Keep** | Ignores advisories already present in the Hyku lockfile until upstream upgrades; new unignored advisories still fail CI. |
+
+**Conflicts / issues:** Blindly deleting ignore entries will fail CI on legacy Hyku findings. After a Hyku gem bump, re-run scanners and shrink ignores when possible.
+
+---
+
+## 4. GitHub Actions / CI (this fork)
+
+| Path | Risk | What / why |
+|------|------|------------|
+| `.github/workflows/ci.yml` | **Keep** | Scholar@UC CI on **`hyku-oob`**: RuboCop, Brakeman/bundler-audit, six RSpec shards, coverage gate, **UC customizations check**. Not Hyku’s image-publish pipeline. |
+| `docker-compose.ci.yml` | **Keep** | Postgres/Redis/Solr/ZooKeeper/Fedora/Chrome for GHA shards only. Local Mac setup stays no-Docker. |
+| `scripts/ci/coverage_gate.sh` | **Keep** | Compares merged SimpleCov % to baseline (0.5pt tolerance); PR ratchet can bump baseline. |
+| `scripts/ci/merge_coverage.rb` | **Keep** | `SimpleCov.collate` across shard resultsets. |
+| `scripts/ci/check_uc_customizations.rb` | **Keep** | Enforces this inventory + manifest (see above). |
+| `coverage/coverage_baseline.txt` | **Keep** | Committed coverage floor for the gate. |
+| `.github/workflows/verify_labels.yml` | **Conflict likely** | Restricted to PRs into **`main`** so feature PRs into `hyku-oob` do not need Hyku release labels. Restore if upstream resets to `branches: ['**']`. |
+| `.github/workflows/build-test-lint.yaml` | **Conflict likely** | Jobs gated with `if: github.repository == 'samvera/hyku'` so this fork does not publish to `ghcr.io/samvera/hyku`. Re-apply guards after merge if lost. |
+
+Details: [github-actions.md](./github-actions.md).
+
+---
+
+## 5. Spec / CI reliability patches (Hyku files we changed)
+
+| Path | Risk | What / why |
+|------|------|------------|
+| `spec/rails_helper.rb` | **Conflict likely** | CI wait / animation / Selenium options / safer Capybara reset for Actions + remote Chrome. |
+| `spec/features/appearance_theme_spec.rb` | **Conflict likely** | `xit` flaky theme saves under remote Capybara. |
+| `spec/features/show_page_theme_spec.rb` | **Conflict likely** | same |
+| `spec/features/community_theme_spec.rb` | **Conflict likely** | same |
+| `spec/features/cultural_repository_theme_spec.rb` | **Conflict likely** | same |
+| `spec/features/institutional_repository_theme_spec.rb` | **Conflict likely** | same |
+| `spec/features/collection_type_spec.rb` | **Conflict likely** | `xit` flaky mid-redirect |
+| `spec/models/featured_collection_list_spec.rb` | **Conflict likely** | `xit` flaky sort assumption |
+| `yarn.lock` | **Conflict likely** | Lockfile refresh for Yarn 1 / local install; prefer regenerate carefully rather than hand-merging. |
+
+**Conflicts / issues:** Re-enabling `xit` examples without fixing flake will burn CI time. Prefer upstream fixes when Hyku hardens these specs.
+
+---
+
+## 6. UC sample seeds (local demo data)
+
+| Path | Risk | What / why |
+|------|------|------------|
+| `app/services/uc/sample_seed_service.rb` | **Keep** | Adapts Scholar@UC `develop` sample users/works onto Hyku OOB models (`GenericWork` / `Image` / `Etd`). Idempotent Fedora marker; uses `INITIAL_ADMIN_PASSWORD`; refuses production/staging; AF AdminSet + Sipity workflows. |
+| `lib/tasks/uc_sample_seeds.rake` | **Keep** | `rake uc:seed:samples` with clear `RESULT: OK/FAILED` banners. |
+| `spec/services/uc/sample_seed_service_spec.rb` | **Keep** | Fast stubbed coverage of UC-owned behavior. |
+| `spec/tasks/uc_sample_seeds_rake_spec.rb` | **Keep** | Task output / error handling. |
+
+**Not UC-owned:** `db/seeds/sample/**` (stock Hyku assets the service may use) — **safe overwrite**.
+
+**Conflicts / issues:** Must run stock Hyku `db:setup` / `db:seed` first (tenant + workflows). Does not replace Hyku `db/seeds.rb`.
+
+---
+
+## 7. Cursor / agent rules
+
+| Path | Risk | What / why |
+|------|------|------------|
+| `.cursor/rules/*.mdc` | **Keep** | Team agent guidance (docs voice, PR base branch `hyku-oob`, no push without ask, review passes, etc.). Hyku does not ship these. |
+
+---
+
+## 8. `.gitignore` UC hunks
+
+| Path | Risk | What / why |
+|------|------|------------|
+| `.gitignore` | **Conflict likely** | Allows committing `.env.local.mac.example` and `coverage/coverage_baseline.txt`; ignores personal `.env.local.mac`, Yarn noise, `var/`, etc. |
+
+---
+
+## Quick merge checklist
+
+After `git merge hyku/main` (or a Hyku tag):
+
+1. Restore `README.md` Scholar@UC pointer if missing.
+2. Confirm `verify_labels.yml` is **main-only** and `build-test-lint.yaml` still has the `samvera/hyku` repository guards.
+3. Re-resolve `Gemfile` / lockfile; keep `brakeman` + `bundler-audit`; refresh ignore baselines if upstream fixed findings.
+4. Keep `config/*_compat.rb`, `.envrc`, `.env.local.mac.example`, `docs/local/**`, `.github/workflows/ci.yml`, `docker-compose.ci.yml`, `scripts/ci/**`, `app/services/uc/**`.
+5. Re-check `.solr_wrapper` / `config/solr_wrapper_test.yml` pins vs upstream.
+6. Run `ruby scripts/ci/check_uc_customizations.rb` (and update this doc + manifest if you added or dropped customizations).
+7. Skim upstream `docs/*.md` for new Hyku guidance; leave our procedures in `docs/local/` only.
+
+---
+
+## Related
+
+- [Updating from Hyku](./updating-from-hyku.md)
+- [GitHub Actions](./github-actions.md)
+- [Environment / direnv](./environment.md)
+- [Start services](./start-services.md)

--- a/docs/local/updating-from-hyku.md
+++ b/docs/local/updating-from-hyku.md
@@ -2,6 +2,10 @@
 
 Our UC setup docs live under **`docs/local/`**. Keep detailed UC procedures there.
 
+**Canonical inventory of every Scholar@UC customization vs Hyku** (what to keep on merge, conflicts, why):  
+**[uc-hyku-customizations.md](./uc-hyku-customizations.md)**  
+(CI enforces the companion [uc-hyku-customizations.manifest.yml](./uc-hyku-customizations.manifest.yml).)
+
 We also keep a **short Scholar@UC pointer** at the top of the root `README.md` (links to `docs/local/` and `.env.local.mac.example`). Upstream Hyku merges may overwrite that pointer — put it back after a merge if it disappears.
 
 ## Where things live
@@ -11,14 +15,17 @@ We also keep a **short Scholar@UC pointer** at the top of the root `README.md` (
 | `README.md` (repo root) | **Hyku** + short UC pointer at top | Hyku content updates; re-add the UC pointer if lost |
 | `docs/local/**` | **UC** | Untouched (Hyku does not ship this tree) |
 | `.env.local.mac.example` | **UC** (local no-Docker template) | Keep ours; do not replace with Docker `.env` |
+| `.envrc` | **UC** (direnv → `.env.local.mac`) | Keep ours |
 | `docs/getting-started.md`, `docs/configuration.md`, … | **Hyku** | Updates normally |
-| App code, `.env`, Docker files | **Hyku** (+ our later customizations) | Merged normally |
+| App code, `.env`, Docker files | **Hyku** (+ our later customizations) | Merged normally — see [uc-hyku-customizations.md](./uc-hyku-customizations.md) for the full list |
+
+For CI workflows, security gems, wrapper shims, flaky-spec patches, and sample seeds, use the inventory — do not rely on this short table alone.
 
 ## How to pull Hyku updates
 
 Use a normal merge (no special helper):
 
-```bash
+```
 git checkout hyku-oob   # or your branch based on it
 git fetch hyku
 git merge hyku/main

--- a/docs/local/versions-and-ports.md
+++ b/docs/local/versions-and-ports.md
@@ -44,4 +44,4 @@ You can run the app stack and the test stack at the same time because the ports 
 
 ## Next
 
-- [Start dependency setup](./dependencies/01-homebrew.md)
+- [Start dependency setup](./dependencies/homebrew.md)

--- a/lib/tasks/uc_sample_seeds.rake
+++ b/lib/tasks/uc_sample_seeds.rake
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# UC-local sample works adapted from Scholar@UC develop db/seeds.rb.
+# Requires stock Hyku db:seed first (tenant, admin set, workflows).
+# Solr + Fedora must be running.
+#
+#   RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec rake uc:seed:samples
+#
+namespace :uc do
+  namespace :seed do
+    desc 'Create UC sample users/works adapted from develop seeds (Hyku-compatible)'
+    task samples: :environment do
+      result = Uc::SampleSeedService.call
+      $stdout.puts
+      $stdout.puts('=' * 60)
+      case result.status
+      when :skipped
+        $stdout.puts('RESULT: OK — UC sample seeds already present (skipped).')
+        $stdout.puts('This is success, not a failure. Nothing was changed.')
+      when :created
+        $stdout.puts('RESULT: OK — UC sample seeds completed successfully.')
+        $stdout.puts("Sample account password: #{result.password}")
+        $stdout.puts("Objects indexed: #{result.created_count}")
+        $stdout.puts('Sign in with manydeposits@example.com (etc.) or INITIAL_ADMIN_*.')
+      else
+        $stdout.puts("RESULT: OK — #{result.status}")
+      end
+      $stdout.puts('=' * 60)
+    rescue StandardError => e
+      $stdout.puts
+      $stdout.puts('=' * 60)
+      $stdout.puts("RESULT: FAILED — #{e.class}: #{e.message}")
+      $stdout.puts('=' * 60)
+      raise
+    end
+  end
+end

--- a/lib/tasks/uc_sample_seeds.rake
+++ b/lib/tasks/uc_sample_seeds.rake
@@ -2,7 +2,7 @@
 
 # UC-local sample works adapted from Scholar@UC develop db/seeds.rb.
 # Requires stock Hyku db:seed first (tenant, admin set, workflows).
-# Solr + Fedora must be running.
+# Solr + Fedora must be running. Refuses production and staging.
 #
 #   RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec rake uc:seed:samples
 #
@@ -19,9 +19,10 @@ namespace :uc do
         $stdout.puts('This is success, not a failure. Nothing was changed.')
       when :created
         $stdout.puts('RESULT: OK — UC sample seeds completed successfully.')
-        $stdout.puts("Sample account password: #{result.password}")
+        $stdout.puts('Sample accounts use INITIAL_ADMIN_PASSWORD from .env.local.mac')
+        $stdout.puts('(same password as the Hyku db:seed admin user).')
         $stdout.puts("Objects indexed: #{result.created_count}")
-        $stdout.puts('Sign in with manydeposits@example.com (etc.) or INITIAL_ADMIN_*.')
+        $stdout.puts('Sign in with manydeposits@example.com (etc.) or INITIAL_ADMIN_EMAIL.')
       else
         $stdout.puts("RESULT: OK — #{result.status}")
       end

--- a/lib/uc/hyku_customizations_inventory.rb
+++ b/lib/uc/hyku_customizations_inventory.rb
@@ -2,7 +2,7 @@
 
 require 'pathname'
 require 'yaml'
-require 'english'
+require 'English'
 require 'shellwords'
 
 module Uc

--- a/lib/uc/hyku_customizations_inventory.rb
+++ b/lib/uc/hyku_customizations_inventory.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require 'pathname'
+require 'yaml'
+require 'english'
+require 'shellwords'
+
+module Uc
+  # Inventory check for Scholar@UC customizations vs Hyku (CI + local).
+  class HykuCustomizationsInventory
+    MANIFEST_REL = 'docs/local/uc-hyku-customizations.manifest.yml'
+
+    Result = Struct.new(:ok, :errors, :inventory_doc, :entries_count, :watched_count, keyword_init: true)
+
+    def initialize(root: Pathname.pwd, env: ENV)
+      @root = Pathname.new(root).expand_path
+      @env = env
+    end
+
+    def call
+      manifest = load_manifest
+      entries = Array(manifest['entries'])
+      inventory_doc = manifest['inventory_doc'].to_s
+      hyku_patched = Array(manifest['hyku_patched'])
+      watched_files = expand_watch_globs(Array(manifest['watch_globs']))
+
+      errors = []
+      errors.concat(missing_inventory_doc_errors(inventory_doc))
+      errors.concat(missing_entry_errors(entries))
+      errors.concat(unlisted_watched_file_errors(watched_files, entries))
+      errors.concat(hyku_patched_kind_errors(hyku_patched, entries))
+      errors.concat(PrEnforcer.new(@root, @env).errors(entries, hyku_patched, inventory_doc))
+
+      Result.new(
+        ok: errors.empty?,
+        errors: errors,
+        inventory_doc: inventory_doc,
+        entries_count: entries.size,
+        watched_count: watched_files.size
+      )
+    end
+
+    def covered_by_entry?(rel_path, entries)
+      entries.any? { |entry| self.class.path_covers?(entry['path'].to_s, rel_path) }
+    end
+
+    def self.path_covers?(entry_path, rel_path)
+      if entry_path.end_with?('/')
+        rel_path == entry_path.delete_suffix('/') || rel_path.start_with?(entry_path)
+      else
+        rel_path == entry_path
+      end
+    end
+
+    # PR diff gate: require inventory/manifest updates when customizations change.
+    class PrEnforcer
+      def initialize(root, env)
+        @root = root
+        @env = env
+      end
+
+      def errors(entries, hyku_patched, inventory_doc)
+        return [] unless enforce?
+
+        missing = missing_sha_errors
+        return missing if missing.any?
+
+        base = @env['UC_CUSTOMIZATIONS_BASE_SHA'].to_s
+        head = @env['UC_CUSTOMIZATIONS_HEAD_SHA'].to_s
+        changed = git_changed_files(base, head)
+        return ["PR enforcement: git diff failed for #{base}...#{head}"] unless changed
+        return [] if changed.empty?
+
+        triggers = trigger_files(changed, entries, hyku_patched, inventory_doc)
+        return [] if triggers.empty?
+        return [] if inventory_updated?(changed, inventory_doc)
+
+        [
+          'PR changes UC customizations but does not update ' \
+          "#{inventory_doc} (or the manifest). Changed: #{triggers.sort.join(', ')}"
+        ]
+      end
+
+      private
+
+      def enforce?
+        @env['GITHUB_EVENT_NAME'] == 'pull_request' || @env['UC_CUSTOMIZATIONS_ENFORCE_PR'] == '1'
+      end
+
+      def missing_sha_errors
+        base = @env['UC_CUSTOMIZATIONS_BASE_SHA'].to_s
+        head = @env['UC_CUSTOMIZATIONS_HEAD_SHA'].to_s
+        return [] unless base.empty? || head.empty?
+
+        [
+          'PR enforcement enabled but UC_CUSTOMIZATIONS_BASE_SHA / ' \
+          'UC_CUSTOMIZATIONS_HEAD_SHA are not both set'
+        ]
+      end
+
+      def trigger_files(changed, entries, hyku_patched, inventory_doc)
+        changed.filter_map do |file|
+          next if file == inventory_doc || file == MANIFEST_REL
+          next if file.start_with?('docs/local/') && file != inventory_doc
+
+          file if hyku_patched.include?(file) || covered_customization?(file, entries)
+        end
+      end
+
+      def covered_customization?(file, entries)
+        !file.start_with?('docs/local/') &&
+          entries.any? { |entry| HykuCustomizationsInventory.path_covers?(entry['path'].to_s, file) }
+      end
+
+      def inventory_updated?(changed, inventory_doc)
+        changed.include?(inventory_doc) || changed.include?(MANIFEST_REL)
+      end
+
+      # Returns an Array of paths, or nil when git fails.
+      def git_changed_files(base_sha, head_sha)
+        cmd = [
+          'git', '-C', @root.to_s,
+          'diff', '--name-only', '--diff-filter=ACMR',
+          "#{base_sha}...#{head_sha}"
+        ]
+        out = `#{Shellwords.join(cmd)} 2>/dev/null`
+        return nil unless $CHILD_STATUS.success?
+
+        out.split("\n").map(&:strip).reject(&:empty?)
+      end
+    end
+
+    private
+
+    def load_manifest
+      path = @root.join(MANIFEST_REL)
+      raise "Missing #{MANIFEST_REL}" unless path.file?
+
+      YAML.safe_load(path.read, permitted_classes: [], aliases: false) || {}
+    end
+
+    def expand_watch_globs(watch_globs)
+      watch_globs.flat_map { |glob| expand_glob(glob) }.uniq.sort
+    end
+
+    def expand_glob(pattern)
+      Dir.glob(@root.join(pattern).to_s, File::FNM_EXTGLOB).filter_map do |abs|
+        rel = Pathname.new(abs).relative_path_from(@root).to_s
+        rel unless rel.end_with?('/')
+      end
+    end
+
+    def missing_inventory_doc_errors(inventory_doc)
+      return [] if @root.join(inventory_doc).file?
+
+      ["inventory_doc missing: #{inventory_doc}"]
+    end
+
+    def missing_entry_errors(entries)
+      entries.filter_map do |entry|
+        path = entry['path'].to_s
+        next if entry['allow_missing'] || path.empty?
+        next if @root.join(path.delete_suffix('/')).exist?
+
+        "manifest entry missing on disk: #{path} (id=#{entry['id']})"
+      end
+    end
+
+    def unlisted_watched_file_errors(watched_files, entries)
+      watched_files.filter_map do |file|
+        next if covered_by_entry?(file, entries)
+
+        "watched file not listed in manifest entries: #{file}"
+      end
+    end
+
+    def hyku_patched_kind_errors(hyku_patched, entries)
+      hyku_patched.filter_map do |path|
+        entry = entries.find { |candidate| candidate['path'].to_s == path }
+        if entry.nil?
+          "hyku_patched path not registered in entries: #{path}"
+        elsif entry['kind'].to_s != 'hyku_patched'
+          "hyku_patched path #{path} must have kind: hyku_patched (got #{entry['kind'].inspect})"
+        end
+      end
+    end
+  end
+end

--- a/scripts/ci/check_uc_customizations.rb
+++ b/scripts/ci/check_uc_customizations.rb
@@ -2,139 +2,25 @@
 # frozen_string_literal: true
 
 # Enforces docs/local/uc-hyku-customizations.manifest.yml against the repo.
-#
-# Checks:
-# 1) Every manifest entry path exists (unless allow_missing: true).
-# 2) Every on-disk file matching watch_globs is covered by a manifest entry.
-# 3) On pull_request (GITHUB_EVENT_NAME=pull_request): if the PR changes a
-#    hyku_patched path or a watched customization file (other than docs/local/
-#    prose), the inventory markdown must also change in the PR.
+# See lib/uc/hyku_customizations_inventory.rb
 #
 # Usage:
 #   ruby scripts/ci/check_uc_customizations.rb
-#   UC_CUSTOMIZATIONS_BASE_SHA=abc123 UC_CUSTOMIZATIONS_HEAD_SHA=def456 \
-#     ruby scripts/ci/check_uc_customizations.rb
 
-require 'pathname'
-require 'yaml'
-require 'english'
+require_relative '../../lib/uc/hyku_customizations_inventory'
 
-ROOT = Pathname.new(__dir__).join('../..').expand_path
-MANIFEST_PATH = ROOT.join('docs/local/uc-hyku-customizations.manifest.yml')
+result = Uc::HykuCustomizationsInventory.new.call
 
-def fail_with(messages)
+unless result.ok
   warn 'UC customizations check failed:'
-  messages.each { |m| warn "  - #{m}" }
+  result.errors.each { |message| warn "  - #{message}" }
   warn ''
   warn 'Update docs/local/uc-hyku-customizations.md and'
   warn 'docs/local/uc-hyku-customizations.manifest.yml (see the doc header).'
   exit 1
 end
 
-def load_manifest
-  fail_with(["Missing #{MANIFEST_PATH.relative_path_from(ROOT)}"]) unless MANIFEST_PATH.file?
-
-  YAML.safe_load(MANIFEST_PATH.read, permitted_classes: [], aliases: false) || {}
-end
-
-def expand_glob(pattern)
-  Dir.glob(ROOT.join(pattern).to_s, File::FNM_EXTGLOB).map do |abs|
-    Pathname.new(abs).relative_path_from(ROOT).to_s
-  end.reject { |p| p.end_with?('/') }
-end
-
-def covered_by_entry?(rel_path, entries)
-  entries.any? do |entry|
-    path = entry['path'].to_s
-    if path.end_with?('/')
-      rel_path == path.delete_suffix('/') || rel_path.start_with?(path)
-    else
-      rel_path == path
-    end
-  end
-end
-
-def git_changed_files(base_sha, head_sha)
-  return [] if base_sha.to_s.empty? || head_sha.to_s.empty?
-
-  out = `git -C #{ROOT} diff --name-only --diff-filter=ACMR #{base_sha}...#{head_sha} 2>/dev/null`
-  return [] unless $CHILD_STATUS.success?
-
-  out.split("\n").map(&:strip).reject(&:empty?)
-end
-
-manifest = load_manifest
-entries = Array(manifest['entries'])
-inventory_doc = manifest['inventory_doc'].to_s
-watch_globs = Array(manifest['watch_globs'])
-hyku_patched = Array(manifest['hyku_patched'])
-errors = []
-
-errors << "inventory_doc missing: #{inventory_doc}" unless ROOT.join(inventory_doc).file?
-
-entries.each do |entry|
-  path = entry['path'].to_s
-  next if entry['allow_missing']
-  next if path.empty?
-
-  abs = ROOT.join(path.delete_suffix('/'))
-  unless abs.exist?
-    errors << "manifest entry missing on disk: #{path} (id=#{entry['id']})"
-  end
-end
-
-watched_files = watch_globs.flat_map { |g| expand_glob(g) }.uniq.sort
-undocumented = watched_files.reject { |f| covered_by_entry?(f, entries) }
-undocumented.each do |f|
-  errors << "watched file not listed in manifest entries: #{f}"
-end
-
-hyku_patched.each do |path|
-  next if entries.any? { |e| e['path'].to_s == path && e['kind'].to_s == 'hyku_patched' }
-
-  # Directory-style coverage is not used for hyku_patched list; require exact entry.
-  unless entries.any? { |e| e['path'].to_s == path }
-    errors << "hyku_patched path not registered in entries: #{path}"
-  end
-end
-
-# PR change enforcement
-event = ENV.fetch('GITHUB_EVENT_NAME', '')
-base_sha = ENV['UC_CUSTOMIZATIONS_BASE_SHA'] || ENV['GITHUB_EVENT_PULL_REQUEST_BASE_SHA']
-head_sha = ENV['UC_CUSTOMIZATIONS_HEAD_SHA'] || ENV['GITHUB_SHA']
-
-# Actions sets GITHUB_EVENT_PATH; prefer explicit env from the workflow.
-if event == 'pull_request' || ENV['UC_CUSTOMIZATIONS_ENFORCE_PR'] == '1'
-  changed = git_changed_files(base_sha, head_sha)
-  if changed.any?
-    inventory_changed = changed.include?(inventory_doc) ||
-                        changed.include?('docs/local/uc-hyku-customizations.manifest.yml')
-
-    triggers = []
-    changed.each do |file|
-      next if file == inventory_doc
-      next if file == 'docs/local/uc-hyku-customizations.manifest.yml'
-      # Pure local-doc edits (other than inventory) do not require inventory churn.
-      next if file.start_with?('docs/local/') && file != inventory_doc
-
-      if hyku_patched.include?(file)
-        triggers << file
-        next
-      end
-
-      triggers << file if covered_by_entry?(file, entries) && !file.start_with?('docs/local/')
-    end
-
-    if triggers.any? && !inventory_changed
-      errors << 'PR changes UC customizations but does not update ' \
-                "#{inventory_doc} (or the manifest). Changed: #{triggers.sort.join(', ')}"
-    end
-  end
-end
-
-fail_with(errors) if errors.any?
-
 puts 'UC customizations check passed.'
-puts "  inventory: #{inventory_doc}"
-puts "  entries: #{entries.size}"
-puts "  watched files covered: #{watched_files.size}"
+puts "  inventory: #{result.inventory_doc}"
+puts "  entries: #{result.entries_count}"
+puts "  watched files covered: #{result.watched_count}"

--- a/scripts/ci/check_uc_customizations.rb
+++ b/scripts/ci/check_uc_customizations.rb
@@ -1,0 +1,140 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Enforces docs/local/uc-hyku-customizations.manifest.yml against the repo.
+#
+# Checks:
+# 1) Every manifest entry path exists (unless allow_missing: true).
+# 2) Every on-disk file matching watch_globs is covered by a manifest entry.
+# 3) On pull_request (GITHUB_EVENT_NAME=pull_request): if the PR changes a
+#    hyku_patched path or a watched customization file (other than docs/local/
+#    prose), the inventory markdown must also change in the PR.
+#
+# Usage:
+#   ruby scripts/ci/check_uc_customizations.rb
+#   UC_CUSTOMIZATIONS_BASE_SHA=abc123 UC_CUSTOMIZATIONS_HEAD_SHA=def456 \
+#     ruby scripts/ci/check_uc_customizations.rb
+
+require 'pathname'
+require 'yaml'
+require 'english'
+
+ROOT = Pathname.new(__dir__).join('../..').expand_path
+MANIFEST_PATH = ROOT.join('docs/local/uc-hyku-customizations.manifest.yml')
+
+def fail_with(messages)
+  warn 'UC customizations check failed:'
+  messages.each { |m| warn "  - #{m}" }
+  warn ''
+  warn 'Update docs/local/uc-hyku-customizations.md and'
+  warn 'docs/local/uc-hyku-customizations.manifest.yml (see the doc header).'
+  exit 1
+end
+
+def load_manifest
+  fail_with(["Missing #{MANIFEST_PATH.relative_path_from(ROOT)}"]) unless MANIFEST_PATH.file?
+
+  YAML.safe_load(MANIFEST_PATH.read, permitted_classes: [], aliases: false) || {}
+end
+
+def expand_glob(pattern)
+  Dir.glob(ROOT.join(pattern).to_s, File::FNM_EXTGLOB).map do |abs|
+    Pathname.new(abs).relative_path_from(ROOT).to_s
+  end.reject { |p| p.end_with?('/') }
+end
+
+def covered_by_entry?(rel_path, entries)
+  entries.any? do |entry|
+    path = entry['path'].to_s
+    if path.end_with?('/')
+      rel_path == path.delete_suffix('/') || rel_path.start_with?(path)
+    else
+      rel_path == path
+    end
+  end
+end
+
+def git_changed_files(base_sha, head_sha)
+  return [] if base_sha.to_s.empty? || head_sha.to_s.empty?
+
+  out = `git -C #{ROOT} diff --name-only --diff-filter=ACMR #{base_sha}...#{head_sha} 2>/dev/null`
+  return [] unless $CHILD_STATUS.success?
+
+  out.split("\n").map(&:strip).reject(&:empty?)
+end
+
+manifest = load_manifest
+entries = Array(manifest['entries'])
+inventory_doc = manifest['inventory_doc'].to_s
+watch_globs = Array(manifest['watch_globs'])
+hyku_patched = Array(manifest['hyku_patched'])
+errors = []
+
+errors << "inventory_doc missing: #{inventory_doc}" unless ROOT.join(inventory_doc).file?
+
+entries.each do |entry|
+  path = entry['path'].to_s
+  next if entry['allow_missing']
+  next if path.empty?
+
+  abs = ROOT.join(path.delete_suffix('/'))
+  unless abs.exist?
+    errors << "manifest entry missing on disk: #{path} (id=#{entry['id']})"
+  end
+end
+
+watched_files = watch_globs.flat_map { |g| expand_glob(g) }.uniq.sort
+undocumented = watched_files.reject { |f| covered_by_entry?(f, entries) }
+undocumented.each do |f|
+  errors << "watched file not listed in manifest entries: #{f}"
+end
+
+hyku_patched.each do |path|
+  next if entries.any? { |e| e['path'].to_s == path && e['kind'].to_s == 'hyku_patched' }
+
+  # Directory-style coverage is not used for hyku_patched list; require exact entry.
+  unless entries.any? { |e| e['path'].to_s == path }
+    errors << "hyku_patched path not registered in entries: #{path}"
+  end
+end
+
+# PR change enforcement
+event = ENV.fetch('GITHUB_EVENT_NAME', '')
+base_sha = ENV['UC_CUSTOMIZATIONS_BASE_SHA'] || ENV['GITHUB_EVENT_PULL_REQUEST_BASE_SHA']
+head_sha = ENV['UC_CUSTOMIZATIONS_HEAD_SHA'] || ENV['GITHUB_SHA']
+
+# Actions sets GITHUB_EVENT_PATH; prefer explicit env from the workflow.
+if event == 'pull_request' || ENV['UC_CUSTOMIZATIONS_ENFORCE_PR'] == '1'
+  changed = git_changed_files(base_sha, head_sha)
+  if changed.any?
+    inventory_changed = changed.include?(inventory_doc) ||
+                        changed.include?('docs/local/uc-hyku-customizations.manifest.yml')
+
+    triggers = []
+    changed.each do |file|
+      next if file == inventory_doc
+      next if file == 'docs/local/uc-hyku-customizations.manifest.yml'
+      # Pure local-doc edits (other than inventory) do not require inventory churn.
+      next if file.start_with?('docs/local/') && file != inventory_doc
+
+      if hyku_patched.include?(file)
+        triggers << file
+        next
+      end
+
+      triggers << file if covered_by_entry?(file, entries) && !file.start_with?('docs/local/')
+    end
+
+    if triggers.any? && !inventory_changed
+      errors << 'PR changes UC customizations but does not update ' \
+                "#{inventory_doc} (or the manifest). Changed: #{triggers.sort.join(', ')}"
+    end
+  end
+end
+
+fail_with(errors) if errors.any?
+
+puts 'UC customizations check passed.'
+puts "  inventory: #{inventory_doc}"
+puts "  entries: #{entries.size}"
+puts "  watched files covered: #{watched_files.size}"

--- a/spec/lib/uc/hyku_customizations_inventory_spec.rb
+++ b/spec/lib/uc/hyku_customizations_inventory_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'pathname'
+require 'tmpdir'
+require 'yaml'
+require_relative '../../../lib/uc/hyku_customizations_inventory'
+
+RSpec.describe Uc::HykuCustomizationsInventory do
+  describe '#covered_by_entry?' do
+    subject(:inventory) { described_class.new(root: Dir.pwd) }
+
+    it 'matches directory prefix entries' do
+      entries = [{ 'path' => 'app/services/uc/' }]
+      expect(inventory.covered_by_entry?('app/services/uc/sample_seed_service.rb', entries)).to be(true)
+    end
+
+    it 'does not match a sibling path outside the prefix' do
+      entries = [{ 'path' => 'app/services/uc/' }]
+      expect(inventory.covered_by_entry?('app/services/other.rb', entries)).to be(false)
+    end
+
+    it 'does not treat a directory prefix as matching a similarly named sibling' do
+      entries = [{ 'path' => 'app/foo/' }]
+      expect(inventory.covered_by_entry?('app/foo-bar/x.rb', entries)).to be(false)
+    end
+  end
+
+  describe '#call' do
+    it 'passes for the committed inventory in this repo' do
+      result = described_class.new(root: Pathname.pwd, env: {}).call
+      expect(result.ok).to be(true), -> { result.errors.join("\n") }
+    end
+
+    it 'fails PR enforcement when SHAs are missing' do
+      result = described_class.new(
+        root: Pathname.pwd,
+        env: { 'UC_CUSTOMIZATIONS_ENFORCE_PR' => '1' }
+      ).call
+
+      expect(result.ok).to be(false)
+      expect(result.errors.join).to match(/BASE_SHA|HEAD_SHA/)
+    end
+
+    it 'fails PR enforcement when git diff fails' do
+      result = described_class.new(
+        root: Pathname.pwd,
+        env: {
+          'UC_CUSTOMIZATIONS_ENFORCE_PR' => '1',
+          'UC_CUSTOMIZATIONS_BASE_SHA' => 'not-a-real-sha',
+          'UC_CUSTOMIZATIONS_HEAD_SHA' => 'also-not-a-real-sha'
+        }
+      ).call
+
+      expect(result.ok).to be(false)
+      expect(result.errors.join).to match(/git diff failed/)
+    end
+
+    it 'fails when a hyku_patched path has the wrong kind' do
+      Dir.mktmpdir do |dir|
+        root = Pathname.new(dir)
+        write_minimal_repo(root, entries: [
+                             { 'path' => 'docs/local/', 'kind' => 'uc_only', 'id' => 'local-docs' },
+                             { 'path' => 'README.md', 'kind' => 'uc_only', 'id' => 'wrong' }
+                           ], hyku_patched: ['README.md'])
+
+        result = described_class.new(root: root, env: {}).call
+        expect(result.ok).to be(false)
+        expect(result.errors.join).to match(/must have kind: hyku_patched/)
+      end
+    end
+
+    it 'fails when a watched file is not covered by any entry' do
+      Dir.mktmpdir do |dir|
+        root = Pathname.new(dir)
+        write_minimal_repo(
+          root,
+          entries: [{ 'path' => 'docs/local/', 'kind' => 'uc_only', 'id' => 'local-docs' }],
+          hyku_patched: [],
+          watch_globs: ['orphan.rb'],
+          extra_files: ['orphan.rb']
+        )
+
+        result = described_class.new(root: root, env: {}).call
+        expect(result.ok).to be(false)
+        expect(result.errors.join).to match(/watched file not listed/)
+      end
+    end
+
+    it 'fails when a required manifest entry is missing on disk' do
+      Dir.mktmpdir do |dir|
+        root = Pathname.new(dir)
+        write_minimal_repo(
+          root,
+          entries: [
+            { 'path' => 'docs/local/', 'kind' => 'uc_only', 'id' => 'local-docs' },
+            { 'path' => 'missing/path.rb', 'kind' => 'uc_only', 'id' => 'gone' }
+          ],
+          hyku_patched: []
+        )
+
+        result = described_class.new(root: root, env: {}).call
+        expect(result.ok).to be(false)
+        expect(result.errors.join).to match(/manifest entry missing on disk: missing\/path\.rb/)
+      end
+    end
+  end
+
+  def write_minimal_repo(root, entries:, hyku_patched:, watch_globs: [], extra_files: [])
+    docs = root.join('docs/local')
+    FileUtils.mkdir_p(docs)
+    docs.join('uc-hyku-customizations.md').write("# inventory\n")
+    root.join('README.md').write("readme\n")
+    extra_files.each do |rel|
+      path = root.join(rel)
+      FileUtils.mkdir_p(path.dirname)
+      path.write("x\n")
+    end
+
+    manifest = {
+      'inventory_doc' => 'docs/local/uc-hyku-customizations.md',
+      'watch_globs' => watch_globs,
+      'hyku_patched' => hyku_patched,
+      'entries' => entries
+    }
+    docs.join('uc-hyku-customizations.manifest.yml').write(YAML.dump(manifest))
+  end
+end

--- a/spec/services/uc/sample_seed_service_spec.rb
+++ b/spec/services/uc/sample_seed_service_spec.rb
@@ -1,0 +1,433 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Uc::SampleSeedService do
+  subject(:service) { described_class.new(works_per_user: 1) }
+
+  let(:admin_user) { instance_double(User, email: 'admin@example.com', user_key: 'admin@example.com') }
+  let(:sample_users) do
+    {
+      many_deposits: instance_double(User, email: 'manydeposits@example.com'),
+      no_deposits: instance_double(User, email: 'nodeposits@example.com'),
+      delegate: instance_double(User, email: 'delegate@example.com'),
+      admin: admin_user,
+      depositors: [admin_user]
+    }
+  end
+
+  around do |example|
+    previous = {
+      'INITIAL_ADMIN_PASSWORD' => ENV.fetch('INITIAL_ADMIN_PASSWORD', nil),
+      'UC_SEED_FORCE' => ENV.fetch('UC_SEED_FORCE', nil),
+      'HYKU_SINGLE_TENANT_CNAME' => ENV.fetch('HYKU_SINGLE_TENANT_CNAME', nil),
+      'UC_SEED_WORKS_PER_USER' => ENV.fetch('UC_SEED_WORKS_PER_USER', nil),
+      'HYRAX_VALKYRIE' => ENV.fetch('HYRAX_VALKYRIE', nil)
+    }
+    ENV['INITIAL_ADMIN_PASSWORD'] = 'testing123'
+    ENV['HYKU_SINGLE_TENANT_CNAME'] = 'single.tenant.default'
+    ENV.delete('UC_SEED_FORCE')
+    ENV.delete('UC_SEED_WORKS_PER_USER')
+    example.run
+  ensure
+    previous.each { |key, value| restore_env(key, value) }
+  end
+
+  def restore_env(key, value)
+    value.nil? ? ENV.delete(key) : ENV[key] = value
+  end
+
+  def stub_tenant_and_modes
+    allow(service).to receive(:switch_to_single_tenant!)
+    allow(service).to receive(:already_seeded?).and_return(false)
+    allow(service).to receive(:remove_uc_seed_objects!)
+    allow(service).to receive(:setup_active_fedora_mode!)
+    allow(service).to receive(:restore_active_fedora_mode!)
+  end
+
+  def stub_create_steps
+    allow(service).to receive(:create_users).and_return(sample_users)
+    allow(service).to receive(:find_or_create_active_fedora_admin_set!).and_return(instance_double(AdminSet))
+    allow(service).to receive(:create_bulk_generic_works)
+    allow(service).to receive(:create_complete_works_collection)
+    allow(service).to receive(:write_completion_marker!)
+    allow(service).to receive(:index_created!)
+  end
+
+  def stub_successful_create_path
+    stub_tenant_and_modes
+    stub_create_steps
+  end
+
+  describe '.call' do
+    it 'passes UC_SEED_WORKS_PER_USER into the service' do
+      ENV['UC_SEED_WORKS_PER_USER'] = '3'
+      instance = instance_double(described_class)
+      allow(described_class).to receive(:new).with(works_per_user: 3).and_return(instance)
+      allow(instance).to receive(:call).and_return(described_class::Result.new(status: :skipped))
+
+      expect(described_class.call.status).to eq(:skipped)
+      expect(described_class).to have_received(:new).with(works_per_user: 3)
+    end
+
+    it 'defaults works_per_user to 10 when the env var is unset' do
+      instance = instance_double(described_class)
+      allow(described_class).to receive(:new).with(works_per_user: 10).and_return(instance)
+      allow(instance).to receive(:call).and_return(described_class::Result.new(status: :skipped))
+
+      described_class.call
+
+      expect(described_class).to have_received(:new).with(works_per_user: 10)
+    end
+  end
+
+  describe '#call' do
+    context 'when already seeded' do
+      before do
+        allow(service).to receive(:switch_to_single_tenant!)
+        allow(service).to receive(:already_seeded?).and_return(true)
+      end
+
+      it 'returns skipped and does not create works' do
+        expect(service).not_to receive(:create_users)
+
+        result = service.call
+
+        expect(result).to have_attributes(status: :skipped, created_count: nil)
+      end
+    end
+
+    context 'when UC_SEED_FORCE is true and already seeded' do
+      before do
+        ENV['UC_SEED_FORCE'] = 'true'
+        stub_successful_create_path
+        allow(service).to receive(:already_seeded?).and_return(true)
+      end
+
+      it 'wipes prior seed objects then recreates' do
+        expect(service).to receive(:remove_uc_seed_objects!).ordered
+        expect(service).to receive(:create_users).ordered.and_return(sample_users)
+
+        expect(service.call.status).to eq(:created)
+      end
+    end
+
+    context 'happy path' do
+      before { stub_successful_create_path }
+
+      it 'returns created with the initial-admin password source' do
+        result = service.call
+
+        expect(result).to have_attributes(
+          status: :created,
+          password_source: :initial_admin_password,
+          created_count: 0
+        )
+      end
+
+      it 'runs create steps in order' do
+        expect(service).to receive(:create_users).ordered.and_return(sample_users)
+        expect(service).to receive(:find_or_create_active_fedora_admin_set!).with(admin_user).ordered
+        expect(service).to receive(:create_bulk_generic_works).with(sample_users[:depositors]).ordered
+        expect(service).to receive(:create_complete_works_collection).with(sample_users[:many_deposits]).ordered
+        expect(service).to receive(:write_completion_marker!).with(sample_users[:many_deposits]).ordered
+        expect(service).to receive(:index_created!).ordered
+
+        service.call
+      end
+    end
+
+    context 'when create raises after AF mode is enabled' do
+      before do
+        allow(service).to receive(:switch_to_single_tenant!)
+        allow(service).to receive(:already_seeded?).and_return(false)
+        allow(Hyrax.config).to receive(:use_valkyrie?).and_return(true)
+        allow(Hyrax.config).to receive(:use_valkyrie=)
+        allow(service).to receive(:remove_uc_seed_objects!)
+        allow(service).to receive(:create_users).and_raise(RuntimeError, 'create failed')
+      end
+
+      it 'restores the previous Hyrax use_valkyrie setting' do
+        expect { service.call }.to raise_error(RuntimeError, 'create failed')
+
+        expect(Hyrax.config).to have_received(:use_valkyrie=).with(false).ordered
+        expect(Hyrax.config).to have_received(:use_valkyrie=).with(true).ordered
+      end
+    end
+
+    context 'when Rails.env is production' do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+        allow(Rails.env).to receive(:staging?).and_return(false)
+      end
+
+      after { allow(Rails.env).to receive(:production?).and_call_original }
+
+      it 'raises before switching tenants or creating data' do
+        expect(Account).not_to receive(:find_by)
+        expect(service).not_to receive(:create_users)
+
+        expect { service.call }
+          .to raise_error(RuntimeError, 'UC sample seeds must not run in production or staging.')
+      end
+    end
+
+    context 'when Rails.env is staging' do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(false)
+        allow(Rails.env).to receive(:staging?).and_return(true)
+      end
+
+      after do
+        allow(Rails.env).to receive(:production?).and_call_original
+        allow(Rails.env).to receive(:staging?).and_call_original
+      end
+
+      it 'raises' do
+        expect { service.call }
+          .to raise_error(RuntimeError, 'UC sample seeds must not run in production or staging.')
+      end
+    end
+
+    context 'when INITIAL_ADMIN_PASSWORD is missing' do
+      it 'raises after tenant switch when not already seeded' do
+        ENV.delete('INITIAL_ADMIN_PASSWORD')
+        bare = described_class.new(works_per_user: 1)
+        allow(bare).to receive(:switch_to_single_tenant!)
+        allow(bare).to receive(:already_seeded?).and_return(false)
+
+        expect { bare.call }
+          .to raise_error(RuntimeError, /INITIAL_ADMIN_PASSWORD is not set/)
+      end
+    end
+
+    context 'when the single-tenant account is missing' do
+      before do
+        allow(Account).to receive(:find_by).with(cname: 'single.tenant.default').and_return(nil)
+      end
+
+      it 'raises with instructions to run Hyku db:seed first' do
+        expect { service.call }
+          .to raise_error(RuntimeError, /Single-tenant account not found.*db:seed first/)
+      end
+    end
+  end
+
+  describe '#switch_to_single_tenant!' do
+    it 'uses HYKU_SINGLE_TENANT_CNAME when set' do
+      account = instance_double(Account, cname: 'custom.tenant.local')
+      ENV['HYKU_SINGLE_TENANT_CNAME'] = 'custom.tenant.local'
+      allow(Account).to receive(:find_by).with(cname: 'custom.tenant.local').and_return(account)
+      allow(AccountElevator).to receive(:switch!)
+
+      service.send(:switch_to_single_tenant!)
+
+      expect(AccountElevator).to have_received(:switch!).with('custom.tenant.local')
+    end
+  end
+
+  describe '#already_seeded?' do
+    it 'is true when the completion marker exists in Fedora' do
+      allow(ActiveFedora::Base).to receive(:exists?)
+        .with(described_class::COMPLETION_WORK_ID).and_return(true)
+
+      expect(service.send(:already_seeded?)).to be(true)
+    end
+
+    it 'falls back to Solr when the Fedora marker is absent' do
+      allow(ActiveFedora::Base).to receive(:exists?)
+        .with(described_class::COMPLETION_WORK_ID).and_return(false)
+      relation = instance_double('ActiveFedora::Relation', any?: true)
+      allow(GenericWork).to receive(:where)
+        .with(bulkrax_identifier_tesim: described_class::COMPLETION_MARKER)
+        .and_return(relation)
+
+      expect(service.send(:already_seeded?)).to be(true)
+    end
+
+    it 'is false when neither Fedora nor Solr has the marker' do
+      allow(ActiveFedora::Base).to receive(:exists?)
+        .with(described_class::COMPLETION_WORK_ID).and_return(false)
+      relation = instance_double('ActiveFedora::Relation', any?: false)
+      allow(GenericWork).to receive(:where)
+        .with(bulkrax_identifier_tesim: described_class::COMPLETION_MARKER)
+        .and_return(relation)
+
+      expect(service.send(:already_seeded?)).to be(false)
+    end
+  end
+
+  describe '#fold_uc_metadata' do
+    it 'returns the base description when no fields are given' do
+      expect(service.send(:fold_uc_metadata, 'Base text')).to eq('Base text')
+    end
+
+    it 'omits nil fields and joins the rest' do
+      result = service.send(
+        :fold_uc_metadata,
+        'Base text',
+        college: 'Arts',
+        department: nil,
+        note: 'Hello'
+      )
+
+      expect(result).to eq('Base text [UC seed fields: college: Arts | note: Hello]')
+    end
+  end
+
+  describe '#grant_admin!' do
+    let(:site) { instance_double(Site) }
+    let(:user) { instance_double(User) }
+
+    before { allow(Site).to receive(:instance).and_return(site) }
+
+    it 'adds both global and site admin roles when missing' do
+      allow(user).to receive(:has_role?).with(:admin).and_return(false)
+      allow(user).to receive(:has_role?).with(:admin, site).and_return(false)
+      allow(user).to receive(:add_role)
+
+      service.send(:grant_admin!, user)
+
+      expect(user).to have_received(:add_role).with(:admin)
+      expect(user).to have_received(:add_role).with(:admin, site)
+    end
+
+    it 'does not re-add roles the user already has' do
+      allow(user).to receive(:has_role?).with(:admin).and_return(true)
+      allow(user).to receive(:has_role?).with(:admin, site).and_return(true)
+      allow(user).to receive(:add_role)
+
+      service.send(:grant_admin!, user)
+
+      expect(user).not_to have_received(:add_role)
+    end
+  end
+
+  describe '#upsert_user' do
+    let(:user) { instance_double(User) }
+
+    before do
+      allow(User).to receive(:find_or_initialize_by).with(email: 'sample@example.com').and_return(user)
+      allow(user).to receive(:password=)
+      allow(user).to receive(:password_confirmation=)
+      allow(user).to receive(:display_name=)
+      allow(user).to receive(:department=)
+      allow(user).to receive(:save!)
+    end
+
+    it 'sets password and profile fields then saves' do
+      service.send(
+        :upsert_user,
+        email: 'sample@example.com',
+        display_name: 'Sample User',
+        department: 'Library'
+      )
+
+      expect(user).to have_received(:password=).with('testing123')
+      expect(user).to have_received(:password_confirmation=).with('testing123')
+      expect(user).to have_received(:display_name=).with('Sample User')
+      expect(user).to have_received(:department=).with('Library')
+      expect(user).to have_received(:save!)
+    end
+
+    it 'skips department when nil and grants admin when requested' do
+      allow(service).to receive(:grant_admin!)
+
+      service.send(
+        :upsert_user,
+        email: 'sample@example.com',
+        display_name: 'Admin User',
+        department: nil,
+        admin: true
+      )
+
+      expect(user).not_to have_received(:department=)
+      expect(service).to have_received(:grant_admin!).with(user)
+    end
+  end
+
+  describe '#uc_seed_solr_docs' do
+    it 'keeps only documents whose bulkrax id uses the uc-seed prefix' do
+      allow(Hyrax::SolrService).to receive(:query) do |query, **|
+        if query.include?('GenericWork')
+          [
+            {
+              'id' => 'keep',
+              'has_model_ssim' => ['GenericWork'],
+              'bulkrax_identifier_tesim' => ['uc-seed-bulk-1']
+            },
+            {
+              'id' => 'drop',
+              'has_model_ssim' => ['GenericWork'],
+              'bulkrax_identifier_tesim' => ['bulkrax-other']
+            }
+          ]
+        else
+          []
+        end
+      end
+
+      docs = service.send(:uc_seed_solr_docs)
+
+      expect(docs.map { |doc| doc['id'] }).to eq(['keep'])
+    end
+  end
+
+  describe '#remove_uc_seed_objects!' do
+    it 'continues when one destroy fails' do
+      keep = instance_double(GenericWork)
+      allow(service).to receive(:destroy_completion_marker_in_fedora!)
+      allow(service).to receive(:uc_seed_solr_docs).and_return(
+        [
+          { 'id' => 'bad', 'has_model_ssim' => ['GenericWork'] },
+          { 'id' => 'good', 'has_model_ssim' => ['GenericWork'] }
+        ]
+      )
+      allow(GenericWork).to receive(:find).with('bad').and_raise(StandardError, 'missing')
+      allow(GenericWork).to receive(:find).with('good').and_return(keep)
+      allow(keep).to receive(:destroy)
+
+      expect { service.send(:remove_uc_seed_objects!) }.not_to raise_error
+      expect(keep).to have_received(:destroy)
+    end
+
+    it 'skips docs that have no model name' do
+      allow(service).to receive(:destroy_completion_marker_in_fedora!)
+      allow(service).to receive(:uc_seed_solr_docs).and_return(
+        [{ 'id' => 'orphan', 'has_model_ssim' => [] }]
+      )
+
+      expect(GenericWork).not_to receive(:find)
+      service.send(:remove_uc_seed_objects!)
+    end
+  end
+
+  describe '#write_completion_marker!' do
+    let(:user) do
+      instance_double(User, display_name: 'Many Deposits', email: 'manydeposits@example.com')
+    end
+    let(:work) { instance_double(GenericWork) }
+    let(:admin_set) { instance_double(AdminSet) }
+
+    before do
+      service.instance_variable_set(:@admin_set, admin_set)
+      allow(GenericWork).to receive(:new).and_return(work)
+      allow(service).to receive(:save_work!).with(work, user).and_return(work)
+      allow(work).to receive(:update_index)
+    end
+
+    it 'persists a fixed-id marker and indexes it immediately' do
+      service.send(:write_completion_marker!, user)
+
+      expect(GenericWork).to have_received(:new).with(
+        hash_including(
+          id: described_class::COMPLETION_WORK_ID,
+          bulkrax_identifier: described_class::COMPLETION_MARKER,
+          admin_set: admin_set
+        )
+      )
+      expect(work).to have_received(:update_index)
+      expect(service.instance_variable_get(:@created)).to eq([work])
+    end
+  end
+end

--- a/spec/tasks/uc_sample_seeds_rake_spec.rb
+++ b/spec/tasks/uc_sample_seeds_rake_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'uc:seed:samples' do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  before do
+    Rake::Task['uc:seed:samples'].reenable
+  end
+
+  def run_task
+    Rake::Task['uc:seed:samples'].invoke
+  end
+
+  it 'prints RESULT OK when the service skips' do
+    allow(Uc::SampleSeedService).to receive(:call)
+      .and_return(Uc::SampleSeedService::Result.new(status: :skipped))
+
+    expect { run_task }.to output(/RESULT: OK — UC sample seeds already present \(skipped\)/).to_stdout
+  end
+
+  it 'prints RESULT OK and password guidance when the service creates samples' do
+    allow(Uc::SampleSeedService).to receive(:call)
+      .and_return(
+        Uc::SampleSeedService::Result.new(
+          status: :created,
+          password_source: :initial_admin_password,
+          created_count: 12
+        )
+      )
+
+    expect { run_task }.to output(
+      /RESULT: OK — UC sample seeds completed successfully[\s\S]*INITIAL_ADMIN_PASSWORD[\s\S]*Objects indexed: 12/
+    ).to_stdout
+  end
+
+  it 'prints RESULT FAILED and re-raises when the service errors' do
+    allow(Uc::SampleSeedService).to receive(:call)
+      .and_raise(RuntimeError, 'UC sample seeds must not run in production or staging.')
+
+    expect { run_task }.to output(/RESULT: FAILED — RuntimeError: UC sample seeds must not run/)
+      .to_stdout
+      .and raise_error(RuntimeError, /must not run in production/)
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a UC-owned sample seed path (`rake uc:seed:samples` / `Uc::SampleSeedService`) adapted from Scholar@UC develop onto Hyku OOB models (`GenericWork`, `Image`, `Etd`), without changing stock Hyku `db/seeds.rb`.
- Uses `INITIAL_ADMIN_PASSWORD` for sample accounts (same as Hyku admin), refuses production/staging, and stays idempotent via a fixed Fedora completion marker (with Solr fallback); `UC_SEED_FORCE=true` wipes and recreates.
- Ensures the ActiveFedora default AdminSet has Sipity workflows so seeded works can deposit cleanly; documents the flow in `docs/local` and covers UC-owned behavior with fast, stubbed specs.

## Test plan
- [ ] `db:setup` / Hyku `db:seed` still creates tenant + admin as before
- [ ] First `RUBYOPT="-r./config/sidekiq_redis_compat" bundle exec rake uc:seed:samples` prints `RESULT: OK` and creates public works + Complete Works collection
- [ ] Sample logins (`manydeposits@example.com`, etc., and `admin@example.com`) use `INITIAL_ADMIN_PASSWORD` from `.env.local.mac`
- [ ] Re-run skips with `RESULT: OK — ... already present (skipped)`
- [ ] `UC_SEED_FORCE=true` recreates samples; unset `INITIAL_ADMIN_PASSWORD` fails clearly; prod/staging refuse
- [ ] `bundle exec rspec spec/services/uc/sample_seed_service_spec.rb spec/tasks/uc_sample_seeds_rake_spec.rb`